### PR TITLE
feat(M4-CSP): GCP WIF 기반 임시 자격증명 발급 구현

### DIFF
--- a/src/model/csp_credential.go
+++ b/src/model/csp_credential.go
@@ -9,15 +9,16 @@ type CspCredentialRequest struct {
 	Region      string `json:"region"`      // AWS 리전 (선택적)
 }
 
-// CspCredentialResponse CSP 임시 자격 증명 발급 응답 모델 (현재는 AWS STS 기준)
-// TODO: 추후 다른 CSP 지원 시 구조 확장 또는 인터페이스 사용 고려
+// CspCredentialResponse CSP 임시 자격 증명 발급 응답 모델
 type CspCredentialResponse struct {
-	CspType         string    `json:"cspType"`          // e.g., "aws"
-	AccessKeyId     string    `json:"accessKeyId"`      // AWS Access Key ID
-	SecretAccessKey string    `json:"secretAccessKey"`  // AWS Secret Access Key
-	SessionToken    string    `json:"sessionToken"`     // AWS Session Token
-	Expiration      time.Time `json:"expiration"`       // Expiration time
-	Region          string    `json:"region,omitempty"` // Optional: AWS Region
+	CspType         string    `json:"cspType"`                    // e.g., "aws", "gcp"
+	AccessKeyId     string    `json:"accessKeyId,omitempty"`      // AWS Access Key ID
+	SecretAccessKey string    `json:"secretAccessKey,omitempty"`  // AWS Secret Access Key
+	SessionToken    string    `json:"sessionToken,omitempty"`     // AWS Session Token
+	AccessToken     string    `json:"accessToken,omitempty"`      // GCP OAuth2 Access Token
+	TokenType       string    `json:"tokenType,omitempty"`        // GCP Token Type (Bearer)
+	Expiration      time.Time `json:"expiration"`                 // Expiration time
+	Region          string    `json:"region,omitempty"`           // Optional: AWS Region
 }
 
 // TempCredential 임시 자격 증명 관리 테이블 모델

--- a/src/service/csp_credential_service.go
+++ b/src/service/csp_credential_service.go
@@ -21,13 +21,12 @@ var (
 
 // CspCredentialService CSP 임시 자격 증명 발급 조율 서비스
 type CspCredentialService struct {
-	db             *gorm.DB
-	userRepo       *repository.UserRepository       // To get user roles
-	mappingRepo    *repository.CspMappingRepository // To get CSP role mapping
-	awsCredService AwsCredentialService             // To call AWS STS
-	// gcpCredService GcpCredentialService             // For future GCP support
-	// azureCredService AzureCredentialService           // For future Azure support
-	keycloakService KeycloakService // To get KcId from token
+	db               *gorm.DB
+	userRepo         *repository.UserRepository       // To get user roles
+	mappingRepo      *repository.CspMappingRepository // To get CSP role mapping
+	awsCredService   AwsCredentialService             // To call AWS STS
+	gcpCredService   GcpCredentialService             // To call GCP WIF
+	keycloakService  KeycloakService                  // To get KcId from token
 }
 
 // NewCspCredentialService 새 CspCredentialService 인스턴스 생성
@@ -35,12 +34,14 @@ func NewCspCredentialService(db *gorm.DB) *CspCredentialService {
 	userRepo := repository.NewUserRepository(db)
 	mappingRepo := repository.NewCspMappingRepository(db)
 	awsCredService := NewAwsCredentialService()
+	gcpCredService := NewGcpCredentialService()
 	keycloakService := NewKeycloakService()
 	return &CspCredentialService{
 		db:              db,
 		userRepo:        userRepo,
 		mappingRepo:     mappingRepo,
 		awsCredService:  awsCredService,
+		gcpCredService:  gcpCredService,
 		keycloakService: keycloakService,
 	}
 }
@@ -142,8 +143,12 @@ func (s *CspCredentialService) GetTemporaryCredentials(ctx context.Context, user
 		log.Printf("[CSP_CREDENTIAL] Calling AWS AssumeRoleWithWebIdentity...")
 		return s.awsCredService.AssumeRoleWithWebIdentity(ctx, roleArn, kcUserId, impersonationToken.AccessToken, idpArn, region)
 	case "gcp":
-		log.Printf("[CSP_CREDENTIAL] Error: GCP not supported yet")
-		return nil, ErrUnsupportedCspType
+		if s.gcpCredService == nil {
+			log.Printf("[CSP_CREDENTIAL] Error: GCP credential service is nil")
+			return nil, fmt.Errorf("GCP credential service is not initialized")
+		}
+		log.Printf("[CSP_CREDENTIAL] Calling GCP WIF ExchangeTokenAndImpersonate...")
+		return s.gcpCredService.ExchangeTokenAndImpersonate(ctx, idpArn, roleArn, impersonationToken.AccessToken)
 	case "azure":
 		log.Printf("[CSP_CREDENTIAL] Error: Azure not supported yet")
 		// TODO: Implement Azure credential logic using azureCredService

--- a/src/service/gcp_credential_service.go
+++ b/src/service/gcp_credential_service.go
@@ -1,0 +1,189 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/m-cmp/mc-iam-manager/model"
+)
+
+// GcpCredentialService defines operations for obtaining GCP temporary credentials
+// via Workload Identity Federation (WIF).
+type GcpCredentialService interface {
+	ExchangeTokenAndImpersonate(
+		ctx context.Context,
+		wifProviderResourceName string,
+		serviceAccountEmail string,
+		webIdentityToken string,
+	) (*model.CspCredentialResponse, error)
+}
+
+type gcpCredentialService struct{}
+
+// NewGcpCredentialService creates a new GcpCredentialService.
+func NewGcpCredentialService() GcpCredentialService {
+	return &gcpCredentialService{}
+}
+
+// gcpStsResponse represents the response from GCP STS token exchange.
+type gcpStsResponse struct {
+	AccessToken     string `json:"access_token"`
+	IssuedTokenType string `json:"issued_token_type"`
+	TokenType       string `json:"token_type"`
+	ExpiresIn       int    `json:"expires_in"`
+}
+
+// gcpGenerateAccessTokenRequest is the request body for SA impersonation.
+type gcpGenerateAccessTokenRequest struct {
+	Scope    []string `json:"scope"`
+	Lifetime string   `json:"lifetime,omitempty"`
+}
+
+// gcpGenerateAccessTokenResponse is the response from SA impersonation.
+type gcpGenerateAccessTokenResponse struct {
+	AccessToken string `json:"accessToken"`
+	ExpireTime  string `json:"expireTime"`
+}
+
+// ExchangeTokenAndImpersonate exchanges a Keycloak OIDC token for a GCP OAuth2
+// access token using the two-step Workload Identity Federation flow:
+//  1. STS token exchange: Keycloak JWT → GCP federated access token
+//  2. Service Account impersonation: federated token → SA access token
+func (s *gcpCredentialService) ExchangeTokenAndImpersonate(
+	ctx context.Context,
+	wifProviderResourceName string,
+	serviceAccountEmail string,
+	webIdentityToken string,
+) (*model.CspCredentialResponse, error) {
+	log.Printf("[GCP_CREDENTIAL] Starting WIF token exchange for SA: %s", serviceAccountEmail)
+
+	// Step 1: Exchange Keycloak JWT for GCP federated access token via GCP STS
+	federatedToken, err := s.exchangeToken(ctx, wifProviderResourceName, webIdentityToken)
+	if err != nil {
+		log.Printf("[GCP_CREDENTIAL] STS token exchange failed: %v", err)
+		return nil, fmt.Errorf("GCP STS token exchange failed: %w", err)
+	}
+	log.Printf("[GCP_CREDENTIAL] STS token exchange succeeded")
+
+	// Step 2: Use federated token to impersonate Service Account
+	saToken, expireTime, err := s.generateAccessToken(ctx, serviceAccountEmail, federatedToken)
+	if err != nil {
+		log.Printf("[GCP_CREDENTIAL] SA impersonation failed: %v", err)
+		return nil, fmt.Errorf("GCP SA impersonation failed: %w", err)
+	}
+	log.Printf("[GCP_CREDENTIAL] SA impersonation succeeded, expiry: %s", expireTime)
+
+	return &model.CspCredentialResponse{
+		CspType:     "gcp",
+		AccessToken: saToken,
+		TokenType:   "Bearer",
+		Expiration:  expireTime,
+	}, nil
+}
+
+// exchangeToken calls GCP STS to exchange a Keycloak JWT for a federated access token.
+func (s *gcpCredentialService) exchangeToken(ctx context.Context, audience, webIdentityToken string) (string, error) {
+	stsURL := "https://sts.googleapis.com/v1/token"
+
+	formData := url.Values{}
+	formData.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
+	formData.Set("subject_token", webIdentityToken)
+	formData.Set("subject_token_type", "urn:ietf:params:oauth:token-type:jwt")
+	formData.Set("requested_token_type", "urn:ietf:params:oauth:token-type:access_token")
+	formData.Set("audience", audience)
+	formData.Set("scope", "https://www.googleapis.com/auth/cloud-platform")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, stsURL, strings.NewReader(formData.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("failed to create STS request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("STS request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read STS response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GCP STS returned HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	var stsResp gcpStsResponse
+	if err := json.Unmarshal(body, &stsResp); err != nil {
+		return "", fmt.Errorf("failed to parse STS response: %w", err)
+	}
+
+	if stsResp.AccessToken == "" {
+		return "", fmt.Errorf("GCP STS returned empty access_token")
+	}
+
+	return stsResp.AccessToken, nil
+}
+
+// generateAccessToken calls GCP IAM Credentials API to impersonate a Service Account.
+func (s *gcpCredentialService) generateAccessToken(ctx context.Context, serviceAccountEmail, federatedToken string) (string, time.Time, error) {
+	iamURL := fmt.Sprintf(
+		"https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken",
+		serviceAccountEmail,
+	)
+
+	reqBody := gcpGenerateAccessTokenRequest{
+		Scope: []string{"https://www.googleapis.com/auth/cloud-platform"},
+	}
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("failed to marshal generateAccessToken request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, iamURL, strings.NewReader(string(bodyBytes)))
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("failed to create generateAccessToken request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+federatedToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("generateAccessToken request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("failed to read generateAccessToken response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", time.Time{}, fmt.Errorf("GCP IAM Credentials returned HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResp gcpGenerateAccessTokenResponse
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return "", time.Time{}, fmt.Errorf("failed to parse generateAccessToken response: %w", err)
+	}
+
+	if tokenResp.AccessToken == "" {
+		return "", time.Time{}, fmt.Errorf("GCP IAM Credentials returned empty accessToken")
+	}
+
+	expireTime, err := time.Parse(time.RFC3339, tokenResp.ExpireTime)
+	if err != nil {
+		log.Printf("[GCP_CREDENTIAL] Warning: failed to parse expireTime %q: %v, using 1h from now", tokenResp.ExpireTime, err)
+		expireTime = time.Now().Add(time.Hour)
+	}
+
+	return tokenResp.AccessToken, expireTime, nil
+}


### PR DESCRIPTION
## Summary

- `gcp_credential_service.go` 신규 생성: GCP Workload Identity Federation 2단계 흐름 구현
  - Step 1: `sts.googleapis.com/v1/token` — Keycloak JWT → GCP federated access token
  - Step 2: `iamcredentials.googleapis.com` — Service Account impersonation → OAuth2 access_token
- `csp_credential_service.go`: `case "gcp":` 분기 추가 및 `gcpCredService` DI 연결
- `model/csp_credential.go`: GCP 응답 필드(`accessToken`, `tokenType`) 추가 및 기존 AWS 필드에 `omitempty` 적용

## Test plan

- [x] `go build ./...` 빌드 성공
- [x] TC-M4-CSP-GCP-032-02: 인증 토큰 없음 → 401 PASS
- [x] TC-M4-CSP-GCP-032-01, 03: GCP WIF 환경 필요 — SKIP (코드 검토 완료)
- [x] 기존 AWS 플로우 회귀 없음 확인 (`case "aws":` 분기 미변경)

## Related

- FR-M4-CSP-032-01
- RQ-M4-CSP-032