### PR TITLE
feat(iam): 그룹-워크스페이스 역할 할당 관리 기능 추가 (IDO-21)

### DIFF
--- a/src/handler/group_role_handler.go
+++ b/src/handler/group_role_handler.go
@@ -149,6 +149,7 @@ func (h *GroupRoleHandler) RemoveGroupPlatformRole(c echo.Context) error {
 // @Param body body model.AssignGroupWorkspaceRequest true "워크스페이스 매핑 요청"
 // @Success 201 {object} map[string]string
 // @Failure 400 {object} map[string]string
+// @Failure 404 {object} map[string]string
 // @Failure 409 {object} map[string]string
 // @Security BearerAuth
 // @Router /api/groups/id/{groupId}/workspaces [post]
@@ -168,13 +169,43 @@ func (h *GroupRoleHandler) AssignGroupWorkspace(c echo.Context) error {
 	}
 
 	if err := h.groupRoleService.AssignGroupWorkspace(uint(groupID), req.WorkspaceID, req.RoleID); err != nil {
-		if errors.Is(err, repository.ErrGroupWorkspaceRoleDuplicate) {
+		switch {
+		case errors.Is(err, repository.ErrWorkspaceNotFound):
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "워크스페이스를 찾을 수 없습니다"})
+		case errors.Is(err, repository.ErrRoleMasterNotFound):
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "역할을 찾을 수 없습니다"})
+		case errors.Is(err, repository.ErrGroupWorkspaceRoleDuplicate):
 			return c.JSON(http.StatusConflict, map[string]string{"error": "이미 매핑된 워크스페이스입니다"})
+		default:
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		}
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}
 
 	return c.JSON(http.StatusCreated, map[string]string{"message": "그룹이 워크스페이스에 매핑되었습니다."})
+}
+
+// GetAvailableGroupWorkspaces godoc
+// @Summary 그룹에 미매핑된 워크스페이스 목록 조회
+// @Description 그룹에 아직 매핑되지 않은 워크스페이스 목록을 조회합니다.
+// @Tags groups
+// @Produce json
+// @Param groupId path int true "그룹 ID"
+// @Success 200 {array} model.Workspace
+// @Failure 400 {object} map[string]string
+// @Security BearerAuth
+// @Router /api/groups/id/{groupId}/workspaces/available [get]
+// @Id getAvailableGroupWorkspaces
+func (h *GroupRoleHandler) GetAvailableGroupWorkspaces(c echo.Context) error {
+	groupID, err := strconv.ParseUint(c.Param("groupId"), 10, 32)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid group ID"})
+	}
+
+	workspaces, err := h.groupRoleService.GetAvailableGroupWorkspaces(uint(groupID))
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	return c.JSON(http.StatusOK, workspaces)
 }
 
 // GetGroupWorkspaces godoc

--- a/src/main.go
+++ b/src/main.go
@@ -479,6 +479,7 @@ func main() {
 		// 그룹-워크스페이스 매핑 관리 (DB 전용)
 		groups.POST("/id/:groupId/workspaces", groupRoleHandler.AssignGroupWorkspace)
 		groups.GET("/id/:groupId/workspaces", groupRoleHandler.GetGroupWorkspaces)
+		groups.GET("/id/:groupId/workspaces/available", groupRoleHandler.GetAvailableGroupWorkspaces)
 		groups.PUT("/id/:groupId/workspaces/:workspaceId", groupRoleHandler.UpdateGroupWorkspaceRole)
 		groups.DELETE("/id/:groupId/workspaces/:workspaceId", groupRoleHandler.RemoveGroupWorkspaceRole)
 	}

--- a/src/repository/group_role_repository.go
+++ b/src/repository/group_role_repository.go
@@ -157,7 +157,9 @@ func (r *GroupRoleRepository) DeleteGroupWorkspaceRole(groupID, workspaceID uint
 	return nil
 }
 
-// isGroupDuplicateError PostgreSQL unique constraint 위반 여부 확인
+// isGroupDuplicateError unique constraint 위반 여부 확인 (PostgreSQL: 23505, SQLite: UNIQUE constraint failed)
 func isGroupDuplicateError(err error) bool {
-	return err != nil && (strings.Contains(err.Error(), "duplicate key") || strings.Contains(err.Error(), "23505"))
+	return err != nil && (strings.Contains(err.Error(), "duplicate key") ||
+		strings.Contains(err.Error(), "23505") ||
+		strings.Contains(err.Error(), "UNIQUE constraint failed"))
 }

--- a/src/repository/group_role_repository.go
+++ b/src/repository/group_role_repository.go
@@ -14,6 +14,7 @@ var (
 	ErrGroupPlatformRoleDuplicate  = errors.New("group platform role mapping already exists")
 	ErrGroupWorkspaceRoleNotFound  = errors.New("group workspace role mapping not found")
 	ErrGroupWorkspaceRoleDuplicate = errors.New("group workspace role mapping already exists")
+	ErrRoleMasterNotFound          = errors.New("role not found")
 )
 
 // GroupRoleRepository 그룹 역할 매핑 데이터 관리
@@ -128,6 +129,20 @@ func (r *GroupRoleRepository) UpdateGroupWorkspaceRole(groupID, workspaceID, rol
 		return ErrGroupWorkspaceRoleNotFound
 	}
 	return nil
+}
+
+// FindAvailableWorkspacesForGroup 그룹에 미매핑된 워크스페이스 목록 조회
+func (r *GroupRoleRepository) FindAvailableWorkspacesForGroup(groupID uint) ([]*model.Workspace, error) {
+	var workspaces []*model.Workspace
+	err := r.db.Where("id NOT IN (?)",
+		r.db.Table("mcmp_group_workspace_roles").
+			Select("workspace_id").
+			Where("group_id = ?", groupID),
+	).Find(&workspaces).Error
+	if err != nil {
+		return nil, fmt.Errorf("error finding available workspaces: %w", err)
+	}
+	return workspaces, nil
 }
 
 // DeleteGroupWorkspaceRole 그룹-워크스페이스 매핑 삭제

--- a/src/repository/group_role_repository_test.go
+++ b/src/repository/group_role_repository_test.go
@@ -1,0 +1,204 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/m-cmp/mc-iam-manager/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupGroupRoleTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+
+	err = db.AutoMigrate(
+		&model.Organization{},
+		&model.Workspace{},
+		&model.RoleMaster{},
+		&model.GroupPlatformRole{},
+		&model.GroupWorkspaceRole{},
+	)
+	require.NoError(t, err)
+	return db
+}
+
+func seedOrganization(t *testing.T, db *gorm.DB, name, code string) *model.Organization {
+	t.Helper()
+	org := &model.Organization{Name: name, OrganizationCode: code}
+	require.NoError(t, db.Create(org).Error)
+	return org
+}
+
+func seedWorkspace(t *testing.T, db *gorm.DB, name string) *model.Workspace {
+	t.Helper()
+	ws := &model.Workspace{Name: name}
+	require.NoError(t, db.Create(ws).Error)
+	return ws
+}
+
+func seedRoleMaster(t *testing.T, db *gorm.DB, name string) *model.RoleMaster {
+	t.Helper()
+	role := &model.RoleMaster{Name: name}
+	require.NoError(t, db.Create(role).Error)
+	return role
+}
+
+// --- TC-M2-UG-025: CreateGroupWorkspaceRole ---
+
+// TC-M2-UG-025-01: 정상 매핑 생성
+func TestGroupRoleRepository_CreateGroupWorkspaceRole(t *testing.T) {
+	db := setupGroupRoleTestDB(t)
+	repo := NewGroupRoleRepository(db)
+
+	org := seedOrganization(t, db, "TestGroup", "GRP-001")
+	ws := seedWorkspace(t, db, "TestWorkspace")
+	role := seedRoleMaster(t, db, "viewer")
+
+	err := repo.CreateGroupWorkspaceRole(org.ID, ws.ID, role.ID)
+	assert.NoError(t, err)
+
+	var count int64
+	db.Model(&model.GroupWorkspaceRole{}).
+		Where("group_id = ? AND workspace_id = ? AND role_id = ?", org.ID, ws.ID, role.ID).
+		Count(&count)
+	assert.Equal(t, int64(1), count)
+}
+
+// TC-M2-UG-025-02: 중복 매핑 시도 → ErrGroupWorkspaceRoleDuplicate
+func TestGroupRoleRepository_CreateGroupWorkspaceRole_Duplicate(t *testing.T) {
+	db := setupGroupRoleTestDB(t)
+	repo := NewGroupRoleRepository(db)
+
+	org := seedOrganization(t, db, "TestGroup", "GRP-002")
+	ws := seedWorkspace(t, db, "TestWorkspace2")
+	role := seedRoleMaster(t, db, "editor")
+
+	require.NoError(t, repo.CreateGroupWorkspaceRole(org.ID, ws.ID, role.ID))
+
+	err := repo.CreateGroupWorkspaceRole(org.ID, ws.ID, role.ID)
+	assert.ErrorIs(t, err, ErrGroupWorkspaceRoleDuplicate)
+}
+
+// --- TC-M2-UG-026: FindGroupWorkspaceRoles ---
+
+// TC-M2-UG-026-02: 매핑 없을 때 빈 배열 반환
+func TestGroupRoleRepository_FindGroupWorkspaceRoles_Empty(t *testing.T) {
+	db := setupGroupRoleTestDB(t)
+	repo := NewGroupRoleRepository(db)
+
+	org := seedOrganization(t, db, "EmptyGroup", "GRP-003")
+
+	results, err := repo.FindGroupWorkspaceRoles(org.ID)
+	assert.NoError(t, err)
+	assert.NotNil(t, results)
+	assert.Len(t, results, 0)
+}
+
+// TC-M2-UG-026-01: 매핑된 워크스페이스 목록 반환
+func TestGroupRoleRepository_FindGroupWorkspaceRoles(t *testing.T) {
+	db := setupGroupRoleTestDB(t)
+	repo := NewGroupRoleRepository(db)
+
+	org := seedOrganization(t, db, "MappedGroup", "GRP-004")
+	ws1 := seedWorkspace(t, db, "Workspace-A")
+	ws2 := seedWorkspace(t, db, "Workspace-B")
+	role := seedRoleMaster(t, db, "member")
+
+	require.NoError(t, repo.CreateGroupWorkspaceRole(org.ID, ws1.ID, role.ID))
+	require.NoError(t, repo.CreateGroupWorkspaceRole(org.ID, ws2.ID, role.ID))
+
+	results, err := repo.FindGroupWorkspaceRoles(org.ID)
+	assert.NoError(t, err)
+	assert.Len(t, results, 2)
+}
+
+// --- TC-M2-UG-027: UpdateGroupWorkspaceRole ---
+
+// TC-M2-UG-027-01: 정상 역할 변경
+func TestGroupRoleRepository_UpdateGroupWorkspaceRole(t *testing.T) {
+	db := setupGroupRoleTestDB(t)
+	repo := NewGroupRoleRepository(db)
+
+	org := seedOrganization(t, db, "UpdateGroup", "GRP-005")
+	ws := seedWorkspace(t, db, "Workspace-C")
+	role1 := seedRoleMaster(t, db, "viewer2")
+	role2 := seedRoleMaster(t, db, "admin")
+
+	require.NoError(t, repo.CreateGroupWorkspaceRole(org.ID, ws.ID, role1.ID))
+
+	err := repo.UpdateGroupWorkspaceRole(org.ID, ws.ID, role2.ID)
+	assert.NoError(t, err)
+
+	var record model.GroupWorkspaceRole
+	require.NoError(t, db.Where("group_id = ? AND workspace_id = ?", org.ID, ws.ID).First(&record).Error)
+	assert.Equal(t, role2.ID, record.RoleID)
+}
+
+// TC-M2-UG-027-02: 존재하지 않는 매핑 업데이트 → ErrGroupWorkspaceRoleNotFound
+func TestGroupRoleRepository_UpdateGroupWorkspaceRole_NotFound(t *testing.T) {
+	db := setupGroupRoleTestDB(t)
+	repo := NewGroupRoleRepository(db)
+
+	err := repo.UpdateGroupWorkspaceRole(9999, 9999, 1)
+	assert.ErrorIs(t, err, ErrGroupWorkspaceRoleNotFound)
+}
+
+// --- TC-M2-UG-028: DeleteGroupWorkspaceRole ---
+
+// TC-M2-UG-028-01: 정상 매핑 삭제
+func TestGroupRoleRepository_DeleteGroupWorkspaceRole(t *testing.T) {
+	db := setupGroupRoleTestDB(t)
+	repo := NewGroupRoleRepository(db)
+
+	org := seedOrganization(t, db, "DeleteGroup", "GRP-006")
+	ws := seedWorkspace(t, db, "Workspace-D")
+	role := seedRoleMaster(t, db, "ops")
+
+	require.NoError(t, repo.CreateGroupWorkspaceRole(org.ID, ws.ID, role.ID))
+
+	err := repo.DeleteGroupWorkspaceRole(org.ID, ws.ID)
+	assert.NoError(t, err)
+
+	var count int64
+	db.Model(&model.GroupWorkspaceRole{}).Where("group_id = ? AND workspace_id = ?", org.ID, ws.ID).Count(&count)
+	assert.Equal(t, int64(0), count)
+}
+
+// TC-M2-UG-028-02: 존재하지 않는 매핑 삭제 → ErrGroupWorkspaceRoleNotFound
+func TestGroupRoleRepository_DeleteGroupWorkspaceRole_NotFound(t *testing.T) {
+	db := setupGroupRoleTestDB(t)
+	repo := NewGroupRoleRepository(db)
+
+	err := repo.DeleteGroupWorkspaceRole(9999, 9999)
+	assert.ErrorIs(t, err, ErrGroupWorkspaceRoleNotFound)
+}
+
+// --- FindAvailableWorkspacesForGroup ---
+
+func TestGroupRoleRepository_FindAvailableWorkspacesForGroup(t *testing.T) {
+	db := setupGroupRoleTestDB(t)
+	repo := NewGroupRoleRepository(db)
+
+	org := seedOrganization(t, db, "AvailGroup", "GRP-007")
+	ws1 := seedWorkspace(t, db, "Workspace-E")
+	ws2 := seedWorkspace(t, db, "Workspace-F")
+	ws3 := seedWorkspace(t, db, "Workspace-G")
+	role := seedRoleMaster(t, db, "dev")
+
+	// ws1만 매핑
+	require.NoError(t, repo.CreateGroupWorkspaceRole(org.ID, ws1.ID, role.ID))
+
+	available, err := repo.FindAvailableWorkspacesForGroup(org.ID)
+	assert.NoError(t, err)
+	// ws2, ws3은 미매핑 → 2개 반환
+	assert.Len(t, available, 2)
+
+	ids := []uint{available[0].ID, available[1].ID}
+	assert.Contains(t, ids, ws2.ID)
+	assert.Contains(t, ids, ws3.ID)
+	assert.NotContains(t, ids, ws1.ID)
+}

--- a/src/repository/role_repository.go
+++ b/src/repository/role_repository.go
@@ -439,8 +439,7 @@ func (r *RoleRepository) CreateWorkspaceRoleCspRoleMapping(req *model.CreateCspR
 		// csp role 저장
 		for _, cspRole := range req.CspRoles {
 			savedCspRole := model.CspRole{}
-			err := tx.Save(&cspRole).Scan(&savedCspRole)
-			if err != nil {
+			if err := tx.Save(&cspRole).Scan(&savedCspRole).Error; err != nil {
 				return fmt.Errorf("failed to create csp role: %w", err)
 			}
 

--- a/src/repository/workspace_repository.go
+++ b/src/repository/workspace_repository.go
@@ -64,7 +64,7 @@ func (r *WorkspaceRepository) FindWorkspaces(req *model.WorkspaceFilterRequest) 
 	// If filter conditions exist, retrieve workspaces that match the conditions
 	// Use query builder to create basic query
 	query := r.db.Model(&model.Workspace{})
-	log.Printf("req", req)
+	log.Printf("req: %+v", req)
 
 	if req.WorkspaceID != "" {
 		workspaceIdInt, err := util.StringToUint(req.WorkspaceID)

--- a/src/service/group_role_service.go
+++ b/src/service/group_role_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/m-cmp/mc-iam-manager/model"
@@ -94,6 +95,22 @@ func (s *GroupRoleService) RemoveGroupPlatformRole(ctx context.Context, groupID,
 
 // AssignGroupWorkspace 그룹-워크스페이스 매핑 생성 (DB 전용)
 func (s *GroupRoleService) AssignGroupWorkspace(groupID, workspaceID, roleID uint) error {
+	// workspace 존재 여부 확인
+	var workspace model.Workspace
+	if err := s.db.First(&workspace, workspaceID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return repository.ErrWorkspaceNotFound
+		}
+		return fmt.Errorf("error checking workspace: %w", err)
+	}
+	// role 존재 여부 확인
+	var roleMaster model.RoleMaster
+	if err := s.db.First(&roleMaster, roleID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return repository.ErrRoleMasterNotFound
+		}
+		return fmt.Errorf("error checking role: %w", err)
+	}
 	return s.groupRoleRepo.CreateGroupWorkspaceRole(groupID, workspaceID, roleID)
 }
 
@@ -110,6 +127,11 @@ func (s *GroupRoleService) UpdateGroupWorkspaceRole(groupID, workspaceID, roleID
 // RemoveGroupWorkspaceRole 그룹-워크스페이스 매핑 제거
 func (s *GroupRoleService) RemoveGroupWorkspaceRole(groupID, workspaceID uint) error {
 	return s.groupRoleRepo.DeleteGroupWorkspaceRole(groupID, workspaceID)
+}
+
+// GetAvailableGroupWorkspaces 그룹에 미매핑된 워크스페이스 목록 조회
+func (s *GroupRoleService) GetAvailableGroupWorkspaces(groupID uint) ([]*model.Workspace, error) {
+	return s.groupRoleRepo.FindAvailableWorkspacesForGroup(groupID)
 }
 
 // --- User-Group (with Keycloak sync) ---

--- a/src/service/group_role_service_test.go
+++ b/src/service/group_role_service_test.go
@@ -1,0 +1,208 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/m-cmp/mc-iam-manager/model"
+	"github.com/m-cmp/mc-iam-manager/repository"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupGroupRoleServiceTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+
+	err = db.AutoMigrate(
+		&model.Organization{},
+		&model.Workspace{},
+		&model.RoleMaster{},
+		&model.GroupPlatformRole{},
+		&model.GroupWorkspaceRole{},
+	)
+	require.NoError(t, err)
+	return db
+}
+
+func seedOrg(t *testing.T, db *gorm.DB, name, code string) *model.Organization {
+	t.Helper()
+	org := &model.Organization{Name: name, OrganizationCode: code}
+	require.NoError(t, db.Create(org).Error)
+	return org
+}
+
+func seedWs(t *testing.T, db *gorm.DB, name string) *model.Workspace {
+	t.Helper()
+	ws := &model.Workspace{Name: name}
+	require.NoError(t, db.Create(ws).Error)
+	return ws
+}
+
+func seedRole(t *testing.T, db *gorm.DB, name string) *model.RoleMaster {
+	t.Helper()
+	role := &model.RoleMaster{Name: name}
+	require.NoError(t, db.Create(role).Error)
+	return role
+}
+
+// --- TC-M2-UG-025: AssignGroupWorkspace ---
+
+// TC-M2-UG-025-01: 정상 매핑 생성
+func TestGroupRoleService_AssignGroupWorkspace(t *testing.T) {
+	db := setupGroupRoleServiceTestDB(t)
+	svc := NewGroupRoleService(db)
+
+	org := seedOrg(t, db, "Group-A", "SVC-001")
+	ws := seedWs(t, db, "Workspace-A")
+	role := seedRole(t, db, "svc-viewer")
+
+	err := svc.AssignGroupWorkspace(org.ID, ws.ID, role.ID)
+	assert.NoError(t, err)
+}
+
+// TC-M2-UG-025-02: 중복 매핑 시도 → ErrGroupWorkspaceRoleDuplicate
+func TestGroupRoleService_AssignGroupWorkspace_Duplicate(t *testing.T) {
+	db := setupGroupRoleServiceTestDB(t)
+	svc := NewGroupRoleService(db)
+
+	org := seedOrg(t, db, "Group-B", "SVC-002")
+	ws := seedWs(t, db, "Workspace-B")
+	role := seedRole(t, db, "svc-editor")
+
+	require.NoError(t, svc.AssignGroupWorkspace(org.ID, ws.ID, role.ID))
+
+	err := svc.AssignGroupWorkspace(org.ID, ws.ID, role.ID)
+	assert.ErrorIs(t, err, repository.ErrGroupWorkspaceRoleDuplicate)
+}
+
+// TC-M2-UG-025-03: 존재하지 않는 워크스페이스 → ErrWorkspaceNotFound
+func TestGroupRoleService_AssignGroupWorkspace_WorkspaceNotFound(t *testing.T) {
+	db := setupGroupRoleServiceTestDB(t)
+	svc := NewGroupRoleService(db)
+
+	org := seedOrg(t, db, "Group-C", "SVC-003")
+	role := seedRole(t, db, "svc-admin")
+
+	err := svc.AssignGroupWorkspace(org.ID, 9999, role.ID)
+	assert.ErrorIs(t, err, repository.ErrWorkspaceNotFound)
+}
+
+// 존재하지 않는 역할 → ErrRoleMasterNotFound
+func TestGroupRoleService_AssignGroupWorkspace_RoleNotFound(t *testing.T) {
+	db := setupGroupRoleServiceTestDB(t)
+	svc := NewGroupRoleService(db)
+
+	org := seedOrg(t, db, "Group-D", "SVC-004")
+	ws := seedWs(t, db, "Workspace-C")
+
+	err := svc.AssignGroupWorkspace(org.ID, ws.ID, 9999)
+	assert.ErrorIs(t, err, repository.ErrRoleMasterNotFound)
+}
+
+// --- TC-M2-UG-026: GetGroupWorkspaces ---
+
+// TC-M2-UG-026-02: 매핑 없을 때 빈 배열
+func TestGroupRoleService_GetGroupWorkspaces_Empty(t *testing.T) {
+	db := setupGroupRoleServiceTestDB(t)
+	svc := NewGroupRoleService(db)
+
+	org := seedOrg(t, db, "Group-E", "SVC-005")
+
+	results, err := svc.GetGroupWorkspaces(org.ID)
+	assert.NoError(t, err)
+	assert.NotNil(t, results)
+	assert.Len(t, results, 0)
+}
+
+// TC-M2-UG-026-01: 매핑된 워크스페이스 2개 반환
+func TestGroupRoleService_GetGroupWorkspaces(t *testing.T) {
+	db := setupGroupRoleServiceTestDB(t)
+	svc := NewGroupRoleService(db)
+
+	org := seedOrg(t, db, "Group-F", "SVC-006")
+	ws1 := seedWs(t, db, "Workspace-D")
+	ws2 := seedWs(t, db, "Workspace-E")
+	role := seedRole(t, db, "svc-member")
+
+	require.NoError(t, svc.AssignGroupWorkspace(org.ID, ws1.ID, role.ID))
+	require.NoError(t, svc.AssignGroupWorkspace(org.ID, ws2.ID, role.ID))
+
+	results, err := svc.GetGroupWorkspaces(org.ID)
+	assert.NoError(t, err)
+	assert.Len(t, results, 2)
+}
+
+// --- TC-M2-UG-027: UpdateGroupWorkspaceRole ---
+
+// TC-M2-UG-027-01: 정상 역할 변경
+func TestGroupRoleService_UpdateGroupWorkspaceRole(t *testing.T) {
+	db := setupGroupRoleServiceTestDB(t)
+	svc := NewGroupRoleService(db)
+
+	org := seedOrg(t, db, "Group-G", "SVC-007")
+	ws := seedWs(t, db, "Workspace-F")
+	role1 := seedRole(t, db, "svc-viewer2")
+	role2 := seedRole(t, db, "svc-ops")
+
+	require.NoError(t, svc.AssignGroupWorkspace(org.ID, ws.ID, role1.ID))
+
+	err := svc.UpdateGroupWorkspaceRole(org.ID, ws.ID, role2.ID)
+	assert.NoError(t, err)
+}
+
+// TC-M2-UG-027-02: 존재하지 않는 매핑 업데이트 → ErrGroupWorkspaceRoleNotFound
+func TestGroupRoleService_UpdateGroupWorkspaceRole_NotFound(t *testing.T) {
+	db := setupGroupRoleServiceTestDB(t)
+	svc := NewGroupRoleService(db)
+
+	err := svc.UpdateGroupWorkspaceRole(9999, 9999, 1)
+	assert.ErrorIs(t, err, repository.ErrGroupWorkspaceRoleNotFound)
+}
+
+// --- TC-M2-UG-028: RemoveGroupWorkspaceRole ---
+
+// TC-M2-UG-028-01: 정상 매핑 삭제
+func TestGroupRoleService_RemoveGroupWorkspaceRole(t *testing.T) {
+	db := setupGroupRoleServiceTestDB(t)
+	svc := NewGroupRoleService(db)
+
+	org := seedOrg(t, db, "Group-H", "SVC-008")
+	ws := seedWs(t, db, "Workspace-G")
+	role := seedRole(t, db, "svc-dev")
+
+	require.NoError(t, svc.AssignGroupWorkspace(org.ID, ws.ID, role.ID))
+
+	err := svc.RemoveGroupWorkspaceRole(org.ID, ws.ID)
+	assert.NoError(t, err)
+}
+
+// TC-M2-UG-028-02: 존재하지 않는 매핑 삭제 → ErrGroupWorkspaceRoleNotFound
+func TestGroupRoleService_RemoveGroupWorkspaceRole_NotFound(t *testing.T) {
+	db := setupGroupRoleServiceTestDB(t)
+	svc := NewGroupRoleService(db)
+
+	err := svc.RemoveGroupWorkspaceRole(9999, 9999)
+	assert.ErrorIs(t, err, repository.ErrGroupWorkspaceRoleNotFound)
+}
+
+// --- GetAvailableGroupWorkspaces ---
+
+func TestGroupRoleService_GetAvailableGroupWorkspaces(t *testing.T) {
+	db := setupGroupRoleServiceTestDB(t)
+	svc := NewGroupRoleService(db)
+
+	org := seedOrg(t, db, "Group-I", "SVC-009")
+	ws1 := seedWs(t, db, "Workspace-H")
+	ws2 := seedWs(t, db, "Workspace-I")
+	role := seedRole(t, db, "svc-lead")
+
+	require.NoError(t, svc.AssignGroupWorkspace(org.ID, ws1.ID, role.ID))
+
+	available, err := svc.GetAvailableGroupWorkspaces(org.ID)
+	assert.NoError(t, err)
+	assert.Len(t, available, 1)
+	assert.Equal(t, ws2.ID, available[0].ID)
+}


### PR DESCRIPTION
## Summary

- 그룹-워크스페이스 역할 할당 시 워크스페이스/역할 존재 여부 사전 검증 추가 (404 응답)
- 그룹에 할당 가능한 워크스페이스 목록 조회 API 추가 (`GET /api/groups/id/:groupId/workspaces/available`)
- Repository/Service 레이어 단위 테스트 20개 추가 (TC-M2-UG-025 ~ TC-M2-UG-028, 전체 PASS)
- SQLite 인메모리 DB 기반 테스트 인프라 구축
- 기존 컴파일 오류 2건 수정 (role_repository.go, workspace_repository.go)

## Test plan

- [x] TC-M2-UG-025-01: 그룹-워크스페이스 정상 매핑 — PASS
- [x] TC-M2-UG-025-02: 중복 매핑 시도 → ErrGroupWorkspaceRoleDuplicate — PASS
- [x] TC-M2-UG-025-03: 존재하지 않는 워크스페이스/역할 매핑 시도 → 404 — PASS
- [x] TC-M2-UG-026-01: 매핑된 워크스페이스 목록 조회 — PASS
- [x] TC-M2-UG-026-02: 매핑 없는 경우 빈 목록 반환 — PASS
- [x] TC-M2-UG-027-01: 매핑 역할 정상 변경 — PASS
- [x] TC-M2-UG-027-02: 존재하지 않는 매핑 변경 → ErrGroupWorkspaceRoleNotFound — PASS
- [x] TC-M2-UG-028-01: 그룹-워크스페이스 매핑 정상 제거 — PASS
- [x] TC-M2-UG-028-02: 존재하지 않는 매핑 제거 → ErrGroupWorkspaceRoleNotFound — PASS
- [x] Repository 9/9 PASS (`go test ./repository/... -run TestGroupRole -v`)
- [x] Service 11/11 PASS (`go test ./service/... -run TestGroupRole -v`)

## Notion

Epic: `mc-iam-ep-사용자그룹생성및관리기능확장개선` / Task: `005_그룹워크스페이스역할할당관리`
ST1~ST4 문서 작성 완료