### PR TITLE
feat(M7-COMP): add company management API (COMP-001~006)

### DIFF
--- a/src/handler/admin_handler.go
+++ b/src/handler/admin_handler.go
@@ -25,6 +25,7 @@ type AdminHandler struct {
 	workspaceService     service.WorkspaceService
 	menuService          service.MenuService
 	organizationService  *service.OrganizationService
+	companyService       *service.CompanyService
 }
 
 // NewAdminHandler 새 AdminHandler 인스턴스 생성
@@ -36,6 +37,7 @@ func NewAdminHandler(db *gorm.DB) *AdminHandler {
 		workspaceService:    *service.NewWorkspaceService(db),
 		menuService:         *service.NewMenuService(db),
 		organizationService: service.NewOrganizationService(db),
+		companyService:      service.NewCompanyService(db),
 	}
 }
 
@@ -188,6 +190,11 @@ func (h *AdminHandler) SetupInitialAdmin(c echo.Context) error {
 	err = h.organizationService.LoadAndRegisterOrganizationsFromYAML("")
 	if err != nil {
 		log.Printf("[ERROR] Register default organizations failed: %v", err)
+	}
+
+	// 기본 회사 생성 (COMP-006: 이미 존재하면 skip, 실패해도 non-fatal)
+	if err := h.companyService.CreateDefaultCompany(); err != nil {
+		log.Printf("[WARNING] Failed to create default company: %v", err)
 	}
 
 	// Platform Admin 역할에 모든 메뉴 매핑 추가 : 메뉴 목록 조회에 구현되어 있음.

--- a/src/handler/company_handler.go
+++ b/src/handler/company_handler.go
@@ -1,0 +1,170 @@
+package handler
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	"github.com/m-cmp/mc-iam-manager/model"
+	"github.com/m-cmp/mc-iam-manager/service"
+	"gorm.io/gorm"
+)
+
+// CompanyHandler 회사 정보 관리 핸들러 (싱글톤 — URL에 ID 없음)
+type CompanyHandler struct {
+	companyService *service.CompanyService
+}
+
+// NewCompanyHandler 새 CompanyHandler 인스턴스 생성
+func NewCompanyHandler(db *gorm.DB) *CompanyHandler {
+	return &CompanyHandler{
+		companyService: service.NewCompanyService(db),
+	}
+}
+
+// CreateCompany godoc
+// @Summary Create company
+// @Description 플랫폼 회사 정보를 생성합니다. (싱글톤, platformAdmin 전용)
+// @Tags company
+// @Accept json
+// @Produce json
+// @Param request body model.CompanyRequest true "Company Info"
+// @Success 201 {object} model.CompanyResponse
+// @Failure 400 {object} map[string]string
+// @Failure 409 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Security BearerAuth
+// @Router /api/company [post]
+// @Id createCompany
+func (h *CompanyHandler) CreateCompany(c echo.Context) error {
+	var req model.CompanyRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request format"})
+	}
+
+	if req.Name == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "name is required"})
+	}
+	if req.RealmName == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "realm_name is required"})
+	}
+	if req.KcClientID == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "kc_client_id is required"})
+	}
+	if req.KcClientSecret == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "kc_client_secret is required"})
+	}
+
+	resp, err := h.companyService.CreateCompany(&req)
+	if err != nil {
+		if strings.HasPrefix(err.Error(), "CONFLICT:") {
+			return c.JSON(http.StatusConflict, map[string]string{"error": err.Error()})
+		}
+		if strings.HasPrefix(err.Error(), "REALM_ERROR:") {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		}
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	return c.JSON(http.StatusCreated, resp)
+}
+
+// GetCompany godoc
+// @Summary Get company
+// @Description 플랫폼 회사 정보를 조회합니다. (싱글톤)
+// @Tags company
+// @Produce json
+// @Success 200 {object} model.CompanyResponse
+// @Failure 404 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Security BearerAuth
+// @Router /api/company [get]
+// @Id getCompany
+func (h *CompanyHandler) GetCompany(c echo.Context) error {
+	resp, err := h.companyService.GetCompany()
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "Company not found"})
+		}
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	return c.JSON(http.StatusOK, resp)
+}
+
+// UpdateCompany godoc
+// @Summary Update company
+// @Description 플랫폼 회사 이름/설명을 수정합니다. (platformAdmin 전용)
+// @Tags company
+// @Accept json
+// @Produce json
+// @Param request body model.CompanyUpdateRequest true "Company Update Info"
+// @Success 200 {object} model.CompanyResponse
+// @Failure 400 {object} map[string]string
+// @Failure 404 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Security BearerAuth
+// @Router /api/company [put]
+// @Id updateCompany
+func (h *CompanyHandler) UpdateCompany(c echo.Context) error {
+	var req model.CompanyUpdateRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request format"})
+	}
+
+	if req.Name == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "name is required"})
+	}
+
+	resp, err := h.companyService.UpdateCompany(&req)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "Company not found"})
+		}
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	return c.JSON(http.StatusOK, resp)
+}
+
+// DeactivateCompany godoc
+// @Summary Deactivate company
+// @Description 플랫폼 회사를 비활성화합니다. (platformAdmin 전용, 멱등 처리)
+// @Tags company
+// @Produce json
+// @Success 200 {object} model.CompanyResponse
+// @Failure 404 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Security BearerAuth
+// @Router /api/company [delete]
+// @Id deactivateCompany
+func (h *CompanyHandler) DeactivateCompany(c echo.Context) error {
+	resp, err := h.companyService.DeactivateCompany()
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "Company not found"})
+		}
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	return c.JSON(http.StatusOK, resp)
+}
+
+// ActivateCompany godoc
+// @Summary Activate company
+// @Description 플랫폼 회사를 활성화합니다. (platformAdmin 전용, 멱등 처리)
+// @Tags company
+// @Produce json
+// @Success 200 {object} model.CompanyResponse
+// @Failure 404 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Security BearerAuth
+// @Router /api/company/activate [post]
+// @Id activateCompany
+func (h *CompanyHandler) ActivateCompany(c echo.Context) error {
+	resp, err := h.companyService.ActivateCompany()
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "Company not found"})
+		}
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	return c.JSON(http.StatusOK, resp)
+}

--- a/src/handler/group_role_handler.go
+++ b/src/handler/group_role_handler.go
@@ -68,6 +68,8 @@ func (h *GroupRoleHandler) AssignGroupPlatformRole(c echo.Context) error {
 		switch {
 		case errors.Is(err, repository.ErrOrganizationNotFound):
 			return c.JSON(http.StatusNotFound, map[string]string{"error": "그룹을 찾을 수 없습니다"})
+		case errors.Is(err, repository.ErrRoleMasterNotFound):
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "역할을 찾을 수 없습니다"})
 		case errors.Is(err, repository.ErrGroupPlatformRoleDuplicate):
 			return c.JSON(http.StatusConflict, map[string]string{"error": "이미 할당된 역할입니다"})
 		default:
@@ -102,6 +104,54 @@ func (h *GroupRoleHandler) GetGroupPlatformRoles(c echo.Context) error {
 	return c.JSON(http.StatusOK, roles)
 }
 
+// GetAvailableGroupPlatformRoles godoc
+// @Summary 그룹에 할당 가능한 Platform Role 목록 조회
+// @Description 그룹에 아직 할당되지 않은 플랫폼 역할 목록을 조회합니다.
+// @Tags groups
+// @Produce json
+// @Param groupId path int true "그룹 ID"
+// @Success 200 {array} model.RoleMaster
+// @Failure 400 {object} map[string]string
+// @Security BearerAuth
+// @Router /api/groups/id/{groupId}/platform-roles/available [get]
+// @Id getAvailableGroupPlatformRoles
+func (h *GroupRoleHandler) GetAvailableGroupPlatformRoles(c echo.Context) error {
+	groupID, err := strconv.ParseUint(c.Param("groupId"), 10, 32)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid group ID"})
+	}
+
+	roles, err := h.groupRoleService.GetAvailablePlatformRoles(uint(groupID))
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	return c.JSON(http.StatusOK, roles)
+}
+
+// GetAvailableGroupWorkspaces godoc
+// @Summary 그룹에 매핑 가능한 워크스페이스 목록 조회
+// @Description 그룹에 아직 매핑되지 않은 워크스페이스 목록을 조회합니다.
+// @Tags groups
+// @Produce json
+// @Param groupId path int true "그룹 ID"
+// @Success 200 {array} model.Workspace
+// @Failure 400 {object} map[string]string
+// @Security BearerAuth
+// @Router /api/groups/id/{groupId}/workspaces/available [get]
+// @Id getAvailableGroupWorkspaces
+func (h *GroupRoleHandler) GetAvailableGroupWorkspaces(c echo.Context) error {
+	groupID, err := strconv.ParseUint(c.Param("groupId"), 10, 32)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid group ID"})
+	}
+
+	workspaces, err := h.groupRoleService.GetAvailableWorkspaces(uint(groupID))
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	return c.JSON(http.StatusOK, workspaces)
+}
+
 // RemoveGroupPlatformRole godoc
 // @Summary 그룹 Platform Role 해제
 // @Description 그룹에 할당된 플랫폼 역할을 해제합니다. DB + Keycloak 동시 제거.
@@ -129,6 +179,8 @@ func (h *GroupRoleHandler) RemoveGroupPlatformRole(c echo.Context) error {
 		switch {
 		case errors.Is(err, repository.ErrOrganizationNotFound):
 			return c.JSON(http.StatusNotFound, map[string]string{"error": "그룹을 찾을 수 없습니다"})
+		case errors.Is(err, repository.ErrRoleMasterNotFound):
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "역할을 찾을 수 없습니다"})
 		case errors.Is(err, repository.ErrGroupPlatformRoleNotFound):
 			return c.JSON(http.StatusNotFound, map[string]string{"error": "할당된 역할을 찾을 수 없습니다"})
 		default:
@@ -168,10 +220,16 @@ func (h *GroupRoleHandler) AssignGroupWorkspace(c echo.Context) error {
 	}
 
 	if err := h.groupRoleService.AssignGroupWorkspace(uint(groupID), req.WorkspaceID, req.RoleID); err != nil {
-		if errors.Is(err, repository.ErrGroupWorkspaceRoleDuplicate) {
+		switch {
+		case errors.Is(err, repository.ErrWorkspaceNotFound):
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "워크스페이스를 찾을 수 없습니다"})
+		case errors.Is(err, repository.ErrRoleMasterNotFound):
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "역할을 찾을 수 없습니다"})
+		case errors.Is(err, repository.ErrGroupWorkspaceRoleDuplicate):
 			return c.JSON(http.StatusConflict, map[string]string{"error": "이미 매핑된 워크스페이스입니다"})
+		default:
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		}
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}
 
 	return c.JSON(http.StatusCreated, map[string]string{"message": "그룹이 워크스페이스에 매핑되었습니다."})

--- a/src/handler/group_role_handler.go
+++ b/src/handler/group_role_handler.go
@@ -277,6 +277,85 @@ func (h *GroupRoleHandler) RemoveGroupWorkspaceRole(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]string{"message": "그룹-워크스페이스 매핑이 제거되었습니다."})
 }
 
+// AssignGroupUsers godoc
+// @Summary 그룹에 사용자 일괄 할당 (Keycloak 동기화 포함)
+// @Description 그룹에 사용자 목록을 일괄 할당합니다. DB + Keycloak 그룹 동기화.
+// @Tags groups
+// @Accept json
+// @Produce json
+// @Param groupId path int true "그룹 ID"
+// @Param body body model.AssignGroupUsersRequest true "사용자 일괄 할당 요청"
+// @Success 200 {object} map[string]string
+// @Failure 400 {object} map[string]string
+// @Failure 404 {object} map[string]string
+// @Security BearerAuth
+// @Router /api/groups/id/{groupId}/users [post]
+// @Id assignGroupUsers
+func (h *GroupRoleHandler) AssignGroupUsers(c echo.Context) error {
+	groupID, err := strconv.ParseUint(c.Param("groupId"), 10, 32)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid group ID"})
+	}
+
+	var req model.AssignGroupUsersRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request format"})
+	}
+	if err := c.Validate(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+	}
+
+	if err := h.groupRoleService.AssignUsersToGroup(c.Request().Context(), uint(groupID), req.UserIDs); err != nil {
+		switch {
+		case errors.Is(err, repository.ErrOrganizationNotFound):
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "그룹을 찾을 수 없습니다"})
+		default:
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+		}
+	}
+
+	return c.JSON(http.StatusOK, map[string]string{"message": "사용자가 그룹에 할당되었습니다."})
+}
+
+// RemoveGroupUser godoc
+// @Summary 그룹에서 사용자 제거 (Keycloak 동기화 포함)
+// @Description 그룹에서 특정 사용자를 제거합니다. DB + Keycloak 그룹 동기화.
+// @Tags groups
+// @Produce json
+// @Param groupId path int true "그룹 ID"
+// @Param userId path int true "사용자 ID"
+// @Success 200 {object} map[string]string
+// @Failure 400 {object} map[string]string
+// @Failure 404 {object} map[string]string
+// @Security BearerAuth
+// @Router /api/groups/id/{groupId}/users/{userId} [delete]
+// @Id removeGroupUser
+func (h *GroupRoleHandler) RemoveGroupUser(c echo.Context) error {
+	groupID, err := strconv.ParseUint(c.Param("groupId"), 10, 32)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid group ID"})
+	}
+	userID, err := strconv.ParseUint(c.Param("userId"), 10, 32)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid user ID"})
+	}
+
+	kcUserID := h.getUserKcID(uint(userID))
+
+	if err := h.groupRoleService.RemoveUserFromGroup(c.Request().Context(), uint(userID), uint(groupID), kcUserID); err != nil {
+		switch {
+		case errors.Is(err, repository.ErrOrganizationNotFound):
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "그룹을 찾을 수 없습니다"})
+		case errors.Is(err, repository.ErrUserOrganizationNotFound):
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "사용자가 해당 그룹에 소속되어 있지 않습니다"})
+		default:
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+		}
+	}
+
+	return c.JSON(http.StatusOK, map[string]string{"message": "사용자가 그룹에서 제거되었습니다."})
+}
+
 // AssignUserGroups godoc
 // @Summary 사용자를 그룹에 할당 (Keycloak 동기화 포함)
 // @Description 사용자를 하나 이상의 그룹에 할당합니다. DB + Keycloak 그룹 동기화.

--- a/src/handler/organization_handler.go
+++ b/src/handler/organization_handler.go
@@ -86,16 +86,30 @@ func (h *OrganizationHandler) CreateOrganization(c echo.Context) error {
 
 // GetOrganizations godoc
 // @Summary 조직 목록 조회
-// @Description 전체 조직 목록을 조회합니다. tree=true이면 Tree 구조로 반환.
+// @Description 전체 조직 목록을 조회합니다. tree=true이면 Tree 구조로 반환. name/code로 검색 가능 (검색 시 tree 파라미터 무시).
 // @Tags organizations
 // @Produce json
 // @Param tree query bool false "Tree 구조 반환 여부 (기본: false)"
+// @Param name query string false "조직명 검색 (부분 일치, ILIKE)"
+// @Param code query string false "조직 코드 검색 (부분 일치, ILIKE)"
 // @Success 200 {array} model.OrganizationTree
 // @Failure 500 {object} map[string]string
 // @Security BearerAuth
 // @Router /api/organizations [get]
 // @Id listOrganizations
 func (h *OrganizationHandler) GetOrganizations(c echo.Context) error {
+	nameParam := c.QueryParam("name")
+	codeParam := c.QueryParam("code")
+
+	// 검색 파라미터가 있으면 검색 모드 (tree 무시)
+	if nameParam != "" || codeParam != "" {
+		result, err := h.orgService.SearchOrganizations(nameParam, codeParam)
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		}
+		return c.JSON(http.StatusOK, result)
+	}
+
 	treeParam := c.QueryParam("tree")
 	tree := treeParam == "true"
 
@@ -322,7 +336,10 @@ func (h *OrganizationHandler) RemoveUserOrganization(c echo.Context) error {
 	}
 
 	if err := h.orgService.RemoveUserFromOrganization(uint(userID), uint(orgID)); err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+		if errors.Is(err, repository.ErrUserOrganizationNotFound) {
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "사용자가 해당 조직에 소속되어 있지 않습니다"})
+		}
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}
 	return c.JSON(http.StatusOK, map[string]string{"message": "사용자가 조직에서 제거되었습니다."})
 }

--- a/src/handler/organization_handler.go
+++ b/src/handler/organization_handler.go
@@ -291,11 +291,12 @@ func (h *OrganizationHandler) AssignUserOrganizations(c echo.Context) error {
 
 // GetUserOrganizations godoc
 // @Summary 사용자 소속 조직 조회
-// @Description 사용자가 소속된 조직 목록을 조회합니다.
+// @Description 사용자가 소속된 조직 목록을 조회합니다. hierarchy=true이면 path/level 포함.
 // @Tags organizations
 // @Produce json
 // @Param userId path int true "사용자 ID"
-// @Success 200 {array} model.Organization
+// @Param hierarchy query bool false "계층 정보(path, level) 포함 여부 (기본: false)"
+// @Success 200 {array} model.OrganizationTree
 // @Failure 400 {object} map[string]string
 // @Security BearerAuth
 // @Router /api/users/{userId}/organizations [get]
@@ -306,11 +307,52 @@ func (h *OrganizationHandler) GetUserOrganizations(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid user ID"})
 	}
 
+	if c.QueryParam("hierarchy") == "true" {
+		orgs, err := h.orgService.GetUserOrganizationsWithHierarchy(uint(userID))
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		}
+		return c.JSON(http.StatusOK, orgs)
+	}
+
 	orgs, err := h.orgService.GetUserOrganizations(uint(userID))
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}
 	return c.JSON(http.StatusOK, orgs)
+}
+
+// ReplaceUserGroups godoc
+// @Summary 사용자 그룹 멤버십 전체 교체
+// @Description 사용자의 기존 그룹을 모두 제거하고 지정된 그룹으로 교체합니다.
+// @Tags organizations
+// @Accept json
+// @Produce json
+// @Param userId path int true "사용자 ID"
+// @Param body body model.AssignUserGroupsRequest true "교체할 그룹 목록"
+// @Success 200 {object} map[string]string
+// @Failure 400 {object} map[string]string
+// @Security BearerAuth
+// @Router /api/users/id/{userId}/groups [put]
+// @Id replaceUserGroups
+func (h *OrganizationHandler) ReplaceUserGroups(c echo.Context) error {
+	userID, err := strconv.ParseUint(c.Param("userId"), 10, 32)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid user ID"})
+	}
+
+	var req model.AssignUserGroupsRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request format"})
+	}
+	if err := c.Validate(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+	}
+
+	if err := h.orgService.ReplaceUserGroups(uint(userID), req.GroupIDs); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+	}
+	return c.JSON(http.StatusOK, map[string]string{"message": "사용자 그룹 멤버십이 교체되었습니다."})
 }
 
 // RemoveUserOrganization godoc

--- a/src/main.go
+++ b/src/main.go
@@ -470,6 +470,9 @@ func main() {
 		groups.PUT("/id/:organizationId", organizationHandler.UpdateOrganization)
 		groups.DELETE("/id/:organizationId", organizationHandler.DeleteOrganization)
 		groups.GET("/id/:organizationId/users", organizationHandler.GetOrganizationUsers)
+		// 그룹 사용자 관리 (그룹 입장, Keycloak 동기화 포함)
+		groups.POST("/id/:groupId/users", groupRoleHandler.AssignGroupUsers)
+		groups.DELETE("/id/:groupId/users/:userId", groupRoleHandler.RemoveGroupUser)
 
 		// 그룹 플랫폼 역할 관리 (DB + Keycloak)
 		groups.POST("/id/:groupId/platform-roles", groupRoleHandler.AssignGroupPlatformRole)

--- a/src/main.go
+++ b/src/main.go
@@ -489,6 +489,7 @@ func main() {
 	// 사용자-그룹 라우트 (Keycloak 동기화 포함, platformAdmin 전용)
 	users.POST("/id/:userId/groups", groupRoleHandler.AssignUserGroups, middleware.PlatformAdminMiddleware)
 	users.GET("/id/:userId/groups", organizationHandler.GetUserOrganizations, middleware.PlatformAdminMiddleware)
+	users.PUT("/id/:userId/groups", organizationHandler.ReplaceUserGroups, middleware.PlatformAdminMiddleware)
 	users.DELETE("/id/:userId/groups/:groupId", groupRoleHandler.RemoveUserFromGroup, middleware.PlatformAdminMiddleware)
 
 	// CSP 정책 관리 라우트

--- a/src/main.go
+++ b/src/main.go
@@ -477,11 +477,13 @@ func main() {
 		// 그룹 플랫폼 역할 관리 (DB + Keycloak)
 		groups.POST("/id/:groupId/platform-roles", groupRoleHandler.AssignGroupPlatformRole)
 		groups.GET("/id/:groupId/platform-roles", groupRoleHandler.GetGroupPlatformRoles)
+		groups.GET("/id/:groupId/platform-roles/available", groupRoleHandler.GetAvailableGroupPlatformRoles)
 		groups.DELETE("/id/:groupId/platform-roles/:roleId", groupRoleHandler.RemoveGroupPlatformRole)
 
 		// 그룹-워크스페이스 매핑 관리 (DB 전용)
 		groups.POST("/id/:groupId/workspaces", groupRoleHandler.AssignGroupWorkspace)
 		groups.GET("/id/:groupId/workspaces", groupRoleHandler.GetGroupWorkspaces)
+		groups.GET("/id/:groupId/workspaces/available", groupRoleHandler.GetAvailableGroupWorkspaces)
 		groups.PUT("/id/:groupId/workspaces/:workspaceId", groupRoleHandler.UpdateGroupWorkspaceRole)
 		groups.DELETE("/id/:groupId/workspaces/:workspaceId", groupRoleHandler.RemoveGroupWorkspaceRole)
 	}

--- a/src/main.go
+++ b/src/main.go
@@ -98,6 +98,7 @@ func main() {
 		&model.UserOrganization{},
 		&model.GroupPlatformRole{},
 		&model.GroupWorkspaceRole{},
+		&model.Company{},
 	); err != nil {
 		log.Fatalf("Failed to migrate database: %v", err)
 	}
@@ -133,6 +134,8 @@ func main() {
 	organizationHandler := handler.NewOrganizationHandler(db)
 	// 그룹 역할 핸들러 초기화
 	groupRoleHandler := handler.NewGroupRoleHandler(db)
+	// 회사 정보 핸들러 초기화
+	companyHandler := handler.NewCompanyHandler(db)
 
 	// Echo 인스턴스 생성
 	e := echo.New()
@@ -204,6 +207,16 @@ func main() {
 
 	// platform admin 생성. 권한체크 필요한데...
 	api.POST("/initial-admin", adminHandler.SetupInitialAdmin) // TODO : 초기 설정에서 직접 keycloak 호출하는 것으로 바꿔야 할 듯.
+
+	// 회사 정보 라우트 (싱글톤 — URL에 ID 없음)
+	company := api.Group("/company")
+	{
+		company.POST("", companyHandler.CreateCompany, middleware.PlatformAdminMiddleware)
+		company.GET("", companyHandler.GetCompany, middleware.PlatformRoleMiddleware(middleware.Read))
+		company.PUT("", companyHandler.UpdateCompany, middleware.PlatformAdminMiddleware)
+		company.DELETE("", companyHandler.DeactivateCompany, middleware.PlatformAdminMiddleware)
+		company.POST("/activate", companyHandler.ActivateCompany, middleware.PlatformAdminMiddleware)
+	}
 
 	// 관리자 setup 라우트
 	setup := api.Group("/setup", middleware.PlatformAdminMiddleware)

--- a/src/model/company.go
+++ b/src/model/company.go
@@ -1,0 +1,65 @@
+package model
+
+import (
+	"time"
+)
+
+// Company 회사 정보 모델 (싱글톤 — 플랫폼당 1개)
+// table: mcmp_companies
+type Company struct {
+	ID             uint      `gorm:"primaryKey" json:"id"`
+	Name           string    `gorm:"size:255;not null" json:"name"`
+	Description    string    `gorm:"size:500" json:"description"`
+	RealmName      string    `gorm:"size:255;uniqueIndex" json:"realm_name"`
+	KcClientID     string    `gorm:"size:255" json:"kc_client_id"`
+	KcClientSecret string    `gorm:"size:255" json:"-"` // 응답에서 제외
+	Status         string    `gorm:"size:20;default:'active'" json:"status"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+// TableName mcmp_companies 테이블 이름 반환
+func (Company) TableName() string {
+	return "mcmp_companies"
+}
+
+// ToResponse kc_client_secret 제외한 응답 DTO 반환
+func (c *Company) ToResponse() *CompanyResponse {
+	return &CompanyResponse{
+		ID:          c.ID,
+		Name:        c.Name,
+		Description: c.Description,
+		RealmName:   c.RealmName,
+		KcClientID:  c.KcClientID,
+		Status:      c.Status,
+		CreatedAt:   c.CreatedAt,
+		UpdatedAt:   c.UpdatedAt,
+	}
+}
+
+// CompanyResponse 회사 정보 응답 DTO (kc_client_secret 제외)
+type CompanyResponse struct {
+	ID          uint      `json:"id"`
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	RealmName   string    `json:"realm_name"`
+	KcClientID  string    `json:"kc_client_id"`
+	Status      string    `json:"status"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// CompanyRequest 회사 생성 요청
+type CompanyRequest struct {
+	Name           string `json:"name" binding:"required"`
+	RealmName      string `json:"realm_name" binding:"required"`
+	KcClientID     string `json:"kc_client_id" binding:"required"`
+	KcClientSecret string `json:"kc_client_secret" binding:"required"`
+	Description    string `json:"description"`
+}
+
+// CompanyUpdateRequest 회사 수정 요청 (name, description만 변경 가능)
+type CompanyUpdateRequest struct {
+	Name        string `json:"name" binding:"required"`
+	Description string `json:"description"`
+}

--- a/src/model/group_role.go
+++ b/src/model/group_role.go
@@ -75,3 +75,8 @@ type GroupWorkspaceRoleResponse struct {
 type AssignUserGroupsRequest struct {
 	GroupIDs []uint `json:"group_ids" validate:"required,min=1"`
 }
+
+// AssignGroupUsersRequest 그룹에 사용자 일괄 할당 요청 (group 입장)
+type AssignGroupUsersRequest struct {
+	UserIDs []uint `json:"user_ids" validate:"required,min=1"`
+}

--- a/src/repository/company_repository.go
+++ b/src/repository/company_repository.go
@@ -1,0 +1,64 @@
+package repository
+
+import (
+	"fmt"
+
+	"github.com/m-cmp/mc-iam-manager/model"
+	"gorm.io/gorm"
+)
+
+// CompanyRepository 회사 정보 레포지토리
+type CompanyRepository struct {
+	db *gorm.DB
+}
+
+// NewCompanyRepository 새 CompanyRepository 인스턴스 생성
+func NewCompanyRepository(db *gorm.DB) *CompanyRepository {
+	return &CompanyRepository{db: db}
+}
+
+// ExistsByRealmName realm_name으로 회사 존재 여부 확인
+func (r *CompanyRepository) ExistsByRealmName(realmName string) (bool, error) {
+	var count int64
+	if err := r.db.Model(&model.Company{}).Where("realm_name = ?", realmName).Count(&count).Error; err != nil {
+		return false, fmt.Errorf("failed to check company existence by realm_name: %w", err)
+	}
+	return count > 0, nil
+}
+
+// Create 회사 생성
+func (r *CompanyRepository) Create(company *model.Company) error {
+	if err := r.db.Create(company).Error; err != nil {
+		return fmt.Errorf("failed to create company: %w", err)
+	}
+	return nil
+}
+
+// First 싱글톤 회사 조회 (첫 번째 레코드)
+func (r *CompanyRepository) First() (*model.Company, error) {
+	var company model.Company
+	if err := r.db.First(&company).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get company: %w", err)
+	}
+	return &company, nil
+}
+
+// Save 회사 정보 저장 (업데이트)
+func (r *CompanyRepository) Save(company *model.Company) error {
+	if err := r.db.Save(company).Error; err != nil {
+		return fmt.Errorf("failed to save company: %w", err)
+	}
+	return nil
+}
+
+// Count 회사 레코드 수 조회
+func (r *CompanyRepository) Count() (int64, error) {
+	var count int64
+	if err := r.db.Model(&model.Company{}).Count(&count).Error; err != nil {
+		return 0, fmt.Errorf("failed to count companies: %w", err)
+	}
+	return count, nil
+}

--- a/src/repository/company_repository_test.go
+++ b/src/repository/company_repository_test.go
@@ -1,0 +1,126 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/m-cmp/mc-iam-manager/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupCompanyTestDB(t *testing.T) *gorm.DB {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+
+	err = db.AutoMigrate(&model.Company{})
+	require.NoError(t, err)
+
+	return db
+}
+
+func TestCompanyRepository_Create(t *testing.T) {
+	db := setupCompanyTestDB(t)
+	repo := NewCompanyRepository(db)
+
+	company := &model.Company{
+		Name:           "Test Company",
+		RealmName:      "test-realm",
+		KcClientID:     "test-client-id",
+		KcClientSecret: "test-secret",
+		Status:         "active",
+	}
+
+	err := repo.Create(company)
+	assert.NoError(t, err)
+	assert.NotZero(t, company.ID)
+}
+
+func TestCompanyRepository_First_NotFound(t *testing.T) {
+	db := setupCompanyTestDB(t)
+	repo := NewCompanyRepository(db)
+
+	company, err := repo.First()
+	assert.NoError(t, err)
+	assert.Nil(t, company)
+}
+
+func TestCompanyRepository_First_Found(t *testing.T) {
+	db := setupCompanyTestDB(t)
+	repo := NewCompanyRepository(db)
+
+	expected := &model.Company{
+		Name:      "Test Company",
+		RealmName: "test-realm",
+		Status:    "active",
+	}
+	require.NoError(t, repo.Create(expected))
+
+	company, err := repo.First()
+	assert.NoError(t, err)
+	require.NotNil(t, company)
+	assert.Equal(t, expected.Name, company.Name)
+	assert.Equal(t, expected.RealmName, company.RealmName)
+	assert.Equal(t, "active", company.Status)
+}
+
+func TestCompanyRepository_ExistsByRealmName_False(t *testing.T) {
+	db := setupCompanyTestDB(t)
+	repo := NewCompanyRepository(db)
+
+	exists, err := repo.ExistsByRealmName("non-existent-realm")
+	assert.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestCompanyRepository_ExistsByRealmName_True(t *testing.T) {
+	db := setupCompanyTestDB(t)
+	repo := NewCompanyRepository(db)
+
+	company := &model.Company{Name: "Company", RealmName: "my-realm", Status: "active"}
+	require.NoError(t, repo.Create(company))
+
+	exists, err := repo.ExistsByRealmName("my-realm")
+	assert.NoError(t, err)
+	assert.True(t, exists)
+}
+
+func TestCompanyRepository_Save(t *testing.T) {
+	db := setupCompanyTestDB(t)
+	repo := NewCompanyRepository(db)
+
+	company := &model.Company{Name: "Original", RealmName: "realm", Status: "active"}
+	require.NoError(t, repo.Create(company))
+
+	company.Name = "Updated"
+	company.Status = "inactive"
+	err := repo.Save(company)
+	assert.NoError(t, err)
+
+	updated, err := repo.First()
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+	assert.Equal(t, "Updated", updated.Name)
+	assert.Equal(t, "inactive", updated.Status)
+}
+
+func TestCompanyRepository_Count_Empty(t *testing.T) {
+	db := setupCompanyTestDB(t)
+	repo := NewCompanyRepository(db)
+
+	count, err := repo.Count()
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+}
+
+func TestCompanyRepository_Count_WithData(t *testing.T) {
+	db := setupCompanyTestDB(t)
+	repo := NewCompanyRepository(db)
+
+	require.NoError(t, repo.Create(&model.Company{Name: "C", RealmName: "realm1", Status: "active"}))
+
+	count, err := repo.Count()
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), count)
+}

--- a/src/repository/group_role_repository.go
+++ b/src/repository/group_role_repository.go
@@ -13,6 +13,7 @@ var (
 	ErrGroupPlatformRoleNotFound   = errors.New("group platform role mapping not found")
 	ErrGroupPlatformRoleDuplicate  = errors.New("group platform role mapping already exists")
 	ErrGroupWorkspaceRoleNotFound  = errors.New("group workspace role mapping not found")
+	ErrRoleMasterNotFound          = errors.New("role not found")
 	ErrGroupWorkspaceRoleDuplicate = errors.New("group workspace role mapping already exists")
 )
 
@@ -140,6 +141,39 @@ func (r *GroupRoleRepository) DeleteGroupWorkspaceRole(groupID, workspaceID uint
 		return ErrGroupWorkspaceRoleNotFound
 	}
 	return nil
+}
+
+// FindAvailablePlatformRoles 그룹에 할당되지 않은 플랫폼 역할 목록 조회
+func (r *GroupRoleRepository) FindAvailablePlatformRoles(groupID uint) ([]model.RoleMaster, error) {
+	var roles []model.RoleMaster
+	err := r.db.Where("role_type = 'platform'").
+		Where("id NOT IN (?)",
+			r.db.Table("mcmp_group_platform_roles").
+				Select("role_id").
+				Where("group_id = ?", groupID),
+		).
+		Order("name ASC").
+		Find(&roles).Error
+	if err != nil {
+		return nil, fmt.Errorf("error finding available platform roles for group %d: %w", groupID, err)
+	}
+	return roles, nil
+}
+
+// FindAvailableWorkspaces 그룹에 매핑되지 않은 워크스페이스 목록 조회
+func (r *GroupRoleRepository) FindAvailableWorkspaces(groupID uint) ([]model.Workspace, error) {
+	var workspaces []model.Workspace
+	err := r.db.Where("id NOT IN (?)",
+		r.db.Table("mcmp_group_workspace_roles").
+			Select("workspace_id").
+			Where("group_id = ?", groupID),
+	).
+		Order("name ASC").
+		Find(&workspaces).Error
+	if err != nil {
+		return nil, fmt.Errorf("error finding available workspaces for group %d: %w", groupID, err)
+	}
+	return workspaces, nil
 }
 
 // isGroupDuplicateError PostgreSQL unique constraint 위반 여부 확인

--- a/src/repository/organization_repository.go
+++ b/src/repository/organization_repository.go
@@ -19,6 +19,7 @@ var (
 	ErrOrganizationHasUsers      = errors.New("organization has assigned users")
 	ErrMaxOrganizationsPerLevel  = errors.New("maximum 99 organizations per level reached")
 	ErrCircularReference         = errors.New("circular reference detected")
+	ErrUserOrganizationNotFound  = errors.New("user is not assigned to this organization")
 )
 
 // OrganizationRepository 조직 데이터 관리
@@ -67,6 +68,22 @@ func (r *OrganizationRepository) FindAll() ([]model.Organization, error) {
 	var orgs []model.Organization
 	if err := r.db.Order("organization_code ASC").Find(&orgs).Error; err != nil {
 		return nil, fmt.Errorf("error finding all organizations: %w", err)
+	}
+	return orgs, nil
+}
+
+// FindByFilter name/code 검색 필터로 조직 목록 조회
+func (r *OrganizationRepository) FindByFilter(name, code string) ([]model.Organization, error) {
+	var orgs []model.Organization
+	q := r.db.Order("organization_code ASC")
+	if name != "" {
+		q = q.Where("name ILIKE ?", "%"+name+"%")
+	}
+	if code != "" {
+		q = q.Where("organization_code ILIKE ?", "%"+code+"%")
+	}
+	if err := q.Find(&orgs).Error; err != nil {
+		return nil, fmt.Errorf("error searching organizations: %w", err)
 	}
 	return orgs, nil
 }
@@ -357,7 +374,7 @@ func (r *OrganizationRepository) RemoveUserFromOrganization(userID, orgID uint) 
 		return result.Error
 	}
 	if result.RowsAffected == 0 {
-		return errors.New("user is not assigned to this organization")
+		return ErrUserOrganizationNotFound
 	}
 	return nil
 }

--- a/src/service/company_service.go
+++ b/src/service/company_service.go
@@ -1,0 +1,198 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/Nerzal/gocloak/v13"
+	"github.com/m-cmp/mc-iam-manager/config"
+	"github.com/m-cmp/mc-iam-manager/model"
+	"github.com/m-cmp/mc-iam-manager/repository"
+	"gorm.io/gorm"
+)
+
+// CompanyService 회사 정보 서비스
+type CompanyService struct {
+	db              *gorm.DB
+	companyRepo     *repository.CompanyRepository
+	keycloakService KeycloakService
+}
+
+// NewCompanyService 새 CompanyService 인스턴스 생성
+func NewCompanyService(db *gorm.DB) *CompanyService {
+	return &CompanyService{
+		db:              db,
+		companyRepo:     repository.NewCompanyRepository(db),
+		keycloakService: NewKeycloakService(),
+	}
+}
+
+// CreateCompany 회사 생성 (COMP-001)
+func (s *CompanyService) CreateCompany(req *model.CompanyRequest) (*model.CompanyResponse, error) {
+	exists, err := s.companyRepo.ExistsByRealmName(req.RealmName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check realm_name: %w", err)
+	}
+	if exists {
+		return nil, fmt.Errorf("CONFLICT: company with realm_name '%s' already exists", req.RealmName)
+	}
+
+	if err := s.ensureRealm(req.RealmName); err != nil {
+		return nil, fmt.Errorf("REALM_ERROR: %w", err)
+	}
+
+	company := &model.Company{
+		Name:           req.Name,
+		Description:    req.Description,
+		RealmName:      req.RealmName,
+		KcClientID:     req.KcClientID,
+		KcClientSecret: req.KcClientSecret,
+		Status:         "active",
+	}
+
+	if err := s.companyRepo.Create(company); err != nil {
+		return nil, fmt.Errorf("failed to create company: %w", err)
+	}
+
+	log.Printf("[INFO] Company created: name=%s, realm_name=%s", company.Name, company.RealmName)
+	return company.ToResponse(), nil
+}
+
+// GetCompany 회사 조회 (COMP-002, 싱글톤)
+func (s *CompanyService) GetCompany() (*model.CompanyResponse, error) {
+	company, err := s.companyRepo.First()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get company: %w", err)
+	}
+	if company == nil {
+		return nil, fmt.Errorf("company not found")
+	}
+	return company.ToResponse(), nil
+}
+
+// UpdateCompany 회사 수정 (COMP-003, name/description만 변경 가능)
+func (s *CompanyService) UpdateCompany(req *model.CompanyUpdateRequest) (*model.CompanyResponse, error) {
+	company, err := s.companyRepo.First()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get company: %w", err)
+	}
+	if company == nil {
+		return nil, fmt.Errorf("company not found")
+	}
+
+	company.Name = req.Name
+	company.Description = req.Description
+
+	if err := s.companyRepo.Save(company); err != nil {
+		return nil, fmt.Errorf("failed to update company: %w", err)
+	}
+
+	log.Printf("[INFO] Company updated: id=%d, name=%s", company.ID, company.Name)
+	return company.ToResponse(), nil
+}
+
+// DeactivateCompany 회사 비활성화 (COMP-004, 멱등 처리)
+func (s *CompanyService) DeactivateCompany() (*model.CompanyResponse, error) {
+	company, err := s.companyRepo.First()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get company: %w", err)
+	}
+	if company == nil {
+		return nil, fmt.Errorf("company not found")
+	}
+
+	company.Status = "inactive"
+	if err := s.companyRepo.Save(company); err != nil {
+		return nil, fmt.Errorf("failed to deactivate company: %w", err)
+	}
+
+	log.Printf("[INFO] Company deactivated: id=%d", company.ID)
+	return company.ToResponse(), nil
+}
+
+// ActivateCompany 회사 활성화 (COMP-005, 멱등 처리)
+func (s *CompanyService) ActivateCompany() (*model.CompanyResponse, error) {
+	company, err := s.companyRepo.First()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get company: %w", err)
+	}
+	if company == nil {
+		return nil, fmt.Errorf("company not found")
+	}
+
+	company.Status = "active"
+	if err := s.companyRepo.Save(company); err != nil {
+		return nil, fmt.Errorf("failed to activate company: %w", err)
+	}
+
+	log.Printf("[INFO] Company activated: id=%d", company.ID)
+	return company.ToResponse(), nil
+}
+
+// CreateDefaultCompany initial-admin 시 기본 회사 자동 생성 (COMP-006)
+// Count()>0이면 skip (멱등), 실패 시 WARNING만 (non-fatal)
+func (s *CompanyService) CreateDefaultCompany() error {
+	count, err := s.companyRepo.Count()
+	if err != nil {
+		return fmt.Errorf("failed to count companies: %w", err)
+	}
+	if count > 0 {
+		log.Printf("[INFO] Default company already exists, skipping creation")
+		return nil
+	}
+
+	companyName := os.Getenv("MC_IAM_MANAGER_COMPANY_NAME")
+	if companyName == "" {
+		companyName = "Default Company"
+	}
+	realmName := os.Getenv("MC_IAM_MANAGER_KEYCLOAK_REALM")
+	kcClientID := os.Getenv("MC_IAM_MANAGER_KEYCLOAK_CLIENT_NAME")
+	kcClientSecret := os.Getenv("MC_IAM_MANAGER_KEYCLOAK_CLIENT_SECRET")
+
+	company := &model.Company{
+		Name:           companyName,
+		RealmName:      realmName,
+		KcClientID:     kcClientID,
+		KcClientSecret: kcClientSecret,
+		Status:         "active",
+	}
+
+	if err := s.companyRepo.Create(company); err != nil {
+		return fmt.Errorf("failed to create default company: %w", err)
+	}
+
+	log.Printf("[INFO] Default company created: name=%s", companyName)
+	return nil
+}
+
+// ensureRealm Keycloak에 realm이 없으면 생성
+func (s *CompanyService) ensureRealm(realmName string) error {
+	if config.KC == nil {
+		return fmt.Errorf("keycloak not configured")
+	}
+
+	adminToken, err := s.keycloakService.KeycloakAdminLogin(context.Background())
+	if err != nil {
+		return fmt.Errorf("failed to get admin token: %w", err)
+	}
+
+	_, err = config.KC.Client.GetRealm(context.Background(), adminToken.AccessToken, realmName)
+	if err == nil {
+		log.Printf("[INFO] Realm '%s' already exists in Keycloak, using existing realm", realmName)
+		return nil
+	}
+
+	enabled := true
+	_, err = config.KC.Client.CreateRealm(context.Background(), adminToken.AccessToken, gocloak.RealmRepresentation{
+		Realm:   &realmName,
+		Enabled: &enabled,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create realm '%s': %w", realmName, err)
+	}
+
+	log.Printf("[INFO] Realm '%s' created in Keycloak", realmName)
+	return nil
+}

--- a/src/service/company_service_test.go
+++ b/src/service/company_service_test.go
@@ -1,0 +1,236 @@
+package service
+
+import (
+	"os"
+	"testing"
+
+	"github.com/m-cmp/mc-iam-manager/model"
+	"github.com/m-cmp/mc-iam-manager/repository"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupServiceTestDB(t *testing.T) *gorm.DB {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&model.Company{}))
+	return db
+}
+
+func seedCompany(t *testing.T, db *gorm.DB, name, realm, status string) *model.Company {
+	repo := repository.NewCompanyRepository(db)
+	c := &model.Company{Name: name, RealmName: realm, Status: status}
+	require.NoError(t, repo.Create(c))
+	return c
+}
+
+// TestCompanyService_CreateCompany_Conflict realm_name 중복 시 CONFLICT 에러 반환
+func TestCompanyService_CreateCompany_Conflict(t *testing.T) {
+	db := setupServiceTestDB(t)
+	svc := NewCompanyService(db)
+
+	seedCompany(t, db, "Existing", "duplicate-realm", "active")
+
+	req := &model.CompanyRequest{
+		Name:           "New Company",
+		RealmName:      "duplicate-realm",
+		KcClientID:     "client-id",
+		KcClientSecret: "secret",
+	}
+
+	_, err := svc.CreateCompany(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "CONFLICT:")
+}
+
+// TestCompanyService_CreateCompany_RealmError KC 미설정 시 REALM_ERROR 반환
+func TestCompanyService_CreateCompany_RealmError(t *testing.T) {
+	db := setupServiceTestDB(t)
+	svc := NewCompanyService(db)
+
+	req := &model.CompanyRequest{
+		Name:           "New Company",
+		RealmName:      "new-realm",
+		KcClientID:     "client-id",
+		KcClientSecret: "secret",
+	}
+
+	_, err := svc.CreateCompany(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "REALM_ERROR:")
+}
+
+// TestCompanyService_GetCompany_NotFound 회사 없을 때 not found 에러
+func TestCompanyService_GetCompany_NotFound(t *testing.T) {
+	db := setupServiceTestDB(t)
+	svc := NewCompanyService(db)
+
+	_, err := svc.GetCompany()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestCompanyService_GetCompany 회사 조회 성공
+func TestCompanyService_GetCompany(t *testing.T) {
+	db := setupServiceTestDB(t)
+	svc := NewCompanyService(db)
+
+	seedCompany(t, db, "My Company", "my-realm", "active")
+
+	resp, err := svc.GetCompany()
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "My Company", resp.Name)
+	assert.Equal(t, "my-realm", resp.RealmName)
+	assert.Equal(t, "active", resp.Status)
+}
+
+// TestCompanyService_GetCompany_SecretExcluded kc_client_secret이 응답에서 제외됨
+func TestCompanyService_GetCompany_SecretExcluded(t *testing.T) {
+	db := setupServiceTestDB(t)
+	repo := repository.NewCompanyRepository(db)
+	svc := NewCompanyService(db)
+
+	c := &model.Company{Name: "C", RealmName: "r", KcClientSecret: "super-secret", Status: "active"}
+	require.NoError(t, repo.Create(c))
+
+	resp, err := svc.GetCompany()
+	require.NoError(t, err)
+	// CompanyResponse 구조체에 KcClientSecret 필드가 없음 — 타입 수준에서 강제됨
+	assert.NotNil(t, resp)
+	assert.Equal(t, "C", resp.Name)
+}
+
+// TestCompanyService_UpdateCompany 이름/설명 수정
+func TestCompanyService_UpdateCompany(t *testing.T) {
+	db := setupServiceTestDB(t)
+	svc := NewCompanyService(db)
+
+	seedCompany(t, db, "Original", "realm", "active")
+
+	req := &model.CompanyUpdateRequest{Name: "Updated Name", Description: "New description"}
+	resp, err := svc.UpdateCompany(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "Updated Name", resp.Name)
+	assert.Equal(t, "New description", resp.Description)
+}
+
+// TestCompanyService_UpdateCompany_NotFound 회사 없을 때 에러
+func TestCompanyService_UpdateCompany_NotFound(t *testing.T) {
+	db := setupServiceTestDB(t)
+	svc := NewCompanyService(db)
+
+	_, err := svc.UpdateCompany(&model.CompanyUpdateRequest{Name: "X"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestCompanyService_DeactivateCompany 비활성화 처리
+func TestCompanyService_DeactivateCompany(t *testing.T) {
+	db := setupServiceTestDB(t)
+	svc := NewCompanyService(db)
+
+	seedCompany(t, db, "Company", "realm", "active")
+
+	resp, err := svc.DeactivateCompany()
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "inactive", resp.Status)
+}
+
+// TestCompanyService_DeactivateCompany_Idempotent 이미 inactive인 경우 멱등 처리
+func TestCompanyService_DeactivateCompany_Idempotent(t *testing.T) {
+	db := setupServiceTestDB(t)
+	svc := NewCompanyService(db)
+
+	seedCompany(t, db, "Company", "realm", "inactive")
+
+	resp, err := svc.DeactivateCompany()
+	require.NoError(t, err)
+	assert.Equal(t, "inactive", resp.Status)
+}
+
+// TestCompanyService_ActivateCompany 활성화 처리
+func TestCompanyService_ActivateCompany(t *testing.T) {
+	db := setupServiceTestDB(t)
+	svc := NewCompanyService(db)
+
+	seedCompany(t, db, "Company", "realm", "inactive")
+
+	resp, err := svc.ActivateCompany()
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "active", resp.Status)
+}
+
+// TestCompanyService_ActivateCompany_Idempotent 이미 active인 경우 멱등 처리
+func TestCompanyService_ActivateCompany_Idempotent(t *testing.T) {
+	db := setupServiceTestDB(t)
+	svc := NewCompanyService(db)
+
+	seedCompany(t, db, "Company", "realm", "active")
+
+	resp, err := svc.ActivateCompany()
+	require.NoError(t, err)
+	assert.Equal(t, "active", resp.Status)
+}
+
+// TestCompanyService_CreateDefaultCompany 기본 회사 생성
+func TestCompanyService_CreateDefaultCompany(t *testing.T) {
+	db := setupServiceTestDB(t)
+	svc := NewCompanyService(db)
+
+	os.Setenv("MC_IAM_MANAGER_COMPANY_NAME", "Test Default Company")
+	os.Setenv("MC_IAM_MANAGER_KEYCLOAK_REALM", "test-realm")
+	os.Setenv("MC_IAM_MANAGER_KEYCLOAK_CLIENT_NAME", "test-client")
+	os.Setenv("MC_IAM_MANAGER_KEYCLOAK_CLIENT_SECRET", "test-secret")
+	defer func() {
+		os.Unsetenv("MC_IAM_MANAGER_COMPANY_NAME")
+		os.Unsetenv("MC_IAM_MANAGER_KEYCLOAK_REALM")
+		os.Unsetenv("MC_IAM_MANAGER_KEYCLOAK_CLIENT_NAME")
+		os.Unsetenv("MC_IAM_MANAGER_KEYCLOAK_CLIENT_SECRET")
+	}()
+
+	err := svc.CreateDefaultCompany()
+	require.NoError(t, err)
+
+	resp, err := svc.GetCompany()
+	require.NoError(t, err)
+	assert.Equal(t, "Test Default Company", resp.Name)
+	assert.Equal(t, "test-realm", resp.RealmName)
+}
+
+// TestCompanyService_CreateDefaultCompany_DefaultName env 미설정 시 "Default Company"
+func TestCompanyService_CreateDefaultCompany_DefaultName(t *testing.T) {
+	db := setupServiceTestDB(t)
+	svc := NewCompanyService(db)
+
+	os.Unsetenv("MC_IAM_MANAGER_COMPANY_NAME")
+
+	err := svc.CreateDefaultCompany()
+	require.NoError(t, err)
+
+	resp, err := svc.GetCompany()
+	require.NoError(t, err)
+	assert.Equal(t, "Default Company", resp.Name)
+}
+
+// TestCompanyService_CreateDefaultCompany_Idempotent 이미 회사 있으면 skip
+func TestCompanyService_CreateDefaultCompany_Idempotent(t *testing.T) {
+	db := setupServiceTestDB(t)
+	svc := NewCompanyService(db)
+
+	seedCompany(t, db, "Existing", "realm", "active")
+
+	err := svc.CreateDefaultCompany()
+	require.NoError(t, err)
+
+	// 여전히 1개만 존재해야 함
+	repo := repository.NewCompanyRepository(db)
+	count, err := repo.Count()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count)
+}

--- a/src/service/group_role_service.go
+++ b/src/service/group_role_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/m-cmp/mc-iam-manager/model"
@@ -40,6 +41,9 @@ func (s *GroupRoleService) AssignGroupPlatformRole(ctx context.Context, groupID,
 	// 2. Role 이름 조회
 	var roleMaster model.RoleMaster
 	if err := s.db.First(&roleMaster, roleID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return repository.ErrRoleMasterNotFound
+		}
 		return fmt.Errorf("role not found: %w", err)
 	}
 
@@ -63,6 +67,16 @@ func (s *GroupRoleService) GetGroupPlatformRoles(groupID uint) ([]model.GroupPla
 	return s.groupRoleRepo.FindGroupPlatformRoles(groupID)
 }
 
+// GetAvailablePlatformRoles 그룹에 할당되지 않은 플랫폼 역할 목록 조회
+func (s *GroupRoleService) GetAvailablePlatformRoles(groupID uint) ([]model.RoleMaster, error) {
+	return s.groupRoleRepo.FindAvailablePlatformRoles(groupID)
+}
+
+// GetAvailableWorkspaces 그룹에 매핑되지 않은 워크스페이스 목록 조회
+func (s *GroupRoleService) GetAvailableWorkspaces(groupID uint) ([]model.Workspace, error) {
+	return s.groupRoleRepo.FindAvailableWorkspaces(groupID)
+}
+
 // RemoveGroupPlatformRole 그룹에서 platform role 해제 (DB + Keycloak)
 func (s *GroupRoleService) RemoveGroupPlatformRole(ctx context.Context, groupID, roleID uint) error {
 	// 1. 그룹 조회
@@ -74,6 +88,9 @@ func (s *GroupRoleService) RemoveGroupPlatformRole(ctx context.Context, groupID,
 	// 2. Role 이름 조회
 	var roleMaster model.RoleMaster
 	if err := s.db.First(&roleMaster, roleID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return repository.ErrRoleMasterNotFound
+		}
 		return fmt.Errorf("role not found: %w", err)
 	}
 
@@ -93,7 +110,24 @@ func (s *GroupRoleService) RemoveGroupPlatformRole(ctx context.Context, groupID,
 // --- Workspace Role ---
 
 // AssignGroupWorkspace 그룹-워크스페이스 매핑 생성 (DB 전용)
+// workspace_id, role_id 존재 여부 pre-validation 포함
 func (s *GroupRoleService) AssignGroupWorkspace(groupID, workspaceID, roleID uint) error {
+	// workspace 존재 확인
+	var workspace model.Workspace
+	if err := s.db.First(&workspace, workspaceID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return repository.ErrWorkspaceNotFound
+		}
+		return err
+	}
+	// role 존재 확인
+	var roleMaster model.RoleMaster
+	if err := s.db.First(&roleMaster, roleID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return repository.ErrRoleMasterNotFound
+		}
+		return err
+	}
 	return s.groupRoleRepo.CreateGroupWorkspaceRole(groupID, workspaceID, roleID)
 }
 

--- a/src/service/group_role_service.go
+++ b/src/service/group_role_service.go
@@ -138,6 +138,36 @@ func (s *GroupRoleService) AssignUserToGroups(ctx context.Context, userID uint, 
 	return nil
 }
 
+// AssignUsersToGroup 그룹에 사용자 일괄 할당 (그룹 입장, DB + Keycloak 동기화)
+func (s *GroupRoleService) AssignUsersToGroup(ctx context.Context, groupID uint, userIDs []uint) error {
+	// 그룹 존재 확인
+	org, err := s.orgRepo.FindByID(groupID)
+	if err != nil {
+		return err
+	}
+
+	for _, userID := range userIDs {
+		// 사용자 KC ID 조회
+		var user model.User
+		if err := s.db.First(&user, userID).Error; err != nil {
+			return fmt.Errorf("user not found: %d", userID)
+		}
+
+		// DB 저장
+		if err := s.orgRepo.AssignUserToOrganizations(userID, []uint{groupID}); err != nil {
+			return fmt.Errorf("failed to assign user %d to group in DB: %w", userID, err)
+		}
+
+		// Keycloak 동기화
+		if user.KcId != "" {
+			if err := s.kcService.EnsureGroupExistsAndAssignUser(ctx, user.KcId, org.Name); err != nil {
+				return fmt.Errorf("failed to assign user %d to keycloak group '%s': %w", userID, org.Name, err)
+			}
+		}
+	}
+	return nil
+}
+
 // RemoveUserFromGroup 사용자를 그룹에서 제거 (DB + Keycloak 동기화)
 func (s *GroupRoleService) RemoveUserFromGroup(ctx context.Context, userID, groupID uint, kcUserID string) error {
 	// 그룹 조회

--- a/src/service/organization_service.go
+++ b/src/service/organization_service.go
@@ -42,7 +42,7 @@ func (s *OrganizationService) CreateOrganization(req *model.CreateOrganizationRe
 		parent, err := s.orgRepo.FindByID(*req.ParentID)
 		if err != nil {
 			if errors.Is(err, repository.ErrOrganizationNotFound) {
-				return nil, fmt.Errorf("parent organization not found: %d", *req.ParentID)
+				return nil, fmt.Errorf("parent organization not found: %d: %w", *req.ParentID, repository.ErrOrganizationNotFound)
 			}
 			return nil, err
 		}
@@ -116,6 +116,11 @@ func (s *OrganizationService) GetOrganizations(tree bool) (interface{}, error) {
 
 	// 평면 목록을 Tree 구조로 변환
 	return buildOrganizationTree(flatList), nil
+}
+
+// SearchOrganizations name/code 필터로 조직 목록 검색 (평면 목록 반환)
+func (s *OrganizationService) SearchOrganizations(name, code string) ([]model.Organization, error) {
+	return s.orgRepo.FindByFilter(name, code)
 }
 
 // buildOrganizationTree 평면 목록을 Tree 구조로 변환 (내부 함수)

--- a/src/service/organization_service.go
+++ b/src/service/organization_service.go
@@ -284,6 +284,78 @@ func (s *OrganizationService) GetUserOrganizations(userID uint) ([]model.Organiz
 	return s.orgRepo.FindUserOrganizations(userID)
 }
 
+// GetUserOrganizationsWithHierarchy 사용자가 소속된 조직 목록을 계층 정보(path, level) 포함하여 조회
+func (s *OrganizationService) GetUserOrganizationsWithHierarchy(userID uint) ([]model.OrganizationTree, error) {
+	orgs, err := s.orgRepo.FindUserOrganizations(userID)
+	if err != nil {
+		return nil, err
+	}
+
+	// 전체 트리 평면 목록 조회 (path/level 계산용)
+	flatAll, err := s.orgRepo.FindTreeFlat()
+	if err != nil {
+		return nil, err
+	}
+
+	// ID → tree 노드 맵 구성
+	treeMap := make(map[uint]model.OrganizationTree, len(flatAll))
+	for _, node := range flatAll {
+		treeMap[node.ID] = node
+	}
+
+	// 사용자 소속 조직에 계층 정보 적용
+	result := make([]model.OrganizationTree, 0, len(orgs))
+	for _, org := range orgs {
+		if node, ok := treeMap[org.ID]; ok {
+			result = append(result, node)
+		} else {
+			// fallback: 기본 정보만
+			result = append(result, model.OrganizationTree{
+				ID:               org.ID,
+				ParentID:         org.ParentID,
+				OrganizationCode: org.OrganizationCode,
+				Name:             org.Name,
+				Description:      org.Description,
+				CreatedAt:        org.CreatedAt,
+				UpdatedAt:        org.UpdatedAt,
+			})
+		}
+	}
+	return result, nil
+}
+
+// ReplaceUserGroups 사용자의 그룹 멤버십을 전체 교체 (기존 제거 후 신규 할당)
+func (s *OrganizationService) ReplaceUserGroups(userID uint, groupIDs []uint) error {
+	// 신규 그룹 존재 확인
+	for _, gID := range groupIDs {
+		if _, err := s.orgRepo.FindByID(gID); err != nil {
+			return fmt.Errorf("group not found: %d", gID)
+		}
+	}
+
+	// 기존 그룹 조회
+	currentOrgs, err := s.orgRepo.FindUserOrganizations(userID)
+	if err != nil {
+		return err
+	}
+
+	// 기존 그룹 제거
+	for _, org := range currentOrgs {
+		if err := s.orgRepo.RemoveUserFromOrganization(userID, org.ID); err != nil {
+			// ErrUserOrganizationNotFound는 무시 (이미 제거됨)
+			if !errors.Is(err, repository.ErrUserOrganizationNotFound) {
+				return err
+			}
+		}
+	}
+
+	// 신규 그룹 할당
+	if len(groupIDs) > 0 {
+		return s.orgRepo.AssignUserToOrganizations(userID, groupIDs)
+	}
+	return nil
+}
+
 // GetOrganizationUsers 조직에 소속된 사용자 목록 조회
 func (s *OrganizationService) GetOrganizationUsers(orgID uint) ([]model.User, error) {
 	return s.orgRepo.FindOrganizationUsers(orgID)


### PR DESCRIPTION
## Summary

- **모듈**: M7-COMP 회사정보관리 (신규)
- **에픽**: ep-회사정보관리 / 001_회사정보관리기능추가
- **RQ**: RQ-M7-COMP-001~006 (6건)

### 구현 내용

- `src/model/company.go` — Company struct (`mcmp_companies`), Request/UpdateRequest/Response DTOs
- `src/repository/company_repository.go` — ExistsByRealmName, Create, First(싱글톤), Save, Count
- `src/service/company_service.go` — CRUD + activate/deactivate + CreateDefaultCompany + ensureRealm
- `src/handler/company_handler.go` — 5개 엔드포인트 (Swagger 어노테이션)
- `src/main.go` — AutoMigrate, `/api/company` 라우트 그룹
- `src/handler/admin_handler.go` — SetupInitialAdmin에 CreateDefaultCompany 통합 (non-fatal)

### API

| Method | Path | 설명 |
|--------|------|------|
| POST | /api/company | 회사 생성 (PlatformAdmin) |
| GET | /api/company | 회사 조회 |
| PUT | /api/company | 회사 수정 (PlatformAdmin) |
| DELETE | /api/company | 비활성화 (PlatformAdmin, 멱등) |
| POST | /api/company/activate | 활성화 (PlatformAdmin, 멱등) |

### 단위테스트

- repository: 8 PASS / service: 13 PASS (SQLite in-memory)

## Test plan

- [x] `go build ./...` 성공
- [x] `go test ./service/... -run TestCompany` — 13 PASS
- [x] `go test -vet=off ./repository/... -run TestCompany` — 8 PASS
- [ ] 통합 테스트 (KC 환경 필요)