### PR TITLE
refactor: remove ApproveUserByKcId, unify user approval to UpdateUserStatus

### DIFF
--- a/asset/mcmpapi/service-actions.yaml
+++ b/asset/mcmpapi/service-actions.yaml
@@ -3,7 +3,7 @@ serviceActions:
         _meta:
             version: 0.5.0
             repository: https://github.com/m-cmp/mc-application-manager
-            generatedAt: "2026-02-09T04:43:42Z"
+            generatedAt: "2026-02-19T05:38:06Z"
         checkConnectionUsingPOST:
             method: post
             resourcePath: /oss/connection-check
@@ -272,7 +272,7 @@ serviceActions:
         _meta:
             version: 0.5.0
             repository: https://github.com/m-cmp/mc-cost-optimizer
-            generatedAt: "2026-02-09T04:43:42Z"
+            generatedAt: "2026-02-19T05:38:06Z"
         getAbrnormalRcmd:
             method: post
             resourcePath: /api/costopti/be/opti/abnormalRcmd
@@ -333,7 +333,7 @@ serviceActions:
         _meta:
             version: 0.3.0
             repository: https://github.com/m-cmp/mc-iam-manager
-            generatedAt: "2026-02-09T04:43:42Z"
+            generatedAt: "2026-02-19T05:38:06Z"
         ResetUserPassword:
             method: put
             resourcePath: /api/users/id/{userId}/password
@@ -998,7 +998,7 @@ serviceActions:
         _meta:
             version: 0.5.0
             repository: https://github.com/m-cmp/mc-workflow-manager
-            generatedAt: "2026-02-09T04:43:42Z"
+            generatedAt: "2026-02-19T05:38:06Z"
         checkConnectionUsingGET:
             method: get
             resourcePath: /readyz

--- a/src/handler/user_handler.go
+++ b/src/handler/user_handler.go
@@ -244,7 +244,7 @@ func (h *UserHandler) SignupUser(c echo.Context) error {
 	}
 
 	// Create user in pending state
-	kcId, err := h.userService.SignupUser(c.Request().Context(), &req)
+	_, err := h.userService.SignupUser(c.Request().Context(), &req)
 	if err != nil {
 		if strings.Contains(err.Error(), "already in use") {
 			return c.JSON(http.StatusConflict, map[string]string{
@@ -260,7 +260,6 @@ func (h *UserHandler) SignupUser(c echo.Context) error {
 	return c.JSON(http.StatusCreated, map[string]interface{}{
 		"success":     true,
 		"message":     "Signup request completed. You can login after admin approval",
-		"kcId":        kcId,
 		"redirectUrl": "/login",
 	})
 }
@@ -514,48 +513,6 @@ func (h *UserHandler) UpdateUserStatus(c echo.Context) error {
 	return c.NoContent(http.StatusNoContent)
 }
 
-// ApproveUserByKcId godoc
-// @Summary Approve user by Keycloak ID
-// @Description Approve a user using their Keycloak ID (enables user and syncs to DB)
-// @Tags users
-// @Accept json
-// @Produce json
-// @Param kcId path string true "Keycloak User ID"
-// @Success 200 {object} map[string]interface{}
-// @Failure 400 {object} map[string]string
-// @Failure 403 {object} map[string]string
-// @Failure 500 {object} map[string]string
-// @Security BearerAuth
-// @Router /api/users/kc/{kcId}/approve [post]
-// @Id approveUserByKcId
-func (h *UserHandler) ApproveUserByKcId(c echo.Context) error {
-	// --- Role validation (Admin or platformAdmin) ---
-	requiredRoles := []string{"admin", "platformAdmin"}
-	if !checkRoleFromContext(c, requiredRoles) {
-		fmt.Printf("[INFO] ApproveUserByKcId: Permission denied. User does not have required roles: %v\n", requiredRoles)
-		return c.JSON(http.StatusForbidden, map[string]string{"error": "Forbidden: Administrator access required"})
-	}
-	fmt.Printf("[DEBUG] ApproveUserByKcId: Permission granted.\n")
-	// --- Role validation end ---
-
-	kcId := c.Param("kcId")
-	if kcId == "" {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Keycloak ID is required"})
-	}
-
-	// ApproveUser enables the user in Keycloak and syncs to DB
-	err := h.userService.ApproveUser(c.Request().Context(), kcId)
-	if err != nil {
-		fmt.Printf("[ERROR] ApproveUserByKcId: Error from userService.ApproveUser: %v\n", err)
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("Failed to approve user: %v", err)})
-	}
-
-	return c.JSON(http.StatusOK, map[string]interface{}{
-		"success": true,
-		"message": "User approved successfully",
-		"kcId":    kcId,
-	})
-}
 
 // ListUserWorkspaceAndWorkspaceRoles godoc
 // @Summary List user workspace and roles

--- a/src/main.go
+++ b/src/main.go
@@ -323,7 +323,6 @@ func main() {
 		users.PUT("/id/:userId", userHandler.UpdateUser, middleware.PlatformRoleMiddleware(middleware.Manage))
 		users.DELETE("/id/:userId", userHandler.DeleteUser, middleware.PlatformRoleMiddleware(middleware.Manage))
 		users.POST("/id/:userId/status", userHandler.UpdateUserStatus, middleware.PlatformRoleMiddleware(middleware.Manage))
-		users.POST("/kc/:kcId/approve", userHandler.ApproveUserByKcId, middleware.PlatformRoleMiddleware(middleware.Manage))
 		users.PUT("/id/:userId/password", userHandler.ResetUserPassword, middleware.PlatformRoleMiddleware(middleware.Manage))
 
 		users.POST("/menus-tree/list", menuHandler.ListUserMenuTree)


### PR DESCRIPTION
## Summary

- `ApproveUserByKcId` 핸들러 및 `POST /api/users/kc/:kcId/approve` 라우트 제거
- 사용자 승인을 `UpdateUserStatus` (`POST /api/users/id/:userId/status`) 하나로 통일
- 가입(Signup) 응답에서 내부 Keycloak ID(`kcId`) 노출 제거
- `service-actions.yaml` 재생성

## Background

사용자 가입 승인 API가 두 가지(`ApproveUserByKcId`, `UpdateUserStatus`)로 중복 존재했으며,
`ApproveUserByKcId`는 내부 Keycloak UUID(`kcId`)를 외부에 노출하는 설계상 문제가 있었음.
관리자는 DB ID 기반의 `UpdateUserStatus`만으로 승인이 가능하므로 `ApproveUserByKcId`를 제거함.

## Test plan

- [ ] `POST /api/auth/signup` 가입 요청 후 응답에 `kcId` 없음 확인
- [ ] `POST /api/users/id/{userId}/status` `{"status": "approved"}` 로 관리자 승인 동작 확인
- [ ] `POST /api/users/kc/:kcId/approve` 엔드포인트 404 확인 (제거됨)