### PR TITLE
fix(M3-RBAC): 메뉴 관리 API 버그 수정 5건

### DIFF
--- a/src/handler/menu_handler.go
+++ b/src/handler/menu_handler.go
@@ -218,7 +218,7 @@ func (h *MenuHandler) ListMenus(c echo.Context) error {
 // @Failure 403 {object} map[string]string "error: Forbidden"
 // @Failure 500 {object} map[string]string "error: 서버 내부 오류"
 // @Security BearerAuth
-// @Router /api/menus/tree/list [post]
+// @Router /api/menus/menus-tree/list [post]
 // @Id listMenusTree
 func (h *MenuHandler) ListMenusTree(c echo.Context) error {
 	// If this is an admin-only function, let middleware handle the check.
@@ -324,6 +324,11 @@ func (h *MenuHandler) GetMenuByID(c echo.Context) error {
 	id := c.Param("menuId")
 	menu, err := h.menuService.GetMenuByID(&id)
 	if err != nil {
+		if err == repository.ErrMenuNotFound {
+			return c.JSON(http.StatusNotFound, map[string]string{
+				"error": "Menu not found",
+			})
+		}
 		return c.JSON(http.StatusInternalServerError, map[string]string{
 			"error": "Failed to find menu",
 		})
@@ -426,7 +431,9 @@ func (h *MenuHandler) UpdateMenu(c echo.Context) error {
 	if menu.ResType != "" {
 		updates["res_type"] = menu.ResType
 	}
-	updates["is_action"] = menu.IsAction
+	if menu.IsAction != nil {
+		updates["is_action"] = *menu.IsAction
+	}
 	if menu.Priority != "" {
 		priorityInt, err := util.StringToUint(menu.Priority)
 		if err != nil {
@@ -492,6 +499,11 @@ func (h *MenuHandler) UpdateMenu(c echo.Context) error {
 func (h *MenuHandler) DeleteMenu(c echo.Context) error {
 	id := c.Param("menuId")
 	if err := h.menuService.Delete(id); err != nil {
+		if err == repository.ErrMenuNotFound {
+			return c.JSON(http.StatusNotFound, map[string]string{
+				"error": "Menu not found",
+			})
+		}
 		return c.JSON(http.StatusInternalServerError, map[string]string{
 			"error": "메뉴 삭제에 실패했습니다",
 		})
@@ -654,21 +666,18 @@ func (h *MenuHandler) CreateMenusRolesMapping(c echo.Context) error {
 // @Router /api/menus/platform-roles [delete]
 // @Id deleteMenusRolesMapping
 func (h *MenuHandler) DeleteMenusRolesMapping(c echo.Context) error {
-	roleID := c.Param("roleId")
-	menuID := c.Param("menuId")
+	roleID := c.QueryParam("roleId")
+	menuID := c.QueryParam("menuId")
 
 	roleIDInt, err := util.StringToUint(roleID)
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid role ID"})
 	}
-
-	mappings := []*model.RoleMenuMapping{
-		{
-			RoleID: roleIDInt,
-			MenuID: menuID,
-		},
+	if menuID == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "menuId is required"})
 	}
-	err = h.menuService.DeleteRoleMenuMapping(mappings)
+
+	err = h.menuService.DeleteRoleMenuMappingByRoleAndMenu(roleIDInt, menuID)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}

--- a/src/model/request.go
+++ b/src/model/request.go
@@ -121,7 +121,7 @@ type CreateMenuRequest struct {
 	ParentID    string `json:"parentId,omitempty"`
 	DisplayName string `json:"displayName"`
 	ResType     string `json:"resType"`
-	IsAction    bool   `json:"isAction"`
+	IsAction    *bool  `json:"isAction"`
 	Priority    string `json:"priority"`
 	MenuNumber  string `json:"menuNumber"`
 	RoleIDs     []uint `json:"roleIds,omitempty"` // 생성과 동시에 매핑할 역할 ID 목록 (platform_admin은 항상 자동 매핑)

--- a/src/repository/menu_repository.go
+++ b/src/repository/menu_repository.go
@@ -95,12 +95,16 @@ func (r *MenuRepository) CreateMenu(req *model.CreateMenuRequest) error {
 	if err != nil {
 		return err
 	}
+	isAction := false
+	if req.IsAction != nil {
+		isAction = *req.IsAction
+	}
 	menu := &model.Menu{
 		ID:          req.ID,
 		ParentID:    req.ParentID,
 		DisplayName: req.DisplayName,
 		ResType:     req.ResType,
-		IsAction:    req.IsAction,
+		IsAction:    isAction,
 		Priority:    priorityInt,
 		MenuNumber:  menuNumberInt,
 	}
@@ -146,6 +150,27 @@ func (r *MenuRepository) DeleteMenu(id string) error {
 		return ErrMenuNotFound
 	}
 
+	return nil
+}
+
+// DeleteMenuWithChildren CTE로 하위 메뉴 전체를 포함하여 삭제
+func (r *MenuRepository) DeleteMenuWithChildren(id string) error {
+	// PostgreSQL WITH RECURSIVE로 모든 하위 메뉴 ID 수집 후 삭제
+	query := `
+WITH RECURSIVE menu_tree AS (
+  SELECT id FROM mcmp_menus WHERE id = ?
+  UNION ALL
+  SELECT m.id FROM mcmp_menus m INNER JOIN menu_tree mt ON m.parent_id = mt.id
+)
+DELETE FROM mcmp_menus WHERE id IN (SELECT id FROM menu_tree)
+`
+	result := r.db.Exec(query, id)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return ErrMenuNotFound
+	}
 	return nil
 }
 
@@ -325,6 +350,18 @@ func (r *MenuRepository) CreateMenuWithRoleMappings(menu *model.Menu, roleIDs []
 func (r *MenuRepository) DeleteRoleMenuMapping(mappings []*model.RoleMenuMapping) error {
 	query := r.db.Delete(mappings)
 	return query.Error
+}
+
+// DeleteRoleMenuMappingByRoleAndMenu role_id + menu_id 조건으로 매핑 삭제
+func (r *MenuRepository) DeleteRoleMenuMappingByRoleAndMenu(roleID uint, menuID string) error {
+	result := r.db.Where("role_id = ? AND menu_id = ?", roleID, menuID).Delete(&model.RoleMenuMapping{})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return errors.New("mapping not found")
+	}
+	return nil
 }
 
 // 해당 role 과 매핑된 모든 메뉴 매핑 삭제

--- a/src/service/menu_service.go
+++ b/src/service/menu_service.go
@@ -327,12 +327,16 @@ func (s *MenuService) CreateWithRoleMappings(req *model.CreateMenuRequest) (*mod
 	if err != nil {
 		return nil, fmt.Errorf("잘못된 menuNumber 값: %w", err)
 	}
+	isAction := false
+	if req.IsAction != nil {
+		isAction = *req.IsAction
+	}
 	menu := &model.Menu{
 		ID:          req.ID,
 		ParentID:    req.ParentID,
 		DisplayName: req.DisplayName,
 		ResType:     req.ResType,
-		IsAction:    req.IsAction,
+		IsAction:    isAction,
 		Priority:    priorityInt,
 		MenuNumber:  menuNumberInt,
 	}
@@ -364,8 +368,7 @@ func (s *MenuService) Update(id string, updates map[string]interface{}) error {
 
 // Delete 메뉴 삭제
 func (s *MenuService) Delete(id string) error {
-	// TODO: 필요한 비즈니스 로직 추가 (예: 하위 메뉴 처리 등)
-	return s.menuRepo.DeleteMenu(id)
+	return s.menuRepo.DeleteMenuWithChildren(id)
 }
 
 // LoadAndRegisterMenusFromYAML YAML 파일에서 메뉴를 로드하여 DB에 등록(Upsert)
@@ -708,6 +711,11 @@ func (s *MenuService) CreateRoleMenuMappings(mappings []*model.RoleMenuMapping) 
 // DeleteRoleMenuMapping 플랫폼 역할-메뉴 매핑 삭제
 func (s *MenuService) DeleteRoleMenuMapping(mappings []*model.RoleMenuMapping) error {
 	return s.menuRepo.DeleteRoleMenuMapping(mappings)
+}
+
+// DeleteRoleMenuMappingByRoleAndMenu role_id + menu_id 조건으로 매핑 삭제
+func (s *MenuService) DeleteRoleMenuMappingByRoleAndMenu(roleID uint, menuID string) error {
+	return s.menuRepo.DeleteRoleMenuMappingByRoleAndMenu(roleID, menuID)
 }
 
 // 해당 role 과 매핑된 메뉴 삭제


### PR DESCRIPTION
## Summary

- **BUG-MENU-01** (High): `DeleteMenusRolesMapping` `c.Param` → `c.QueryParam` 수정 + `DeleteRoleMenuMappingByRoleAndMenu` 신규 함수 추가
- **BUG-MENU-02** (Medium): `UpdateMenu`에서 `isAction` 미지정 시 `false`로 덮어쓰는 버그 수정 — `CreateMenuRequest.IsAction` `bool` → `*bool`
- **BUG-MENU-03** (Low): Swagger 주석 라우트 경로 수정 (`/api/menus/tree/list` → `/api/menus/menus-tree/list`)
- **BUG-MENU-04** (Medium): `GetMenuByID` / `DeleteMenu`에서 `ErrMenuNotFound` → 500 반환 버그 수정 → 404 반환
- **BUG-MENU-05** (High): 부모 메뉴 삭제 시 하위 메뉴 미삭제 — `DeleteMenuWithChildren` (PostgreSQL `WITH RECURSIVE` CTE) 추가

## Test plan

- [x] 23개 API TC 실행 (23/23 PASS)
- [x] `go build ./...` 성공 확인
- [x] 버그 수정 후 재검증 완료
- [x] 테스트 결과서: `mc-iam-manager-spec` feature/fr-007-01-menu-test 브랜치