### PR TITLE
feat: sync changeMyPassword to all config and swagger files

### DIFF
--- a/asset/mcmpapi/mcmp_api.yaml
+++ b/asset/mcmpapi/mcmp_api.yaml
@@ -960,7 +960,11 @@ serviceActions:
       method: post
       resourcePath: /api/resource/file/framework/{framework}/menu
       description: "mc-web-console 등 menu yaml을 사용해서 메뉴 리소스를 등록합니다."
-  
+    changeMyPassword:
+      method: put
+      resourcePath: /api/users/me/password
+      description: "Change the authenticated user's own password. Requires current password for verification."
+
   mc-infra-manager:
     Putchangek8snodegroupautoscalesize:
       method: put

--- a/asset/mcmpapi/service-actions.yaml
+++ b/asset/mcmpapi/service-actions.yaml
@@ -333,7 +333,7 @@ serviceActions:
         _meta:
             version: 0.3.0
             repository: https://github.com/m-cmp/mc-iam-manager
-            generatedAt: "2026-03-04T01:17:32Z"
+            generatedAt: "2026-03-11T06:09:51Z"
         ResetUserPassword:
             method: put
             resourcePath: /api/users/id/{userId}/password
@@ -370,6 +370,14 @@ serviceActions:
             method: post
             resourcePath: /api/projects/assign/workspaces
             description: 프로젝트에 워크스페이스를 연결합니다.
+        assignGroupPlatformRole:
+            method: post
+            resourcePath: /api/groups/id/{groupId}/platform-roles
+            description: 그룹에 플랫폼 역할을 할당합니다. DB + Keycloak 이중 관리.
+        assignGroupWorkspace:
+            method: post
+            resourcePath: /api/groups/id/{groupId}/workspaces
+            description: 그룹을 워크스페이스에 매핑하고 역할을 지정합니다. DB 전용 관리.
         assignMciamPermissionToRole:
             method: post
             resourcePath: /api/roles/{roleType}/{roleId}/mciam-permissions/{permissionId}
@@ -382,6 +390,10 @@ serviceActions:
             method: post
             resourcePath: /api/roles/id/{roleId}/assign
             description: Assign a role to a user
+        assignUserGroups:
+            method: post
+            resourcePath: /api/users/id/{userId}/groups
+            description: 사용자를 하나 이상의 그룹에 할당합니다. DB + Keycloak 그룹 동기화.
         assignUserOrganizations:
             method: post
             resourcePath: /api/users/{userId}/organizations
@@ -394,6 +406,10 @@ serviceActions:
             method: post
             resourcePath: /api/csp-policies/attach
             description: Attach a CSP policy to a CSP role
+        changeMyPassword:
+            method: put
+            resourcePath: /api/users/me/password
+            description: Change the authenticated user's own password. Requires current password for verification.
         checkUserRoles:
             method: get
             resourcePath: /api/setup/check-user-roles
@@ -570,6 +586,14 @@ serviceActions:
             method: get
             resourcePath: /api/roles/csp-roles/id/:roleId
             description: Get a mapping between role and CSP role
+        getGroupPlatformRoles:
+            method: get
+            resourcePath: /api/groups/id/{groupId}/platform-roles
+            description: 그룹에 할당된 플랫폼 역할 목록을 조회합니다.
+        getGroupWorkspaces:
+            method: get
+            resourcePath: /api/groups/id/{groupId}/workspaces
+            description: 그룹에 매핑된 워크스페이스 및 역할 목록을 조회합니다.
         getMciamPermissionByID:
             method: get
             resourcePath: /api/permissions/mciam/id/{id}
@@ -914,6 +938,14 @@ serviceActions:
             method: delete
             resourcePath: /api/roles/unassign/csp-roles
             description: Delete a mapping between workspace role and CSP role
+        removeGroupPlatformRole:
+            method: delete
+            resourcePath: /api/groups/id/{groupId}/platform-roles/{roleId}
+            description: 그룹에 할당된 플랫폼 역할을 해제합니다. DB + Keycloak 동시 제거.
+        removeGroupWorkspaceRole:
+            method: delete
+            resourcePath: /api/groups/id/{groupId}/workspaces/{workspaceId}
+            description: 그룹-워크스페이스 매핑을 제거합니다.
         removeMciamPermissionFromRole:
             method: delete
             resourcePath: /api/roles/{roleType}/{roleId}/mciam-permissions/{permissionId}
@@ -930,6 +962,10 @@ serviceActions:
             method: delete
             resourcePath: /api/roles/id/{roleId}/unassign
             description: Remove a role from a user
+        removeUserFromGroup:
+            method: delete
+            resourcePath: /api/users/id/{userId}/groups/{groupId}
+            description: 사용자를 특정 그룹에서 제거합니다. DB + Keycloak 그룹 동기화.
         removeUserFromWorkspace:
             method: delete
             resourcePath: /api/workspaces/{id}/users/{userId}
@@ -954,6 +990,10 @@ serviceActions:
             method: post
             resourcePath: /api/initial-admin
             description: Creates the initial platform admin user with necessary permissions. platform admin 생성인데
+        setupInitialOrganizations:
+            method: post
+            resourcePath: /api/setup/initial-organizations
+            description: YAML 시드 파일에서 기본 조직 구조(MZC + 8개 프레임워크)를 로드하여 등록합니다. 멱등성 보장.
         syncCspPolicies:
             method: post
             resourcePath: /api/csp-policies/sync
@@ -990,6 +1030,10 @@ serviceActions:
             method: put
             resourcePath: /api/roles/csp-roles/id/{roleId}
             description: Update role information
+        updateGroupWorkspaceRole:
+            method: put
+            resourcePath: /api/groups/id/{groupId}/workspaces/{workspaceId}
+            description: 그룹-워크스페이스 매핑의 역할을 변경합니다.
         updateMapping:
             method: put
             resourcePath: /api/mcmp-api-permission-action-mappings/permissions/{permissionId}/actions/{actionId}

--- a/conf/mc-iam-manager/api.yaml
+++ b/conf/mc-iam-manager/api.yaml
@@ -971,6 +971,10 @@ serviceActions:
       method: delete
       resourcePath: /api/projects/unassign/workspaces
       description: "Workspace에서 Project 할당 해제"
+    changeMyPassword:
+      method: put
+      resourcePath: /api/users/me/password
+      description: "Change the authenticated user's own password. Requires current password for verification."
 
   mc-infra-manager:
     Lookupspeclist:

--- a/conf/mc-iam-manager/service-actions.yaml
+++ b/conf/mc-iam-manager/service-actions.yaml
@@ -333,7 +333,7 @@ serviceActions:
         _meta:
             version: 0.3.0
             repository: https://github.com/m-cmp/mc-iam-manager
-            generatedAt: "2026-03-03T01:56:15Z"
+            generatedAt: "2026-03-11T06:09:51Z"
         ResetUserPassword:
             method: put
             resourcePath: /api/users/id/{userId}/password
@@ -370,6 +370,14 @@ serviceActions:
             method: post
             resourcePath: /api/projects/assign/workspaces
             description: 프로젝트에 워크스페이스를 연결합니다.
+        assignGroupPlatformRole:
+            method: post
+            resourcePath: /api/groups/id/{groupId}/platform-roles
+            description: 그룹에 플랫폼 역할을 할당합니다. DB + Keycloak 이중 관리.
+        assignGroupWorkspace:
+            method: post
+            resourcePath: /api/groups/id/{groupId}/workspaces
+            description: 그룹을 워크스페이스에 매핑하고 역할을 지정합니다. DB 전용 관리.
         assignMciamPermissionToRole:
             method: post
             resourcePath: /api/roles/{roleType}/{roleId}/mciam-permissions/{permissionId}
@@ -382,6 +390,10 @@ serviceActions:
             method: post
             resourcePath: /api/roles/id/{roleId}/assign
             description: Assign a role to a user
+        assignUserGroups:
+            method: post
+            resourcePath: /api/users/id/{userId}/groups
+            description: 사용자를 하나 이상의 그룹에 할당합니다. DB + Keycloak 그룹 동기화.
         assignUserOrganizations:
             method: post
             resourcePath: /api/users/{userId}/organizations
@@ -394,6 +406,10 @@ serviceActions:
             method: post
             resourcePath: /api/csp-policies/attach
             description: Attach a CSP policy to a CSP role
+        changeMyPassword:
+            method: put
+            resourcePath: /api/users/me/password
+            description: Change the authenticated user's own password. Requires current password for verification.
         checkUserRoles:
             method: get
             resourcePath: /api/setup/check-user-roles
@@ -570,6 +586,14 @@ serviceActions:
             method: get
             resourcePath: /api/roles/csp-roles/id/:roleId
             description: Get a mapping between role and CSP role
+        getGroupPlatformRoles:
+            method: get
+            resourcePath: /api/groups/id/{groupId}/platform-roles
+            description: 그룹에 할당된 플랫폼 역할 목록을 조회합니다.
+        getGroupWorkspaces:
+            method: get
+            resourcePath: /api/groups/id/{groupId}/workspaces
+            description: 그룹에 매핑된 워크스페이스 및 역할 목록을 조회합니다.
         getMciamPermissionByID:
             method: get
             resourcePath: /api/permissions/mciam/id/{id}
@@ -914,6 +938,14 @@ serviceActions:
             method: delete
             resourcePath: /api/roles/unassign/csp-roles
             description: Delete a mapping between workspace role and CSP role
+        removeGroupPlatformRole:
+            method: delete
+            resourcePath: /api/groups/id/{groupId}/platform-roles/{roleId}
+            description: 그룹에 할당된 플랫폼 역할을 해제합니다. DB + Keycloak 동시 제거.
+        removeGroupWorkspaceRole:
+            method: delete
+            resourcePath: /api/groups/id/{groupId}/workspaces/{workspaceId}
+            description: 그룹-워크스페이스 매핑을 제거합니다.
         removeMciamPermissionFromRole:
             method: delete
             resourcePath: /api/roles/{roleType}/{roleId}/mciam-permissions/{permissionId}
@@ -930,6 +962,10 @@ serviceActions:
             method: delete
             resourcePath: /api/roles/id/{roleId}/unassign
             description: Remove a role from a user
+        removeUserFromGroup:
+            method: delete
+            resourcePath: /api/users/id/{userId}/groups/{groupId}
+            description: 사용자를 특정 그룹에서 제거합니다. DB + Keycloak 그룹 동기화.
         removeUserFromWorkspace:
             method: delete
             resourcePath: /api/workspaces/{id}/users/{userId}
@@ -954,6 +990,10 @@ serviceActions:
             method: post
             resourcePath: /api/initial-admin
             description: Creates the initial platform admin user with necessary permissions. platform admin 생성인데
+        setupInitialOrganizations:
+            method: post
+            resourcePath: /api/setup/initial-organizations
+            description: YAML 시드 파일에서 기본 조직 구조(MZC + 8개 프레임워크)를 로드하여 등록합니다. 멱등성 보장.
         syncCspPolicies:
             method: post
             resourcePath: /api/csp-policies/sync
@@ -990,6 +1030,10 @@ serviceActions:
             method: put
             resourcePath: /api/roles/csp-roles/id/{roleId}
             description: Update role information
+        updateGroupWorkspaceRole:
+            method: put
+            resourcePath: /api/groups/id/{groupId}/workspaces/{workspaceId}
+            description: 그룹-워크스페이스 매핑의 역할을 변경합니다.
         updateMapping:
             method: put
             resourcePath: /api/mcmp-api-permission-action-mappings/permissions/{permissionId}/actions/{actionId}

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -161,6 +161,67 @@
                 }
             }
         },
+        "/api/auth/signup": {
+            "post": {
+                "description": "Public user signup (no authentication required)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "User signup",
+                "operationId": "SignupUser",
+                "parameters": [
+                    {
+                        "description": "Signup Info",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.SignupRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/auth/temp-credential-csps": {
             "get": {
                 "description": "Get temporary credential provider information for AWS and GCP",
@@ -235,6 +296,516 @@
                     },
                     "401": {
                         "description": "error: Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/csp-accounts": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create a new CSP account",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-accounts"
+                ],
+                "summary": "Create CSP account",
+                "operationId": "createCspAccount",
+                "parameters": [
+                    {
+                        "description": "CSP Account Info",
+                        "name": "account",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CreateCspAccountRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/model.CspAccount"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/csp-accounts/id/{accountId}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieve CSP account details by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-accounts"
+                ],
+                "summary": "Get CSP account by ID",
+                "operationId": "getCspAccountByID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Account ID",
+                        "name": "accountId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.CspAccount"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update CSP account details",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-accounts"
+                ],
+                "summary": "Update CSP account",
+                "operationId": "updateCspAccount",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Account ID",
+                        "name": "accountId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "CSP Account Info",
+                        "name": "account",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.UpdateCspAccountRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.CspAccount"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete a CSP account by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-accounts"
+                ],
+                "summary": "Delete CSP account",
+                "operationId": "deleteCspAccount",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Account ID",
+                        "name": "accountId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/csp-accounts/id/{accountId}/activate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Activate a CSP account",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-accounts"
+                ],
+                "summary": "Activate CSP account",
+                "operationId": "activateCspAccount",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Account ID",
+                        "name": "accountId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/csp-accounts/id/{accountId}/deactivate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Deactivate a CSP account",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-accounts"
+                ],
+                "summary": "Deactivate CSP account",
+                "operationId": "deactivateCspAccount",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Account ID",
+                        "name": "accountId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/csp-accounts/id/{accountId}/validate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Validate CSP account configuration",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-accounts"
+                ],
+                "summary": "Validate CSP account",
+                "operationId": "validateCspAccount",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Account ID",
+                        "name": "accountId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/csp-accounts/list": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieve a list of CSP accounts with optional filters",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-accounts"
+                ],
+                "summary": "List CSP accounts",
+                "operationId": "listCspAccounts",
+                "parameters": [
+                    {
+                        "description": "Filter options",
+                        "name": "filter",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/model.CspAccountFilter"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.CspAccount"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -417,6 +988,1582 @@
                     },
                     "404": {
                         "description": "error: Credential not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/csp-idp-configs": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create a new CSP IDP configuration",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-idp-configs"
+                ],
+                "summary": "Create CSP IDP config",
+                "operationId": "createCspIdpConfig",
+                "parameters": [
+                    {
+                        "description": "CSP IDP Config Info",
+                        "name": "config",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CreateCspIdpConfigRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/model.CspIdpConfig"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/csp-idp-configs/id/{configId}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieve CSP IDP configuration details by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-idp-configs"
+                ],
+                "summary": "Get CSP IDP config by ID",
+                "operationId": "getCspIdpConfigByID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Config ID",
+                        "name": "configId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.CspIdpConfig"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update CSP IDP configuration details",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-idp-configs"
+                ],
+                "summary": "Update CSP IDP config",
+                "operationId": "updateCspIdpConfig",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Config ID",
+                        "name": "configId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "CSP IDP Config Info",
+                        "name": "config",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.UpdateCspIdpConfigRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.CspIdpConfig"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete a CSP IDP configuration by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-idp-configs"
+                ],
+                "summary": "Delete CSP IDP config",
+                "operationId": "deleteCspIdpConfig",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Config ID",
+                        "name": "configId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/csp-idp-configs/id/{configId}/activate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Activate a CSP IDP configuration",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-idp-configs"
+                ],
+                "summary": "Activate CSP IDP config",
+                "operationId": "activateCspIdpConfig",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Config ID",
+                        "name": "configId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/csp-idp-configs/id/{configId}/deactivate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Deactivate a CSP IDP configuration",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-idp-configs"
+                ],
+                "summary": "Deactivate CSP IDP config",
+                "operationId": "deactivateCspIdpConfig",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Config ID",
+                        "name": "configId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/csp-idp-configs/id/{configId}/test": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Test connection to CSP using IDP configuration",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-idp-configs"
+                ],
+                "summary": "Test CSP IDP connection",
+                "operationId": "testCspIdpConnection",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Config ID",
+                        "name": "configId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/csp-idp-configs/list": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieve a list of CSP IDP configurations with optional filters",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-idp-configs"
+                ],
+                "summary": "List CSP IDP configs",
+                "operationId": "listCspIdpConfigs",
+                "parameters": [
+                    {
+                        "description": "Filter options",
+                        "name": "filter",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/model.CspIdpConfigFilter"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.CspIdpConfig"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/csp-policies": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create a new CSP policy",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-policies"
+                ],
+                "summary": "Create CSP policy",
+                "operationId": "createCspPolicy",
+                "parameters": [
+                    {
+                        "description": "CSP Policy Info",
+                        "name": "policy",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CreateCspPolicyRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/model.CspPolicy"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/csp-policies/attach": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Attach a CSP policy to a CSP role",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-policies"
+                ],
+                "summary": "Attach policy to role",
+                "operationId": "attachPolicyToRole",
+                "parameters": [
+                    {
+                        "description": "Attach Policy Request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.AttachPolicyRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/csp-policies/detach": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Detach a CSP policy from a CSP role",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-policies"
+                ],
+                "summary": "Detach policy from role",
+                "operationId": "detachPolicyFromRole",
+                "parameters": [
+                    {
+                        "description": "Detach Policy Request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.AttachPolicyRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/csp-policies/id/{policyId}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieve CSP policy details by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-policies"
+                ],
+                "summary": "Get CSP policy by ID",
+                "operationId": "getCspPolicyByID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Policy ID",
+                        "name": "policyId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.CspPolicy"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update CSP policy details",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-policies"
+                ],
+                "summary": "Update CSP policy",
+                "operationId": "updateCspPolicy",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Policy ID",
+                        "name": "policyId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "CSP Policy Info",
+                        "name": "policy",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.UpdateCspPolicyRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.CspPolicy"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete a CSP policy by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-policies"
+                ],
+                "summary": "Delete CSP policy",
+                "operationId": "deleteCspPolicy",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Policy ID",
+                        "name": "policyId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/csp-policies/id/{policyId}/document": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get the policy document content",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-policies"
+                ],
+                "summary": "Get policy document",
+                "operationId": "getPolicyDocument",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Policy ID",
+                        "name": "policyId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/csp-policies/list": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieve a list of CSP policies with optional filters",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-policies"
+                ],
+                "summary": "List CSP policies",
+                "operationId": "listCspPolicies",
+                "parameters": [
+                    {
+                        "description": "Filter options",
+                        "name": "filter",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/model.CspPolicyFilter"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.CspPolicy"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/csp-policies/role/{roleId}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get list of policies attached to a CSP role",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-policies"
+                ],
+                "summary": "Get policies attached to role",
+                "operationId": "getRolePolicies",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Role ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.CspPolicy"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/csp-policies/sync": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Synchronize policies from the CSP cloud",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-policies"
+                ],
+                "summary": "Sync CSP policies from cloud",
+                "operationId": "syncCspPolicies",
+                "parameters": [
+                    {
+                        "description": "Sync Policies Request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.SyncPoliciesRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.CspPolicy"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/groups/id/{groupId}/platform-roles": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "그룹에 할당된 플랫폼 역할 목록을 조회합니다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "groups"
+                ],
+                "summary": "그룹 Platform Role 목록 조회",
+                "operationId": "getGroupPlatformRoles",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "그룹 ID",
+                        "name": "groupId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.GroupPlatformRoleResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "그룹에 플랫폼 역할을 할당합니다. DB + Keycloak 이중 관리.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "groups"
+                ],
+                "summary": "그룹에 Platform Role 할당",
+                "operationId": "assignGroupPlatformRole",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "그룹 ID",
+                        "name": "groupId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "역할 할당 요청",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.AssignGroupPlatformRoleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/groups/id/{groupId}/platform-roles/{roleId}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "그룹에 할당된 플랫폼 역할을 해제합니다. DB + Keycloak 동시 제거.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "groups"
+                ],
+                "summary": "그룹 Platform Role 해제",
+                "operationId": "removeGroupPlatformRole",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "그룹 ID",
+                        "name": "groupId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "역할 ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/groups/id/{groupId}/workspaces": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "그룹에 매핑된 워크스페이스 및 역할 목록을 조회합니다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "groups"
+                ],
+                "summary": "그룹 워크스페이스 매핑 목록 조회",
+                "operationId": "getGroupWorkspaces",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "그룹 ID",
+                        "name": "groupId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.GroupWorkspaceRoleResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "그룹을 워크스페이스에 매핑하고 역할을 지정합니다. DB 전용 관리.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "groups"
+                ],
+                "summary": "그룹-워크스페이스 매핑",
+                "operationId": "assignGroupWorkspace",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "그룹 ID",
+                        "name": "groupId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "워크스페이스 매핑 요청",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.AssignGroupWorkspaceRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/groups/id/{groupId}/workspaces/{workspaceId}": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "그룹-워크스페이스 매핑의 역할을 변경합니다.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "groups"
+                ],
+                "summary": "그룹 워크스페이스 역할 변경",
+                "operationId": "updateGroupWorkspaceRole",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "그룹 ID",
+                        "name": "groupId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "워크스페이스 ID",
+                        "name": "workspaceId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "역할 변경 요청",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.UpdateGroupWorkspaceRoleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "그룹-워크스페이스 매핑을 제거합니다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "groups"
+                ],
+                "summary": "그룹-워크스페이스 매핑 제거",
+                "operationId": "removeGroupWorkspaceRole",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "그룹 ID",
+                        "name": "groupId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "워크스페이스 ID",
+                        "name": "workspaceId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -719,6 +2866,64 @@
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/mcmpapi.McmpApiAction"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/mcmp-apis/import": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Fetches API specifications from remote URLs and imports them to the database. Supports swagger and openapi source types. Optionally accepts baseUrl and authentication info to populate the mcmp_api_services table.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "McmpAPI"
+                ],
+                "summary": "Import MCMP APIs from Remote Sources",
+                "operationId": "importAPIs",
+                "parameters": [
+                    {
+                        "description": "Frameworks to import (with optional baseUrl, authType, authUser, authPass)",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.ImportApiRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Import results",
+                        "schema": {
+                            "$ref": "#/definitions/model.ImportApiResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Invalid request body",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "error: Failed to import APIs",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
                             }
                         }
                     }
@@ -1716,6 +3921,372 @@
                 }
             }
         },
+        "/api/organizations": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "전체 조직 목록을 조회합니다. tree=true이면 Tree 구조로 반환.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "조직 목록 조회",
+                "operationId": "listOrganizations",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "Tree 구조 반환 여부 (기본: false)",
+                        "name": "tree",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.OrganizationTree"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "플랫폼 관리자가 조직을 생성합니다. parent_id가 없으면 최상위 조직 생성.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "조직 생성",
+                "operationId": "createOrganization",
+                "parameters": [
+                    {
+                        "description": "조직 생성 요청",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CreateOrganizationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/model.Organization"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/organizations/code/{code}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "조직 코드로 조직 정보를 조회합니다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "조직 상세 조회 (코드)",
+                "operationId": "getOrganizationByCode",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "조직 코드 (예: 0101)",
+                        "name": "code",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.Organization"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/organizations/id/{organizationId}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "조직 ID로 조직 정보를 조회합니다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "조직 상세 조회 (ID)",
+                "operationId": "getOrganizationByID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "조직 ID",
+                        "name": "organizationId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.Organization"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "조직 정보를 수정합니다. 부모 변경 시 하위 조직 코드 자동 재생성.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "조직 수정",
+                "operationId": "updateOrganization",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "조직 ID",
+                        "name": "organizationId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "조직 수정 요청",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.UpdateOrganizationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "조직을 삭제합니다. 하위 조직 또는 소속 사용자가 있으면 삭제 불가.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "조직 삭제",
+                "operationId": "deleteOrganization",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "조직 ID",
+                        "name": "organizationId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/organizations/id/{organizationId}/users": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "특정 조직에 소속된 사용자 목록을 조회합니다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "조직 소속 사용자 조회",
+                "operationId": "getOrganizationUsers",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "조직 ID",
+                        "name": "organizationId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.User"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/permissions/mciam": {
             "post": {
                 "security": [
@@ -2003,7 +4574,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Create a new project with the specified information.",
+                "description": "Create a new project with the specified information. Optionally specify a workspace to assign the project to.",
                 "consumes": [
                     "application/json"
                 ],
@@ -2022,7 +4593,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/model.Project"
+                            "$ref": "#/definitions/model.CreateProjectRequest"
                         }
                     }
                 ],
@@ -2042,8 +4613,149 @@
                             }
                         }
                     },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/projects/assign/workspaces": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "프로젝트에 워크스페이스를 연결합니다.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "summary": "프로젝트에 워크스페이스 연결",
+                "operationId": "addWorkspaceToProject",
+                "parameters": [
+                    {
+                        "description": "Workspace and Project IDs",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.WorkspaceProjectMappingRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "error: 잘못된 ID 형식",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "error: 프로젝트 또는 워크스페이스를 찾을 수 없습니다",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "error: 서버 내부 오류",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/projects/id/{projectId}/workspaces": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieve list of workspaces that the project is assigned to",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "summary": "Get workspaces assigned to project",
+                "operationId": "getProjectWorkspaces",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Project ID",
+                        "name": "projectId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.Workspace"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "error: Invalid project ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "error: Project not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "error: Internal server error",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -2141,6 +4853,61 @@
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/projects/unassign/workspaces": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Remove a workspace from a project",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "summary": "Remove workspace from project",
+                "operationId": "removeWorkspaceFromProject",
+                "parameters": [
+                    {
+                        "description": "Workspace and Project IDs",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.WorkspaceProjectMappingRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "error: Invalid request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "error: Internal server error",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -2320,75 +5087,6 @@
                     },
                     "500": {
                         "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/projects/{id}/workspaces/{workspaceId}": {
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "프로젝트에 워크스페이스를 연결합니다.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "projects"
-                ],
-                "summary": "프로젝트에 워크스페이스 연결",
-                "operationId": "addWorkspaceToProject",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "프로젝트 ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "워크스페이스 ID",
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    },
-                    "400": {
-                        "description": "error: 잘못된 ID 형식",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "error: 프로젝트 또는 워크스페이스를 찾을 수 없습니다",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "error: 서버 내부 오류",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -4804,7 +7502,7 @@
                     "roles"
                 ],
                 "summary": "List workspace roles",
-                "operationId": "listWorkspaceRoles",
+                "operationId": "listRolesOfWorkspaceType",
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -5060,6 +7758,44 @@
                 }
             }
         },
+        "/api/setup/initial-organizations": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "YAML 시드 파일에서 기본 조직 구조(MZC + 8개 프레임워크)를 로드하여 등록합니다. 멱등성 보장.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "기본 조직 초기화",
+                "operationId": "setupInitialOrganizations",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/setup/initial-role-menu-permission": {
             "get": {
                 "security": [
@@ -5241,6 +7977,201 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/model.User"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/users/id/{userId}/groups": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "사용자를 하나 이상의 그룹에 할당합니다. DB + Keycloak 그룹 동기화.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "groups"
+                ],
+                "summary": "사용자를 그룹에 할당 (Keycloak 동기화 포함)",
+                "operationId": "assignUserGroups",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "사용자 ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "그룹 할당 요청",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.AssignUserGroupsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/users/id/{userId}/groups/{groupId}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "사용자를 특정 그룹에서 제거합니다. DB + Keycloak 그룹 동기화.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "groups"
+                ],
+                "summary": "사용자를 그룹에서 제거 (Keycloak 동기화 포함)",
+                "operationId": "removeUserFromGroup",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "사용자 ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "그룹 ID",
+                        "name": "groupId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/users/id/{userId}/password": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Reset a user's password (admin only)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Reset user password",
+                "operationId": "ResetUserPassword",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID (DB)",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "New Password",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.ResetPasswordRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     },
                     "404": {
@@ -5577,6 +8508,72 @@
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/model.User"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/users/me/password": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Change the authenticated user's own password. Requires current password for verification.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Change my password",
+                "operationId": "changeMyPassword",
+                "parameters": [
+                    {
+                        "description": "Current and New Password",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.ChangeMyPasswordRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
                             }
                         }
                     },
@@ -5972,6 +8969,164 @@
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/users/{userId}/organizations": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "사용자가 소속된 조직 목록을 조회합니다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "사용자 소속 조직 조회",
+                "operationId": "getUserOrganizations",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "사용자 ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.Organization"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "사용자를 하나 이상의 조직에 할당합니다 (다중 소속 가능).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "사용자-조직 할당",
+                "operationId": "assignUserOrganizations",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "사용자 ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "조직 할당 요청",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.AssignUserOrganizationsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/users/{userId}/organizations/{organizationId}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "사용자를 특정 조직에서 제거합니다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "사용자-조직 매핑 제거",
+                "operationId": "removeUserOrganization",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "사용자 ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "조직 ID",
+                        "name": "organizationId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -6671,6 +9826,67 @@
                 }
             }
         },
+        "/api/workspaces/roles/list": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieve all workspace-level roles with optional filtering",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "List workspace roles",
+                "operationId": "listWorkspaceRoles",
+                "parameters": [
+                    {
+                        "description": "Role filter parameters",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.RoleFilterRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully retrieved workspace roles",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.RoleMaster"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "error: Invalid request format",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "error: Failed to retrieve workspace roles",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/workspaces/temporary-credentials": {
             "post": {
                 "security": [
@@ -7239,6 +10455,32 @@
                 }
             }
         },
+        "model.AssignGroupPlatformRoleRequest": {
+            "type": "object",
+            "required": [
+                "role_id"
+            ],
+            "properties": {
+                "role_id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "model.AssignGroupWorkspaceRequest": {
+            "type": "object",
+            "required": [
+                "role_id",
+                "workspace_id"
+            ],
+            "properties": {
+                "role_id": {
+                    "type": "integer"
+                },
+                "workspace_id": {
+                    "type": "integer"
+                }
+            }
+        },
         "model.AssignRoleRequest": {
             "type": "object",
             "properties": {
@@ -7268,6 +10510,36 @@
                 }
             }
         },
+        "model.AssignUserGroupsRequest": {
+            "type": "object",
+            "required": [
+                "group_ids"
+            ],
+            "properties": {
+                "group_ids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "integer"
+                    }
+                }
+            }
+        },
+        "model.AssignUserOrganizationsRequest": {
+            "type": "object",
+            "required": [
+                "organization_ids"
+            ],
+            "properties": {
+                "organization_ids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "integer"
+                    }
+                }
+            }
+        },
         "model.AssignWorkspaceRoleRequest": {
             "type": "object",
             "properties": {
@@ -7290,6 +10562,155 @@
                 "workspaceId": {
                     "description": "워크스페이스 ID (문자열로 받음)",
                     "type": "string"
+                }
+            }
+        },
+        "model.AttachPolicyRequest": {
+            "type": "object",
+            "required": [
+                "csp_policy_id",
+                "csp_role_id"
+            ],
+            "properties": {
+                "csp_policy_id": {
+                    "type": "integer"
+                },
+                "csp_role_id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "model.AuthMethodType": {
+            "type": "string",
+            "enum": [
+                "OIDC",
+                "SAML",
+                "SECRET_KEY"
+            ],
+            "x-enum-varnames": [
+                "AuthMethodOIDC",
+                "AuthMethodSAML",
+                "AuthMethodSecretKey"
+            ]
+        },
+        "model.ChangeMyPasswordRequest": {
+            "type": "object",
+            "required": [
+                "currentPassword",
+                "newPassword"
+            ],
+            "properties": {
+                "currentPassword": {
+                    "type": "string"
+                },
+                "newPassword": {
+                    "type": "string",
+                    "minLength": 8
+                }
+            }
+        },
+        "model.CreateCspAccountRequest": {
+            "type": "object",
+            "required": [
+                "csp_type",
+                "name"
+            ],
+            "properties": {
+                "account_info": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "csp_type": {
+                    "type": "string",
+                    "enum": [
+                        "aws",
+                        "gcp",
+                        "azure"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.CreateCspIdpConfigRequest": {
+            "type": "object",
+            "required": [
+                "auth_method",
+                "config",
+                "csp_account_id",
+                "name"
+            ],
+            "properties": {
+                "auth_method": {
+                    "enum": [
+                        "OIDC",
+                        "SAML",
+                        "SECRET_KEY"
+                    ],
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.AuthMethodType"
+                        }
+                    ]
+                },
+                "config": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "csp_account_id": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.CreateCspPolicyRequest": {
+            "type": "object",
+            "required": [
+                "csp_account_id",
+                "name",
+                "policy_type"
+            ],
+            "properties": {
+                "csp_account_id": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "policy_arn": {
+                    "type": "string"
+                },
+                "policy_doc": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "policy_type": {
+                    "enum": [
+                        "inline",
+                        "managed",
+                        "custom"
+                    ],
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.PolicyType"
+                        }
+                    ]
                 }
             }
         },
@@ -7364,6 +10785,48 @@
                 }
             }
         },
+        "model.CreateOrganizationRequest": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "maxLength": 1000
+                },
+                "name": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "organization_code": {
+                    "description": "비어있으면 자동 생성",
+                    "type": "string"
+                },
+                "parent_id": {
+                    "description": "nil = 최상위 조직",
+                    "type": "integer"
+                }
+            }
+        },
+        "model.CreateProjectRequest": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "workspaceId": {
+                    "description": "optional workspace to assign project to",
+                    "type": "string"
+                }
+            }
+        },
         "model.CreateRoleRequest": {
             "type": "object",
             "required": [
@@ -7400,6 +10863,168 @@
                 }
             }
         },
+        "model.CspAccount": {
+            "type": "object",
+            "properties": {
+                "account_info": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "csp_type": {
+                    "description": "aws, gcp, azure",
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.CspAccountFilter": {
+            "type": "object",
+            "properties": {
+                "csp_type": {
+                    "type": "string"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.CspIdpConfig": {
+            "type": "object",
+            "properties": {
+                "auth_method": {
+                    "description": "OIDC, SAML, SECRET_KEY",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.AuthMethodType"
+                        }
+                    ]
+                },
+                "config": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "csp_account": {
+                    "$ref": "#/definitions/model.CspAccount"
+                },
+                "csp_account_id": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.CspIdpConfigFilter": {
+            "type": "object",
+            "properties": {
+                "auth_method": {
+                    "$ref": "#/definitions/model.AuthMethodType"
+                },
+                "csp_account_id": {
+                    "type": "integer"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.CspPolicy": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "csp_account": {
+                    "$ref": "#/definitions/model.CspAccount"
+                },
+                "csp_account_id": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "policy_arn": {
+                    "type": "string"
+                },
+                "policy_doc": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "policy_type": {
+                    "description": "inline, managed, custom",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.PolicyType"
+                        }
+                    ]
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.CspPolicyFilter": {
+            "type": "object",
+            "properties": {
+                "csp_account_id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "policy_type": {
+                    "$ref": "#/definitions/model.PolicyType"
+                }
+            }
+        },
         "model.CspRole": {
             "type": "object",
             "properties": {
@@ -7409,6 +11034,19 @@
                 "created_at": {
                     "type": "string"
                 },
+                "csp_account": {
+                    "$ref": "#/definitions/model.CspAccount"
+                },
+                "csp_account_id": {
+                    "description": "CSP 계정 및 IDP 설정 참조 (신규 추가)",
+                    "type": "integer"
+                },
+                "csp_idp_config": {
+                    "$ref": "#/definitions/model.CspIdpConfig"
+                },
+                "csp_idp_config_id": {
+                    "type": "integer"
+                },
                 "csp_type": {
                     "type": "string"
                 },
@@ -7417,6 +11055,10 @@
                 },
                 "description": {
                     "type": "string"
+                },
+                "extended_config": {
+                    "type": "object",
+                    "additionalProperties": true
                 },
                 "iam_identifier": {
                     "type": "string"
@@ -7506,6 +11148,163 @@
                 },
                 "workspaceName": {
                     "type": "string"
+                }
+            }
+        },
+        "model.GroupPlatformRoleResponse": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "group_id": {
+                    "type": "integer"
+                },
+                "group_name": {
+                    "type": "string"
+                },
+                "role_id": {
+                    "type": "integer"
+                },
+                "role_name": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.GroupWorkspaceRoleResponse": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "group_id": {
+                    "type": "integer"
+                },
+                "group_name": {
+                    "type": "string"
+                },
+                "role_id": {
+                    "type": "integer"
+                },
+                "role_name": {
+                    "type": "string"
+                },
+                "workspace_id": {
+                    "type": "integer"
+                },
+                "workspace_name": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.ImportApiFramework": {
+            "type": "object",
+            "required": [
+                "name",
+                "sourceType",
+                "sourceUrl",
+                "version"
+            ],
+            "properties": {
+                "authPass": {
+                    "description": "Password for basic auth or token for bearer auth",
+                    "type": "string"
+                },
+                "authType": {
+                    "description": "Authentication type: \"none\", \"basic\", \"bearer\"",
+                    "type": "string"
+                },
+                "authUser": {
+                    "description": "Username for basic auth",
+                    "type": "string"
+                },
+                "baseUrl": {
+                    "description": "Base URL for the service (e.g., \"http://localhost:1323/tumblebug\")",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Framework name (e.g., \"mc-infra-manager\")",
+                    "type": "string"
+                },
+                "repository": {
+                    "description": "Repository URL (e.g., \"https://github.com/...\")",
+                    "type": "string"
+                },
+                "sourceType": {
+                    "description": "Source type: \"swagger\" or \"openapi\"",
+                    "type": "string"
+                },
+                "sourceUrl": {
+                    "description": "URL to fetch the API specification from",
+                    "type": "string"
+                },
+                "version": {
+                    "description": "Framework version (e.g., \"0.9.22\")",
+                    "type": "string"
+                }
+            }
+        },
+        "model.ImportApiFrameworkResult": {
+            "type": "object",
+            "properties": {
+                "actionCount": {
+                    "description": "Number of actions imported (on success)",
+                    "type": "integer"
+                },
+                "errorMessage": {
+                    "description": "Error message (on failure)",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Framework name",
+                    "type": "string"
+                },
+                "success": {
+                    "description": "Whether the import was successful",
+                    "type": "boolean"
+                },
+                "version": {
+                    "description": "Framework version",
+                    "type": "string"
+                }
+            }
+        },
+        "model.ImportApiRequest": {
+            "type": "object",
+            "required": [
+                "frameworks"
+            ],
+            "properties": {
+                "frameworks": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/model.ImportApiFramework"
+                    }
+                }
+            }
+        },
+        "model.ImportApiResponse": {
+            "type": "object",
+            "properties": {
+                "failureCount": {
+                    "description": "Number of failed frameworks",
+                    "type": "integer"
+                },
+                "frameworkResults": {
+                    "description": "Detailed results for each framework",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.ImportApiFrameworkResult"
+                    }
+                },
+                "successCount": {
+                    "description": "Number of successfully imported frameworks",
+                    "type": "integer"
+                },
+                "totalFrameworks": {
+                    "description": "Total number of frameworks in request",
+                    "type": "integer"
                 }
             }
         },
@@ -7650,6 +11449,117 @@
                 }
             }
         },
+        "model.Organization": {
+            "type": "object",
+            "properties": {
+                "children": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.Organization"
+                    }
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "organization_code": {
+                    "type": "string"
+                },
+                "parent": {
+                    "description": "관계 정의 (API 응답 전용 - 필요 시 Preload)",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.Organization"
+                        }
+                    ]
+                },
+                "parent_id": {
+                    "type": "integer"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "users": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.User"
+                    }
+                }
+            }
+        },
+        "model.OrganizationTree": {
+            "type": "object",
+            "properties": {
+                "children": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.OrganizationTree"
+                    }
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "level": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "organization_code": {
+                    "type": "string"
+                },
+                "parent_id": {
+                    "type": "integer"
+                },
+                "path": {
+                    "description": "예: \"/조직A/개발팀\"",
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "user_count": {
+                    "type": "integer"
+                }
+            }
+        },
+        "model.PolicyType": {
+            "type": "string",
+            "enum": [
+                "inline",
+                "managed",
+                "custom"
+            ],
+            "x-enum-comments": {
+                "PolicyTypeCustom": "사용자 정의 정책",
+                "PolicyTypeInline": "인라인 정책 (역할에 직접 포함)",
+                "PolicyTypeManaged": "관리형 정책 (독립 정책)"
+            },
+            "x-enum-descriptions": [
+                "인라인 정책 (역할에 직접 포함)",
+                "관리형 정책 (독립 정책)",
+                "사용자 정의 정책"
+            ],
+            "x-enum-varnames": [
+                "PolicyTypeInline",
+                "PolicyTypeManaged",
+                "PolicyTypeCustom"
+            ]
+        },
         "model.Project": {
             "type": "object",
             "properties": {
@@ -7678,6 +11588,18 @@
                     "items": {
                         "$ref": "#/definitions/model.Workspace"
                     }
+                }
+            }
+        },
+        "model.ResetPasswordRequest": {
+            "type": "object",
+            "required": [
+                "newPassword"
+            ],
+            "properties": {
+                "newPassword": {
+                    "type": "string",
+                    "minLength": 8
                 }
             }
         },
@@ -7715,6 +11637,23 @@
                 },
                 "message": {
                     "type": "string"
+                }
+            }
+        },
+        "model.RoleFilterRequest": {
+            "type": "object",
+            "properties": {
+                "roleId": {
+                    "type": "string"
+                },
+                "roleName": {
+                    "type": "string"
+                },
+                "roleTypes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/constants.IAMRoleType"
+                    }
                 }
             }
         },
@@ -7883,6 +11822,49 @@
                 }
             }
         },
+        "model.SignupRequest": {
+            "type": "object",
+            "required": [
+                "email",
+                "firstName",
+                "lastName",
+                "password"
+            ],
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "firstName": {
+                    "type": "string"
+                },
+                "lastName": {
+                    "type": "string"
+                },
+                "organization": {
+                    "description": "선택 필드",
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string",
+                    "minLength": 8
+                }
+            }
+        },
+        "model.SyncPoliciesRequest": {
+            "type": "object",
+            "required": [
+                "csp_account_id"
+            ],
+            "properties": {
+                "csp_account_id": {
+                    "type": "integer"
+                },
+                "policy_scope": {
+                    "description": "All, AWS, Local",
+                    "type": "string"
+                }
+            }
+        },
         "model.Tag": {
             "type": "object",
             "properties": {
@@ -7891,6 +11873,96 @@
                 },
                 "value": {
                     "type": "string"
+                }
+            }
+        },
+        "model.UpdateCspAccountRequest": {
+            "type": "object",
+            "properties": {
+                "account_info": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "description": {
+                    "type": "string"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.UpdateCspIdpConfigRequest": {
+            "type": "object",
+            "properties": {
+                "config": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "description": {
+                    "type": "string"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.UpdateCspPolicyRequest": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "policy_arn": {
+                    "type": "string"
+                },
+                "policy_doc": {
+                    "type": "object",
+                    "additionalProperties": true
+                }
+            }
+        },
+        "model.UpdateGroupWorkspaceRoleRequest": {
+            "type": "object",
+            "required": [
+                "role_id"
+            ],
+            "properties": {
+                "role_id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "model.UpdateOrganizationRequest": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "maxLength": 1000
+                },
+                "name": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "organization_code": {
+                    "description": "코드 수정 시 입력",
+                    "type": "string"
+                },
+                "parent_id": {
+                    "description": "부모 변경 시 입력",
+                    "type": "integer"
                 }
             }
         },
@@ -7925,6 +11997,10 @@
                 },
                 "lastName": {
                     "description": "Ignore LastName for DB",
+                    "type": "string"
+                },
+                "organization": {
+                    "description": "Organization stored in Keycloak attributes",
                     "type": "string"
                 },
                 "platform_roles": {
@@ -8041,6 +12117,24 @@
                     }
                 },
                 "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.WorkspaceProjectMappingRequest": {
+            "type": "object",
+            "required": [
+                "projectIds",
+                "workspaceId"
+            ],
+            "properties": {
+                "projectIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "workspaceId": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -123,6 +123,23 @@ definitions:
       version:
         type: string
     type: object
+  model.AssignGroupPlatformRoleRequest:
+    properties:
+      role_id:
+        type: integer
+    required:
+    - role_id
+    type: object
+  model.AssignGroupWorkspaceRequest:
+    properties:
+      role_id:
+        type: integer
+      workspace_id:
+        type: integer
+    required:
+    - role_id
+    - workspace_id
+    type: object
   model.AssignRoleRequest:
     properties:
       roleId:
@@ -144,6 +161,26 @@ definitions:
         description: 워크스페이스 ID (문자열로 받음)
         type: string
     type: object
+  model.AssignUserGroupsRequest:
+    properties:
+      group_ids:
+        items:
+          type: integer
+        minItems: 1
+        type: array
+    required:
+    - group_ids
+    type: object
+  model.AssignUserOrganizationsRequest:
+    properties:
+      organization_ids:
+        items:
+          type: integer
+        minItems: 1
+        type: array
+    required:
+    - organization_ids
+    type: object
   model.AssignWorkspaceRoleRequest:
     properties:
       roleId:
@@ -161,6 +198,107 @@ definitions:
       workspaceId:
         description: 워크스페이스 ID (문자열로 받음)
         type: string
+    type: object
+  model.AttachPolicyRequest:
+    properties:
+      csp_policy_id:
+        type: integer
+      csp_role_id:
+        type: integer
+    required:
+    - csp_policy_id
+    - csp_role_id
+    type: object
+  model.AuthMethodType:
+    enum:
+    - OIDC
+    - SAML
+    - SECRET_KEY
+    type: string
+    x-enum-varnames:
+    - AuthMethodOIDC
+    - AuthMethodSAML
+    - AuthMethodSecretKey
+  model.ChangeMyPasswordRequest:
+    properties:
+      currentPassword:
+        type: string
+      newPassword:
+        minLength: 8
+        type: string
+    required:
+    - currentPassword
+    - newPassword
+    type: object
+  model.CreateCspAccountRequest:
+    properties:
+      account_info:
+        additionalProperties:
+          type: string
+        type: object
+      csp_type:
+        enum:
+        - aws
+        - gcp
+        - azure
+        type: string
+      description:
+        type: string
+      name:
+        type: string
+    required:
+    - csp_type
+    - name
+    type: object
+  model.CreateCspIdpConfigRequest:
+    properties:
+      auth_method:
+        allOf:
+        - $ref: '#/definitions/model.AuthMethodType'
+        enum:
+        - OIDC
+        - SAML
+        - SECRET_KEY
+      config:
+        additionalProperties:
+          type: string
+        type: object
+      csp_account_id:
+        type: integer
+      description:
+        type: string
+      name:
+        type: string
+    required:
+    - auth_method
+    - config
+    - csp_account_id
+    - name
+    type: object
+  model.CreateCspPolicyRequest:
+    properties:
+      csp_account_id:
+        type: integer
+      description:
+        type: string
+      name:
+        type: string
+      policy_arn:
+        type: string
+      policy_doc:
+        additionalProperties: true
+        type: object
+      policy_type:
+        allOf:
+        - $ref: '#/definitions/model.PolicyType'
+        enum:
+        - inline
+        - managed
+        - custom
+    required:
+    - csp_account_id
+    - name
+    - policy_type
     type: object
   model.CreateCspRoleRequest:
     properties:
@@ -209,6 +347,35 @@ definitions:
     - menuIds
     - roleId
     type: object
+  model.CreateOrganizationRequest:
+    properties:
+      description:
+        maxLength: 1000
+        type: string
+      name:
+        maxLength: 255
+        type: string
+      organization_code:
+        description: 비어있으면 자동 생성
+        type: string
+      parent_id:
+        description: nil = 최상위 조직
+        type: integer
+    required:
+    - name
+    type: object
+  model.CreateProjectRequest:
+    properties:
+      description:
+        type: string
+      name:
+        type: string
+      workspaceId:
+        description: optional workspace to assign project to
+        type: string
+    required:
+    - name
+    type: object
   model.CreateRoleRequest:
     properties:
       cspRoles:
@@ -234,18 +401,134 @@ definitions:
     required:
     - name
     type: object
+  model.CspAccount:
+    properties:
+      account_info:
+        additionalProperties:
+          type: string
+        type: object
+      created_at:
+        type: string
+      csp_type:
+        description: aws, gcp, azure
+        type: string
+      description:
+        type: string
+      id:
+        type: integer
+      is_active:
+        type: boolean
+      name:
+        type: string
+      updated_at:
+        type: string
+    type: object
+  model.CspAccountFilter:
+    properties:
+      csp_type:
+        type: string
+      is_active:
+        type: boolean
+      name:
+        type: string
+    type: object
+  model.CspIdpConfig:
+    properties:
+      auth_method:
+        allOf:
+        - $ref: '#/definitions/model.AuthMethodType'
+        description: OIDC, SAML, SECRET_KEY
+      config:
+        additionalProperties:
+          type: string
+        type: object
+      created_at:
+        type: string
+      csp_account:
+        $ref: '#/definitions/model.CspAccount'
+      csp_account_id:
+        type: integer
+      description:
+        type: string
+      id:
+        type: integer
+      is_active:
+        type: boolean
+      name:
+        type: string
+      updated_at:
+        type: string
+    type: object
+  model.CspIdpConfigFilter:
+    properties:
+      auth_method:
+        $ref: '#/definitions/model.AuthMethodType'
+      csp_account_id:
+        type: integer
+      is_active:
+        type: boolean
+      name:
+        type: string
+    type: object
+  model.CspPolicy:
+    properties:
+      created_at:
+        type: string
+      csp_account:
+        $ref: '#/definitions/model.CspAccount'
+      csp_account_id:
+        type: integer
+      description:
+        type: string
+      id:
+        type: integer
+      name:
+        type: string
+      policy_arn:
+        type: string
+      policy_doc:
+        additionalProperties: true
+        type: object
+      policy_type:
+        allOf:
+        - $ref: '#/definitions/model.PolicyType'
+        description: inline, managed, custom
+      updated_at:
+        type: string
+    type: object
+  model.CspPolicyFilter:
+    properties:
+      csp_account_id:
+        type: integer
+      name:
+        type: string
+      policy_type:
+        $ref: '#/definitions/model.PolicyType'
+    type: object
   model.CspRole:
     properties:
       create_date:
         type: string
       created_at:
         type: string
+      csp_account:
+        $ref: '#/definitions/model.CspAccount'
+      csp_account_id:
+        description: CSP 계정 및 IDP 설정 참조 (신규 추가)
+        type: integer
+      csp_idp_config:
+        $ref: '#/definitions/model.CspIdpConfig'
+      csp_idp_config_id:
+        type: integer
       csp_type:
         type: string
       deleted_at:
         type: string
       description:
         type: string
+      extended_config:
+        additionalProperties: true
+        type: object
       iam_identifier:
         type: string
       iam_role_id:
@@ -305,6 +588,116 @@ definitions:
         type: string
       workspaceName:
         type: string
+    type: object
+  model.GroupPlatformRoleResponse:
+    properties:
+      created_at:
+        type: string
+      group_id:
+        type: integer
+      group_name:
+        type: string
+      role_id:
+        type: integer
+      role_name:
+        type: string
+    type: object
+  model.GroupWorkspaceRoleResponse:
+    properties:
+      created_at:
+        type: string
+      group_id:
+        type: integer
+      group_name:
+        type: string
+      role_id:
+        type: integer
+      role_name:
+        type: string
+      workspace_id:
+        type: integer
+      workspace_name:
+        type: string
+    type: object
+  model.ImportApiFramework:
+    properties:
+      authPass:
+        description: Password for basic auth or token for bearer auth
+        type: string
+      authType:
+        description: 'Authentication type: "none", "basic", "bearer"'
+        type: string
+      authUser:
+        description: Username for basic auth
+        type: string
+      baseUrl:
+        description: Base URL for the service (e.g., "http://localhost:1323/tumblebug")
+        type: string
+      name:
+        description: Framework name (e.g., "mc-infra-manager")
+        type: string
+      repository:
+        description: Repository URL (e.g., "https://github.com/...")
+        type: string
+      sourceType:
+        description: 'Source type: "swagger" or "openapi"'
+        type: string
+      sourceUrl:
+        description: URL to fetch the API specification from
+        type: string
+      version:
+        description: Framework version (e.g., "0.9.22")
+        type: string
+    required:
+    - name
+    - sourceType
+    - sourceUrl
+    - version
+    type: object
+  model.ImportApiFrameworkResult:
+    properties:
+      actionCount:
+        description: Number of actions imported (on success)
+        type: integer
+      errorMessage:
+        description: Error message (on failure)
+        type: string
+      name:
+        description: Framework name
+        type: string
+      success:
+        description: Whether the import was successful
+        type: boolean
+      version:
+        description: Framework version
+        type: string
+    type: object
+  model.ImportApiRequest:
+    properties:
+      frameworks:
+        items:
+          $ref: '#/definitions/model.ImportApiFramework'
+        minItems: 1
+        type: array
+    required:
+    - frameworks
+    type: object
+  model.ImportApiResponse:
+    properties:
+      failureCount:
+        description: Number of failed frameworks
+        type: integer
+      frameworkResults:
+        description: Detailed results for each framework
+        items:
+          $ref: '#/definitions/model.ImportApiFrameworkResult'
+        type: array
+      successCount:
+        description: Number of successfully imported frameworks
+        type: integer
+      totalFrameworks:
+        description: Total number of frameworks in request
+        type: integer
     type: object
   model.MciamPermission:
     properties:
@@ -402,6 +795,81 @@ definitions:
       resType:
         type: string
     type: object
+  model.Organization:
+    properties:
+      children:
+        items:
+          $ref: '#/definitions/model.Organization'
+        type: array
+      created_at:
+        type: string
+      description:
+        type: string
+      id:
+        type: integer
+      name:
+        type: string
+      organization_code:
+        type: string
+      parent:
+        allOf:
+        - $ref: '#/definitions/model.Organization'
+        description: 관계 정의 (API 응답 전용 - 필요 시 Preload)
+      parent_id:
+        type: integer
+      updated_at:
+        type: string
+      users:
+        items:
+          $ref: '#/definitions/model.User'
+        type: array
+    type: object
+  model.OrganizationTree:
+    properties:
+      children:
+        items:
+          $ref: '#/definitions/model.OrganizationTree'
+        type: array
+      created_at:
+        type: string
+      description:
+        type: string
+      id:
+        type: integer
+      level:
+        type: integer
+      name:
+        type: string
+      organization_code:
+        type: string
+      parent_id:
+        type: integer
+      path:
+        description: '예: "/조직A/개발팀"'
+        type: string
+      updated_at:
+        type: string
+      user_count:
+        type: integer
+    type: object
+  model.PolicyType:
+    enum:
+    - inline
+    - managed
+    - custom
+    type: string
+    x-enum-comments:
+      PolicyTypeCustom: 사용자 정의 정책
+      PolicyTypeInline: 인라인 정책 (역할에 직접 포함)
+      PolicyTypeManaged: 관리형 정책 (독립 정책)
+    x-enum-descriptions:
+    - 인라인 정책 (역할에 직접 포함)
+    - 관리형 정책 (독립 정책)
+    - 사용자 정의 정책
+    x-enum-varnames:
+    - PolicyTypeInline
+    - PolicyTypeManaged
+    - PolicyTypeCustom
   model.Project:
     properties:
       created_at:
@@ -422,6 +890,14 @@ definitions:
         items:
           $ref: '#/definitions/model.Workspace'
         type: array
+    type: object
+  model.ResetPasswordRequest:
+    properties:
+      newPassword:
+        minLength: 8
+        type: string
+    required:
+    - newPassword
     type: object
   model.ResourceType:
     properties:
@@ -447,6 +923,17 @@ definitions:
         type: boolean
       message:
         type: string
+    type: object
+  model.RoleFilterRequest:
+    properties:
+      roleId:
+        type: string
+      roleName:
+        type: string
+      roleTypes:
+        items:
+          $ref: '#/definitions/constants.IAMRoleType'
+        type: array
     type: object
   model.RoleLastUsed:
     properties:
@@ -556,12 +1043,102 @@ definitions:
       username:
         type: string
     type: object
+  model.SignupRequest:
+    properties:
+      email:
+        type: string
+      firstName:
+        type: string
+      lastName:
+        type: string
+      organization:
+        description: 선택 필드
+        type: string
+      password:
+        minLength: 8
+        type: string
+    required:
+    - email
+    - firstName
+    - lastName
+    - password
+    type: object
+  model.SyncPoliciesRequest:
+    properties:
+      csp_account_id:
+        type: integer
+      policy_scope:
+        description: All, AWS, Local
+        type: string
+    required:
+    - csp_account_id
+    type: object
   model.Tag:
     properties:
       key:
         type: string
       value:
         type: string
+    type: object
+  model.UpdateCspAccountRequest:
+    properties:
+      account_info:
+        additionalProperties:
+          type: string
+        type: object
+      description:
+        type: string
+      is_active:
+        type: boolean
+      name:
+        type: string
+    type: object
+  model.UpdateCspIdpConfigRequest:
+    properties:
+      config:
+        additionalProperties:
+          type: string
+        type: object
+      description:
+        type: string
+      is_active:
+        type: boolean
+      name:
+        type: string
+    type: object
+  model.UpdateCspPolicyRequest:
+    properties:
+      description:
+        type: string
+      name:
+        type: string
+      policy_arn:
+        type: string
+      policy_doc:
+        additionalProperties: true
+        type: object
+    type: object
+  model.UpdateGroupWorkspaceRoleRequest:
+    properties:
+      role_id:
+        type: integer
+    required:
+    - role_id
+    type: object
+  model.UpdateOrganizationRequest:
+    properties:
+      description:
+        maxLength: 1000
+        type: string
+      name:
+        maxLength: 255
+        type: string
+      organization_code:
+        description: 코드 수정 시 입력
+        type: string
+      parent_id:
+        description: 부모 변경 시 입력
+        type: integer
     type: object
   model.User:
     properties:
@@ -586,6 +1163,9 @@ definitions:
         type: string
       lastName:
         description: Ignore LastName for DB
+        type: string
+      organization:
+        description: Organization stored in Keycloak attributes
         type: string
       platform_roles:
         description: 관계 정의
@@ -665,6 +1245,18 @@ definitions:
         type: array
       updated_at:
         type: string
+    type: object
+  model.WorkspaceProjectMappingRequest:
+    properties:
+      projectIds:
+        items:
+          type: string
+        type: array
+      workspaceId:
+        type: string
+    required:
+    - projectIds
+    - workspaceId
     type: object
   model.WorkspaceWithUsersAndRoles:
     properties:
@@ -793,6 +1385,47 @@ paths:
       summary: Refresh access token
       tags:
       - auth
+  /api/auth/signup:
+    post:
+      consumes:
+      - application/json
+      description: Public user signup (no authentication required)
+      operationId: SignupUser
+      parameters:
+      - description: Signup Info
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/model.SignupRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "409":
+          description: Conflict
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: User signup
+      tags:
+      - auth
   /api/auth/temp-credential-csps:
     get:
       consumes:
@@ -848,6 +1481,335 @@ paths:
       summary: Validate access token
       tags:
       - auth
+  /api/csp-accounts:
+    post:
+      consumes:
+      - application/json
+      description: Create a new CSP account
+      operationId: createCspAccount
+      parameters:
+      - description: CSP Account Info
+        in: body
+        name: account
+        required: true
+        schema:
+          $ref: '#/definitions/model.CreateCspAccountRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/model.CspAccount'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Create CSP account
+      tags:
+      - csp-accounts
+  /api/csp-accounts/id/{accountId}:
+    delete:
+      consumes:
+      - application/json
+      description: Delete a CSP account by ID
+      operationId: deleteCspAccount
+      parameters:
+      - description: Account ID
+        in: path
+        name: accountId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Delete CSP account
+      tags:
+      - csp-accounts
+    get:
+      consumes:
+      - application/json
+      description: Retrieve CSP account details by ID
+      operationId: getCspAccountByID
+      parameters:
+      - description: Account ID
+        in: path
+        name: accountId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.CspAccount'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Get CSP account by ID
+      tags:
+      - csp-accounts
+    put:
+      consumes:
+      - application/json
+      description: Update CSP account details
+      operationId: updateCspAccount
+      parameters:
+      - description: Account ID
+        in: path
+        name: accountId
+        required: true
+        type: string
+      - description: CSP Account Info
+        in: body
+        name: account
+        required: true
+        schema:
+          $ref: '#/definitions/model.UpdateCspAccountRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.CspAccount'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Update CSP account
+      tags:
+      - csp-accounts
+  /api/csp-accounts/id/{accountId}/activate:
+    post:
+      consumes:
+      - application/json
+      description: Activate a CSP account
+      operationId: activateCspAccount
+      parameters:
+      - description: Account ID
+        in: path
+        name: accountId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Activate CSP account
+      tags:
+      - csp-accounts
+  /api/csp-accounts/id/{accountId}/deactivate:
+    post:
+      consumes:
+      - application/json
+      description: Deactivate a CSP account
+      operationId: deactivateCspAccount
+      parameters:
+      - description: Account ID
+        in: path
+        name: accountId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Deactivate CSP account
+      tags:
+      - csp-accounts
+  /api/csp-accounts/id/{accountId}/validate:
+    post:
+      consumes:
+      - application/json
+      description: Validate CSP account configuration
+      operationId: validateCspAccount
+      parameters:
+      - description: Account ID
+        in: path
+        name: accountId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Validate CSP account
+      tags:
+      - csp-accounts
+  /api/csp-accounts/list:
+    post:
+      consumes:
+      - application/json
+      description: Retrieve a list of CSP accounts with optional filters
+      operationId: listCspAccounts
+      parameters:
+      - description: Filter options
+        in: body
+        name: filter
+        schema:
+          $ref: '#/definitions/model.CspAccountFilter'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.CspAccount'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: List CSP accounts
+      tags:
+      - csp-accounts
   /api/csp-credentials:
     get:
       consumes:
@@ -965,6 +1927,1024 @@ paths:
       summary: CSP 인증 정보 업데이트
       tags:
       - csp-credentials
+  /api/csp-idp-configs:
+    post:
+      consumes:
+      - application/json
+      description: Create a new CSP IDP configuration
+      operationId: createCspIdpConfig
+      parameters:
+      - description: CSP IDP Config Info
+        in: body
+        name: config
+        required: true
+        schema:
+          $ref: '#/definitions/model.CreateCspIdpConfigRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/model.CspIdpConfig'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Create CSP IDP config
+      tags:
+      - csp-idp-configs
+  /api/csp-idp-configs/id/{configId}:
+    delete:
+      consumes:
+      - application/json
+      description: Delete a CSP IDP configuration by ID
+      operationId: deleteCspIdpConfig
+      parameters:
+      - description: Config ID
+        in: path
+        name: configId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Delete CSP IDP config
+      tags:
+      - csp-idp-configs
+    get:
+      consumes:
+      - application/json
+      description: Retrieve CSP IDP configuration details by ID
+      operationId: getCspIdpConfigByID
+      parameters:
+      - description: Config ID
+        in: path
+        name: configId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.CspIdpConfig'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Get CSP IDP config by ID
+      tags:
+      - csp-idp-configs
+    put:
+      consumes:
+      - application/json
+      description: Update CSP IDP configuration details
+      operationId: updateCspIdpConfig
+      parameters:
+      - description: Config ID
+        in: path
+        name: configId
+        required: true
+        type: string
+      - description: CSP IDP Config Info
+        in: body
+        name: config
+        required: true
+        schema:
+          $ref: '#/definitions/model.UpdateCspIdpConfigRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.CspIdpConfig'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Update CSP IDP config
+      tags:
+      - csp-idp-configs
+  /api/csp-idp-configs/id/{configId}/activate:
+    post:
+      consumes:
+      - application/json
+      description: Activate a CSP IDP configuration
+      operationId: activateCspIdpConfig
+      parameters:
+      - description: Config ID
+        in: path
+        name: configId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Activate CSP IDP config
+      tags:
+      - csp-idp-configs
+  /api/csp-idp-configs/id/{configId}/deactivate:
+    post:
+      consumes:
+      - application/json
+      description: Deactivate a CSP IDP configuration
+      operationId: deactivateCspIdpConfig
+      parameters:
+      - description: Config ID
+        in: path
+        name: configId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Deactivate CSP IDP config
+      tags:
+      - csp-idp-configs
+  /api/csp-idp-configs/id/{configId}/test:
+    post:
+      consumes:
+      - application/json
+      description: Test connection to CSP using IDP configuration
+      operationId: testCspIdpConnection
+      parameters:
+      - description: Config ID
+        in: path
+        name: configId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Test CSP IDP connection
+      tags:
+      - csp-idp-configs
+  /api/csp-idp-configs/list:
+    post:
+      consumes:
+      - application/json
+      description: Retrieve a list of CSP IDP configurations with optional filters
+      operationId: listCspIdpConfigs
+      parameters:
+      - description: Filter options
+        in: body
+        name: filter
+        schema:
+          $ref: '#/definitions/model.CspIdpConfigFilter'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.CspIdpConfig'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: List CSP IDP configs
+      tags:
+      - csp-idp-configs
+  /api/csp-policies:
+    post:
+      consumes:
+      - application/json
+      description: Create a new CSP policy
+      operationId: createCspPolicy
+      parameters:
+      - description: CSP Policy Info
+        in: body
+        name: policy
+        required: true
+        schema:
+          $ref: '#/definitions/model.CreateCspPolicyRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/model.CspPolicy'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Create CSP policy
+      tags:
+      - csp-policies
+  /api/csp-policies/attach:
+    post:
+      consumes:
+      - application/json
+      description: Attach a CSP policy to a CSP role
+      operationId: attachPolicyToRole
+      parameters:
+      - description: Attach Policy Request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/model.AttachPolicyRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Attach policy to role
+      tags:
+      - csp-policies
+  /api/csp-policies/detach:
+    post:
+      consumes:
+      - application/json
+      description: Detach a CSP policy from a CSP role
+      operationId: detachPolicyFromRole
+      parameters:
+      - description: Detach Policy Request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/model.AttachPolicyRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Detach policy from role
+      tags:
+      - csp-policies
+  /api/csp-policies/id/{policyId}:
+    delete:
+      consumes:
+      - application/json
+      description: Delete a CSP policy by ID
+      operationId: deleteCspPolicy
+      parameters:
+      - description: Policy ID
+        in: path
+        name: policyId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Delete CSP policy
+      tags:
+      - csp-policies
+    get:
+      consumes:
+      - application/json
+      description: Retrieve CSP policy details by ID
+      operationId: getCspPolicyByID
+      parameters:
+      - description: Policy ID
+        in: path
+        name: policyId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.CspPolicy'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Get CSP policy by ID
+      tags:
+      - csp-policies
+    put:
+      consumes:
+      - application/json
+      description: Update CSP policy details
+      operationId: updateCspPolicy
+      parameters:
+      - description: Policy ID
+        in: path
+        name: policyId
+        required: true
+        type: string
+      - description: CSP Policy Info
+        in: body
+        name: policy
+        required: true
+        schema:
+          $ref: '#/definitions/model.UpdateCspPolicyRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.CspPolicy'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Update CSP policy
+      tags:
+      - csp-policies
+  /api/csp-policies/id/{policyId}/document:
+    get:
+      consumes:
+      - application/json
+      description: Get the policy document content
+      operationId: getPolicyDocument
+      parameters:
+      - description: Policy ID
+        in: path
+        name: policyId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Get policy document
+      tags:
+      - csp-policies
+  /api/csp-policies/list:
+    post:
+      consumes:
+      - application/json
+      description: Retrieve a list of CSP policies with optional filters
+      operationId: listCspPolicies
+      parameters:
+      - description: Filter options
+        in: body
+        name: filter
+        schema:
+          $ref: '#/definitions/model.CspPolicyFilter'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.CspPolicy'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: List CSP policies
+      tags:
+      - csp-policies
+  /api/csp-policies/role/{roleId}:
+    get:
+      consumes:
+      - application/json
+      description: Get list of policies attached to a CSP role
+      operationId: getRolePolicies
+      parameters:
+      - description: Role ID
+        in: path
+        name: roleId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.CspPolicy'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Get policies attached to role
+      tags:
+      - csp-policies
+  /api/csp-policies/sync:
+    post:
+      consumes:
+      - application/json
+      description: Synchronize policies from the CSP cloud
+      operationId: syncCspPolicies
+      parameters:
+      - description: Sync Policies Request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/model.SyncPoliciesRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.CspPolicy'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Sync CSP policies from cloud
+      tags:
+      - csp-policies
+  /api/groups/id/{groupId}/platform-roles:
+    get:
+      description: 그룹에 할당된 플랫폼 역할 목록을 조회합니다.
+      operationId: getGroupPlatformRoles
+      parameters:
+      - description: 그룹 ID
+        in: path
+        name: groupId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.GroupPlatformRoleResponse'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 그룹 Platform Role 목록 조회
+      tags:
+      - groups
+    post:
+      consumes:
+      - application/json
+      description: 그룹에 플랫폼 역할을 할당합니다. DB + Keycloak 이중 관리.
+      operationId: assignGroupPlatformRole
+      parameters:
+      - description: 그룹 ID
+        in: path
+        name: groupId
+        required: true
+        type: integer
+      - description: 역할 할당 요청
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/model.AssignGroupPlatformRoleRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "409":
+          description: Conflict
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 그룹에 Platform Role 할당
+      tags:
+      - groups
+  /api/groups/id/{groupId}/platform-roles/{roleId}:
+    delete:
+      description: 그룹에 할당된 플랫폼 역할을 해제합니다. DB + Keycloak 동시 제거.
+      operationId: removeGroupPlatformRole
+      parameters:
+      - description: 그룹 ID
+        in: path
+        name: groupId
+        required: true
+        type: integer
+      - description: 역할 ID
+        in: path
+        name: roleId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 그룹 Platform Role 해제
+      tags:
+      - groups
+  /api/groups/id/{groupId}/workspaces:
+    get:
+      description: 그룹에 매핑된 워크스페이스 및 역할 목록을 조회합니다.
+      operationId: getGroupWorkspaces
+      parameters:
+      - description: 그룹 ID
+        in: path
+        name: groupId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.GroupWorkspaceRoleResponse'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 그룹 워크스페이스 매핑 목록 조회
+      tags:
+      - groups
+    post:
+      consumes:
+      - application/json
+      description: 그룹을 워크스페이스에 매핑하고 역할을 지정합니다. DB 전용 관리.
+      operationId: assignGroupWorkspace
+      parameters:
+      - description: 그룹 ID
+        in: path
+        name: groupId
+        required: true
+        type: integer
+      - description: 워크스페이스 매핑 요청
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/model.AssignGroupWorkspaceRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "409":
+          description: Conflict
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 그룹-워크스페이스 매핑
+      tags:
+      - groups
+  /api/groups/id/{groupId}/workspaces/{workspaceId}:
+    delete:
+      description: 그룹-워크스페이스 매핑을 제거합니다.
+      operationId: removeGroupWorkspaceRole
+      parameters:
+      - description: 그룹 ID
+        in: path
+        name: groupId
+        required: true
+        type: integer
+      - description: 워크스페이스 ID
+        in: path
+        name: workspaceId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 그룹-워크스페이스 매핑 제거
+      tags:
+      - groups
+    put:
+      consumes:
+      - application/json
+      description: 그룹-워크스페이스 매핑의 역할을 변경합니다.
+      operationId: updateGroupWorkspaceRole
+      parameters:
+      - description: 그룹 ID
+        in: path
+        name: groupId
+        required: true
+        type: integer
+      - description: 워크스페이스 ID
+        in: path
+        name: workspaceId
+        required: true
+        type: integer
+      - description: 역할 변경 요청
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/model.UpdateGroupWorkspaceRoleRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 그룹 워크스페이스 역할 변경
+      tags:
+      - groups
   /api/initial-admin:
     post:
       consumes:
@@ -1165,6 +3145,46 @@ paths:
       summary: Get platform actions by permission ID
       tags:
       - mcmp-api-permission-action-mappings
+  /api/mcmp-apis/import:
+    post:
+      consumes:
+      - application/json
+      description: Fetches API specifications from remote URLs and imports them to
+        the database. Supports swagger and openapi source types. Optionally accepts
+        baseUrl and authentication info to populate the mcmp_api_services table.
+      operationId: importAPIs
+      parameters:
+      - description: Frameworks to import (with optional baseUrl, authType, authUser,
+          authPass)
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/model.ImportApiRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Import results
+          schema:
+            $ref: '#/definitions/model.ImportApiResponse'
+        "400":
+          description: 'error: Invalid request body'
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: 'error: Failed to import APIs'
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Import MCMP APIs from Remote Sources
+      tags:
+      - McmpAPI
   /api/mcmp-apis/list:
     post:
       consumes:
@@ -1814,6 +3834,241 @@ paths:
       summary: Get user menu tree by platform roles
       tags:
       - menus
+  /api/organizations:
+    get:
+      description: 전체 조직 목록을 조회합니다. tree=true이면 Tree 구조로 반환.
+      operationId: listOrganizations
+      parameters:
+      - description: 'Tree 구조 반환 여부 (기본: false)'
+        in: query
+        name: tree
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.OrganizationTree'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 조직 목록 조회
+      tags:
+      - organizations
+    post:
+      consumes:
+      - application/json
+      description: 플랫폼 관리자가 조직을 생성합니다. parent_id가 없으면 최상위 조직 생성.
+      operationId: createOrganization
+      parameters:
+      - description: 조직 생성 요청
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/model.CreateOrganizationRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/model.Organization'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "409":
+          description: Conflict
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 조직 생성
+      tags:
+      - organizations
+  /api/organizations/code/{code}:
+    get:
+      description: 조직 코드로 조직 정보를 조회합니다.
+      operationId: getOrganizationByCode
+      parameters:
+      - description: '조직 코드 (예: 0101)'
+        in: path
+        name: code
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.Organization'
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 조직 상세 조회 (코드)
+      tags:
+      - organizations
+  /api/organizations/id/{organizationId}:
+    delete:
+      description: 조직을 삭제합니다. 하위 조직 또는 소속 사용자가 있으면 삭제 불가.
+      operationId: deleteOrganization
+      parameters:
+      - description: 조직 ID
+        in: path
+        name: organizationId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 조직 삭제
+      tags:
+      - organizations
+    get:
+      description: 조직 ID로 조직 정보를 조회합니다.
+      operationId: getOrganizationByID
+      parameters:
+      - description: 조직 ID
+        in: path
+        name: organizationId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.Organization'
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 조직 상세 조회 (ID)
+      tags:
+      - organizations
+    put:
+      consumes:
+      - application/json
+      description: 조직 정보를 수정합니다. 부모 변경 시 하위 조직 코드 자동 재생성.
+      operationId: updateOrganization
+      parameters:
+      - description: 조직 ID
+        in: path
+        name: organizationId
+        required: true
+        type: integer
+      - description: 조직 수정 요청
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/model.UpdateOrganizationRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "409":
+          description: Conflict
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 조직 수정
+      tags:
+      - organizations
+  /api/organizations/id/{organizationId}/users:
+    get:
+      description: 특정 조직에 소속된 사용자 목록을 조회합니다.
+      operationId: getOrganizationUsers
+      parameters:
+      - description: 조직 ID
+        in: path
+        name: organizationId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.User'
+            type: array
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 조직 소속 사용자 조회
+      tags:
+      - organizations
   /api/permissions/mciam:
     post:
       consumes:
@@ -1998,7 +4253,8 @@ paths:
     post:
       consumes:
       - application/json
-      description: Create a new project with the specified information.
+      description: Create a new project with the specified information. Optionally
+        specify a workspace to assign the project to.
       operationId: createProject
       parameters:
       - description: Project Info
@@ -2006,7 +4262,7 @@ paths:
         name: project
         required: true
         schema:
-          $ref: '#/definitions/model.Project'
+          $ref: '#/definitions/model.CreateProjectRequest'
       produces:
       - application/json
       responses:
@@ -2016,6 +4272,12 @@ paths:
             $ref: '#/definitions/model.Project'
         "400":
           description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
           schema:
             additionalProperties:
               type: string
@@ -2147,23 +4409,19 @@ paths:
       summary: Update project
       tags:
       - projects
-  /api/projects/{id}/workspaces/{workspaceId}:
+  /api/projects/assign/workspaces:
     post:
       consumes:
       - application/json
       description: 프로젝트에 워크스페이스를 연결합니다.
       operationId: addWorkspaceToProject
       parameters:
-      - description: 프로젝트 ID
-        in: path
-        name: id
+      - description: Workspace and Project IDs
+        in: body
+        name: request
         required: true
-        type: integer
-      - description: 워크스페이스 ID
-        in: path
-        name: workspaceId
-        required: true
-        type: integer
+        schema:
+          $ref: '#/definitions/model.WorkspaceProjectMappingRequest'
       produces:
       - application/json
       responses:
@@ -2190,6 +4448,50 @@ paths:
       security:
       - BearerAuth: []
       summary: 프로젝트에 워크스페이스 연결
+      tags:
+      - projects
+  /api/projects/id/{projectId}/workspaces:
+    get:
+      consumes:
+      - application/json
+      description: Retrieve list of workspaces that the project is assigned to
+      operationId: getProjectWorkspaces
+      parameters:
+      - description: Project ID
+        in: path
+        name: projectId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.Workspace'
+            type: array
+        "400":
+          description: 'error: Invalid project ID'
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: 'error: Project not found'
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: 'error: Internal server error'
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Get workspaces assigned to project
       tags:
       - projects
   /api/projects/list:
@@ -2252,6 +4554,41 @@ paths:
       security:
       - BearerAuth: []
       summary: Get project by name
+      tags:
+      - projects
+  /api/projects/unassign/workspaces:
+    delete:
+      consumes:
+      - application/json
+      description: Remove a workspace from a project
+      operationId: removeWorkspaceFromProject
+      parameters:
+      - description: Workspace and Project IDs
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/model.WorkspaceProjectMappingRequest'
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: 'error: Invalid request'
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: 'error: Internal server error'
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Remove workspace from project
       tags:
       - projects
   /api/resource-types/cloud-resources:
@@ -3882,7 +6219,7 @@ paths:
       consumes:
       - application/json
       description: Get a list of all workspace roles
-      operationId: listWorkspaceRoles
+      operationId: listRolesOfWorkspaceType
       produces:
       - application/json
       responses:
@@ -3969,6 +6306,30 @@ paths:
       summary: Check user roles
       tags:
       - admin
+  /api/setup/initial-organizations:
+    post:
+      description: YAML 시드 파일에서 기본 조직 구조(MZC + 8개 프레임워크)를 로드하여 등록합니다. 멱등성 보장.
+      operationId: setupInitialOrganizations
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 기본 조직 초기화
+      tags:
+      - organizations
   /api/setup/initial-role-menu-permission:
     get:
       consumes:
@@ -4144,6 +6505,108 @@ paths:
       summary: Update user
       tags:
       - users
+  /api/users/{userId}/organizations:
+    get:
+      description: 사용자가 소속된 조직 목록을 조회합니다.
+      operationId: getUserOrganizations
+      parameters:
+      - description: 사용자 ID
+        in: path
+        name: userId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.Organization'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 사용자 소속 조직 조회
+      tags:
+      - organizations
+    post:
+      consumes:
+      - application/json
+      description: 사용자를 하나 이상의 조직에 할당합니다 (다중 소속 가능).
+      operationId: assignUserOrganizations
+      parameters:
+      - description: 사용자 ID
+        in: path
+        name: userId
+        required: true
+        type: integer
+      - description: 조직 할당 요청
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/model.AssignUserOrganizationsRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 사용자-조직 할당
+      tags:
+      - organizations
+  /api/users/{userId}/organizations/{organizationId}:
+    delete:
+      description: 사용자를 특정 조직에서 제거합니다.
+      operationId: removeUserOrganization
+      parameters:
+      - description: 사용자 ID
+        in: path
+        name: userId
+        required: true
+        type: integer
+      - description: 조직 ID
+        in: path
+        name: organizationId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 사용자-조직 매핑 제거
+      tags:
+      - organizations
   /api/users/id/{userId}:
     get:
       consumes:
@@ -4178,6 +6641,133 @@ paths:
       security:
       - BearerAuth: []
       summary: Get user by ID
+      tags:
+      - users
+  /api/users/id/{userId}/groups:
+    post:
+      consumes:
+      - application/json
+      description: 사용자를 하나 이상의 그룹에 할당합니다. DB + Keycloak 그룹 동기화.
+      operationId: assignUserGroups
+      parameters:
+      - description: 사용자 ID
+        in: path
+        name: userId
+        required: true
+        type: integer
+      - description: 그룹 할당 요청
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/model.AssignUserGroupsRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 사용자를 그룹에 할당 (Keycloak 동기화 포함)
+      tags:
+      - groups
+  /api/users/id/{userId}/groups/{groupId}:
+    delete:
+      description: 사용자를 특정 그룹에서 제거합니다. DB + Keycloak 그룹 동기화.
+      operationId: removeUserFromGroup
+      parameters:
+      - description: 사용자 ID
+        in: path
+        name: userId
+        required: true
+        type: integer
+      - description: 그룹 ID
+        in: path
+        name: groupId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 사용자를 그룹에서 제거 (Keycloak 동기화 포함)
+      tags:
+      - groups
+  /api/users/id/{userId}/password:
+    put:
+      consumes:
+      - application/json
+      description: Reset a user's password (admin only)
+      operationId: ResetUserPassword
+      parameters:
+      - description: User ID (DB)
+        in: path
+        name: userId
+        required: true
+        type: string
+      - description: New Password
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/model.ResetPasswordRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "403":
+          description: Forbidden
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Reset user password
       tags:
       - users
   /api/users/id/{userId}/status:
@@ -4389,6 +6979,50 @@ paths:
       security:
       - BearerAuth: []
       summary: List all users
+      tags:
+      - users
+  /api/users/me/password:
+    put:
+      consumes:
+      - application/json
+      description: Change the authenticated user's own password. Requires current
+        password for verification.
+      operationId: changeMyPassword
+      parameters:
+      - description: Current and New Password
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/model.ChangeMyPasswordRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Change my password
       tags:
       - users
   /api/users/menus-tree/list:
@@ -5105,6 +7739,45 @@ paths:
       security:
       - BearerAuth: []
       summary: List workspace projects
+      tags:
+      - workspaces
+  /api/workspaces/roles/list:
+    post:
+      consumes:
+      - application/json
+      description: Retrieve all workspace-level roles with optional filtering
+      operationId: listWorkspaceRoles
+      parameters:
+      - description: Role filter parameters
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/model.RoleFilterRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully retrieved workspace roles
+          schema:
+            items:
+              $ref: '#/definitions/model.RoleMaster'
+            type: array
+        "400":
+          description: 'error: Invalid request format'
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: 'error: Failed to retrieve workspace roles'
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: List workspace roles
       tags:
       - workspaces
   /api/workspaces/temporary-credentials:


### PR DESCRIPTION
## Summary

- `docs/swagger.yaml`, `docs/swagger.json`: `src/docs/swagger.yaml` 기준으로 동기화 (changeMyPassword 및 신규 API 포함)
- `conf/mc-iam-manager/api.yaml`: changeMyPassword 액션 추가 (PUT /api/users/me/password)
- `conf/mc-iam-manager/service-actions.yaml`: swagger-to-actions로 mc-iam-manager 섹션 재생성 (165 → 186 actions)
- `asset/mcmpapi/mcmp_api.yaml`: changeMyPassword 액션 추가
- `asset/mcmpapi/service-actions.yaml`: swagger-to-actions로 mc-iam-manager 섹션 재생성

## Test plan

- [ ] conf/mc-iam-manager/api.yaml에 changeMyPassword 엔트리 확인
- [ ] conf/mc-iam-manager/service-actions.yaml에 changeMyPassword 확인
- [ ] asset/mcmpapi/mcmp_api.yaml에 changeMyPassword 엔트리 확인
- [ ] asset/mcmpapi/service-actions.yaml에 changeMyPassword 확인
- [ ] docs/swagger.yaml, swagger.json에 /api/users/me/password 엔드포인트 확인