### PR TITLE
feat(M2-UG): add GET /api/users/me endpoint for self profile retrieval

### DIFF
--- a/src/handler/user_handler.go
+++ b/src/handler/user_handler.go
@@ -338,6 +338,35 @@ func (h *UserHandler) ResetUserPassword(c echo.Context) error {
 	})
 }
 
+// GetMyInfo godoc
+// @Summary Get my info
+// @Description Get the authenticated user's own profile information. No PlatformRole required.
+// @Tags users
+// @Produce json
+// @Success 200 {object} model.User
+// @Failure 401 {object} map[string]string
+// @Failure 404 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Security BearerAuth
+// @Router /api/users/me [get]
+// @Id getMyInfo
+func (h *UserHandler) GetMyInfo(c echo.Context) error {
+	kcUserIdVal := c.Get("kcUserId")
+	if kcUserIdVal == nil {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "Unauthorized"})
+	}
+	kcUserID, ok := kcUserIdVal.(string)
+	if !ok || kcUserID == "" {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "Unauthorized"})
+	}
+
+	user, err := h.userService.GetUserByKcID(c.Request().Context(), kcUserID)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, map[string]string{"error": "User not found"})
+	}
+	return c.JSON(http.StatusOK, user)
+}
+
 // ChangeMyPassword godoc
 // @Summary Change my password
 // @Description Change the authenticated user's own password. Requires current password for verification.

--- a/src/main.go
+++ b/src/main.go
@@ -347,6 +347,7 @@ func main() {
 		users.DELETE("/id/:userId", userHandler.DeleteUser, middleware.PlatformRoleMiddleware(middleware.Manage))
 		users.POST("/id/:userId/status", userHandler.UpdateUserStatus, middleware.PlatformRoleMiddleware(middleware.Manage))
 		users.PUT("/id/:userId/password", userHandler.ResetUserPassword, middleware.PlatformRoleMiddleware(middleware.Manage))
+		users.GET("/me", userHandler.GetMyInfo)                  // 사용자 본인 정보 조회
 		users.PUT("/me/password", userHandler.ChangeMyPassword) // 사용자 본인 패스워드 변경
 
 		users.POST("/menus-tree/list", menuHandler.ListUserMenuTree)


### PR DESCRIPTION
## Summary

- `GET /api/users/me` 엔드포인트 추가 (RQ-M2-UG-006)
- 로그인한 사용자가 PlatformRole 없이 자신의 프로필 정보를 조회 가능
- 기존 `ChangeMyPassword`와 동일한 `c.Get("kcUserId")` → `GetUserByKcID()` 패턴 재사용 (신규 서비스/레포 없음)

## Changes

- `src/handler/user_handler.go` — `GetMyInfo` 핸들러 추가 (+29줄)
- `src/main.go` — `users.GET("/me", userHandler.GetMyInfo)` 라우트 등록 (+1줄)

## Test

- TC-M2-UG-043-01: `GET /api/users/me` 정상 조회 → HTTP 200 ✅
- TC-M2-UG-043-02: 토큰 없음 → HTTP 401 ✅
- GATE 3: PASS (FAIL 0건)

## Related

- RQ-M2-UG-006 (REQUIREMENTS-ALL.md 미구현 → 구현 완료)
- API-SPEC: `design/08-API-SPEC/M2-UG/043-API-M2-UG-043.md`