### PR TITLE
feat(M4-CSP): Alibaba RAM SAML 기반 임시 자격증명 발급 구현

### DIFF
--- a/src/constants/constants.go
+++ b/src/constants/constants.go
@@ -18,9 +18,10 @@ const (
 	AuthMethodOIDC AuthMethod = "OIDC"
 	AuthMethodSAML AuthMethod = "SAML"
 
-	CSPTypeAWS   CSPType = "aws"
-	CSPTypeGCP   CSPType = "gcp"
-	CSPTypeAzure CSPType = "azure"
+	CSPTypeAWS     CSPType = "aws"
+	CSPTypeGCP     CSPType = "gcp"
+	CSPTypeAzure   CSPType = "azure"
+	CSPTypeAlibaba CSPType = "alibaba"
 
 	CspRoleNamePrefix = "mciam-" // csp에 role을 추가할 때 접두사를 붙인다.
 )

--- a/src/handler/csp_account_handler.go
+++ b/src/handler/csp_account_handler.go
@@ -49,8 +49,8 @@ func (h *CspAccountHandler) CreateCspAccount(c echo.Context) error {
 	if req.CspType == "" {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "CSP type is required"})
 	}
-	if req.CspType != "aws" && req.CspType != "gcp" && req.CspType != "azure" {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid CSP type. Must be one of: aws, gcp, azure"})
+	if req.CspType != "aws" && req.CspType != "gcp" && req.CspType != "azure" && req.CspType != "alibaba" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid CSP type. Must be one of: aws, gcp, azure, alibaba"})
 	}
 
 	account, err := h.cspAccountService.CreateCspAccount(&req)

--- a/src/model/csp_credential.go
+++ b/src/model/csp_credential.go
@@ -17,8 +17,10 @@ type CspCredentialResponse struct {
 	SessionToken    string    `json:"sessionToken,omitempty"`     // AWS Session Token
 	AccessToken     string    `json:"accessToken,omitempty"`      // GCP OAuth2 Access Token
 	TokenType       string    `json:"tokenType,omitempty"`        // GCP Token Type (Bearer)
+	AccessKeySecret string    `json:"accessKeySecret,omitempty"`  // Alibaba STS Access Key Secret
+	SecurityToken   string    `json:"securityToken,omitempty"`    // Alibaba STS Security Token
 	Expiration      time.Time `json:"expiration"`                 // Expiration time
-	Region          string    `json:"region,omitempty"`           // Optional: AWS Region
+	Region          string    `json:"region,omitempty"`           // Optional: AWS/Alibaba Region
 }
 
 // TempCredential 임시 자격 증명 관리 테이블 모델

--- a/src/service/alibaba_credential_service.go
+++ b/src/service/alibaba_credential_service.go
@@ -1,0 +1,144 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/m-cmp/mc-iam-manager/model"
+)
+
+// AlibabaCredentialService defines operations for obtaining Alibaba Cloud
+// temporary credentials via RAM AssumeRoleWithSAML.
+type AlibabaCredentialService interface {
+	AssumeRoleWithSAML(
+		ctx context.Context,
+		samlProviderArn string,
+		roleArn string,
+		samlAssertion string,
+		region string,
+	) (*model.CspCredentialResponse, error)
+}
+
+type alibabaCredentialService struct{}
+
+// NewAlibabaCredentialService creates a new AlibabaCredentialService.
+func NewAlibabaCredentialService() AlibabaCredentialService {
+	return &alibabaCredentialService{}
+}
+
+// alibabaStsCredentials represents the Credentials block in Alibaba STS response.
+type alibabaStsCredentials struct {
+	AccessKeyId     string `json:"AccessKeyId"`
+	AccessKeySecret string `json:"AccessKeySecret"`
+	SecurityToken   string `json:"SecurityToken"`
+	Expiration      string `json:"Expiration"`
+}
+
+// alibabaStsResponse represents the Alibaba STS AssumeRoleWithSAML response.
+type alibabaStsResponse struct {
+	RequestId   string                `json:"RequestId"`
+	Credentials alibabaStsCredentials `json:"Credentials"`
+}
+
+// alibabaErrorResponse represents an Alibaba STS error response.
+type alibabaErrorResponse struct {
+	RequestId string `json:"RequestId"`
+	HostId    string `json:"HostId"`
+	Code      string `json:"Code"`
+	Message   string `json:"Message"`
+}
+
+const (
+	alibabaStsEndpoint = "https://sts.aliyuncs.com/"
+	alibabaStsVersion  = "2015-04-01"
+)
+
+// AssumeRoleWithSAML calls Alibaba Cloud STS to exchange a SAML assertion
+// for temporary credentials (AccessKeyId + AccessKeySecret + SecurityToken).
+//
+// samlProviderArn: Alibaba RAM SAML provider ARN (e.g., acs:ram::123456:saml-provider/myProvider)
+// roleArn:         Alibaba RAM Role ARN (e.g., acs:ram::123456:role/myRole)
+// samlAssertion:   Base64-encoded SAML2 assertion from Keycloak
+// region:          Alibaba Cloud region (e.g., cn-hangzhou); used in response only
+func (s *alibabaCredentialService) AssumeRoleWithSAML(
+	ctx context.Context,
+	samlProviderArn string,
+	roleArn string,
+	samlAssertion string,
+	region string,
+) (*model.CspCredentialResponse, error) {
+	log.Printf("[ALIBABA_CREDENTIAL] AssumeRoleWithSAML - RoleArn: %s, SAMLProviderArn: %s", roleArn, samlProviderArn)
+
+	sessionName := fmt.Sprintf("mciam-%d", time.Now().Unix())
+	if len(sessionName) > 32 {
+		sessionName = sessionName[:32]
+	}
+
+	formData := url.Values{}
+	formData.Set("Action", "AssumeRoleWithSAML")
+	formData.Set("Version", alibabaStsVersion)
+	formData.Set("RoleArn", roleArn)
+	formData.Set("SAMLProviderArn", samlProviderArn)
+	formData.Set("SAMLAssertion", samlAssertion)
+	formData.Set("RoleSessionName", sessionName)
+	formData.Set("Format", "JSON")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, alibabaStsEndpoint, strings.NewReader(formData.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Alibaba STS request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("Alibaba STS request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Alibaba STS response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp alibabaErrorResponse
+		if jsonErr := json.Unmarshal(body, &errResp); jsonErr == nil && errResp.Code != "" {
+			return nil, fmt.Errorf("Alibaba STS error [%s]: %s", errResp.Code, errResp.Message)
+		}
+		return nil, fmt.Errorf("Alibaba STS returned HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	var stsResp alibabaStsResponse
+	if err := json.Unmarshal(body, &stsResp); err != nil {
+		return nil, fmt.Errorf("failed to parse Alibaba STS response: %w", err)
+	}
+
+	creds := stsResp.Credentials
+	if creds.AccessKeyId == "" || creds.AccessKeySecret == "" {
+		return nil, fmt.Errorf("Alibaba STS returned empty credentials")
+	}
+
+	expiration, err := time.Parse(time.RFC3339, creds.Expiration)
+	if err != nil {
+		log.Printf("[ALIBABA_CREDENTIAL] Warning: failed to parse Expiration %q: %v, using 1h from now", creds.Expiration, err)
+		expiration = time.Now().Add(time.Hour)
+	}
+
+	log.Printf("[ALIBABA_CREDENTIAL] AssumeRoleWithSAML succeeded, Expiration: %s", expiration)
+
+	return &model.CspCredentialResponse{
+		CspType:         "alibaba",
+		AccessKeyId:     creds.AccessKeyId,
+		AccessKeySecret: creds.AccessKeySecret,
+		SecurityToken:   creds.SecurityToken,
+		Expiration:      expiration,
+		Region:          region,
+	}, nil
+}

--- a/src/service/csp_credential_service.go
+++ b/src/service/csp_credential_service.go
@@ -21,12 +21,13 @@ var (
 
 // CspCredentialService CSP 임시 자격 증명 발급 조율 서비스
 type CspCredentialService struct {
-	db               *gorm.DB
-	userRepo         *repository.UserRepository       // To get user roles
-	mappingRepo      *repository.CspMappingRepository // To get CSP role mapping
-	awsCredService   AwsCredentialService             // To call AWS STS
-	gcpCredService   GcpCredentialService             // To call GCP WIF
-	keycloakService  KeycloakService                  // To get KcId from token
+	db                     *gorm.DB
+	userRepo               *repository.UserRepository       // To get user roles
+	mappingRepo            *repository.CspMappingRepository // To get CSP role mapping
+	awsCredService         AwsCredentialService             // To call AWS STS
+	gcpCredService         GcpCredentialService             // To call GCP WIF
+	alibabaCredService     AlibabaCredentialService         // To call Alibaba RAM STS
+	keycloakService        KeycloakService                  // To get KcId from token
 }
 
 // NewCspCredentialService 새 CspCredentialService 인스턴스 생성
@@ -35,14 +36,16 @@ func NewCspCredentialService(db *gorm.DB) *CspCredentialService {
 	mappingRepo := repository.NewCspMappingRepository(db)
 	awsCredService := NewAwsCredentialService()
 	gcpCredService := NewGcpCredentialService()
+	alibabaCredService := NewAlibabaCredentialService()
 	keycloakService := NewKeycloakService()
 	return &CspCredentialService{
-		db:              db,
-		userRepo:        userRepo,
-		mappingRepo:     mappingRepo,
-		awsCredService:  awsCredService,
-		gcpCredService:  gcpCredService,
-		keycloakService: keycloakService,
+		db:                 db,
+		userRepo:           userRepo,
+		mappingRepo:        mappingRepo,
+		awsCredService:     awsCredService,
+		gcpCredService:     gcpCredService,
+		alibabaCredService: alibabaCredService,
+		keycloakService:    keycloakService,
 	}
 }
 
@@ -149,6 +152,26 @@ func (s *CspCredentialService) GetTemporaryCredentials(ctx context.Context, user
 		}
 		log.Printf("[CSP_CREDENTIAL] Calling GCP WIF ExchangeTokenAndImpersonate...")
 		return s.gcpCredService.ExchangeTokenAndImpersonate(ctx, idpArn, roleArn, impersonationToken.AccessToken)
+	case "alibaba":
+		if s.alibabaCredService == nil {
+			log.Printf("[CSP_CREDENTIAL] Error: Alibaba credential service is nil")
+			return nil, fmt.Errorf("Alibaba credential service is not initialized")
+		}
+		log.Printf("[CSP_CREDENTIAL] Getting SAML assertion for Alibaba...")
+		// idpArn = Alibaba SAML Provider ARN (acs:ram::accountId:saml-provider/...)
+		// roleArn = Alibaba RAM Role ARN (acs:ram::accountId:role/...)
+		// SAML client audience: cspRole.ExtendedConfig["saml_client_id"] 우선, 없으면 idpArn 사용
+		samlClientAudience := idpArn
+		if extConfig, ok := targetCspRole.ExtendedConfig["saml_client_id"].(string); ok && extConfig != "" {
+			samlClientAudience = extConfig
+		}
+		samlAssertion, err := s.keycloakService.GetSamlAssertionByServiceAccount(ctx, samlClientAudience)
+		if err != nil {
+			log.Printf("[CSP_CREDENTIAL] Error getting SAML assertion: %v", err)
+			return nil, fmt.Errorf("failed to get SAML assertion for Alibaba: %w", err)
+		}
+		log.Printf("[CSP_CREDENTIAL] Calling Alibaba AssumeRoleWithSAML...")
+		return s.alibabaCredService.AssumeRoleWithSAML(ctx, idpArn, roleArn, samlAssertion, region)
 	case "azure":
 		log.Printf("[CSP_CREDENTIAL] Error: Azure not supported yet")
 		// TODO: Implement Azure credential logic using azureCredService

--- a/src/service/keycloak_service.go
+++ b/src/service/keycloak_service.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 
 	"github.com/Nerzal/gocloak/v13"
 	"github.com/golang-jwt/jwt/v5"
@@ -60,6 +61,8 @@ type KeycloakService interface {
 	GetImpersonationTokenByAdminToken(ctx context.Context, userID string, targetClientID string) (string, error)
 	// GetImpersonationTokenByServiceAccount: 서비스 계정을 이용해 특정 클라이언트에 로그인한 토큰을 발급
 	GetImpersonationTokenByServiceAccount(ctx context.Context) (*gocloak.JWT, error)
+	// GetSamlAssertionByServiceAccount: RFC 8693 토큰 교환으로 SAML2 assertion을 발급 (Alibaba SAML 연동용)
+	GetSamlAssertionByServiceAccount(ctx context.Context, samlClientAudience string) (string, error)
 	// AssignRealmRoleToUser assigns a realm role to a user
 	AssignRealmRoleToUser(ctx context.Context, kcUserId, roleName string) error
 	// CheckRealmRoleExists checks if a realm role exists
@@ -1272,6 +1275,76 @@ func (s *keycloakService) GetImpersonationTokenByServiceAccount(ctx context.Cont
 	}
 
 	return token, nil
+}
+
+// GetSamlAssertionByServiceAccount: RFC 8693 토큰 교환으로 SAML2 assertion을 발급한다.
+// OIDC 클라이언트 client_credentials로 JWT를 먼저 발급한 후,
+// requested_token_type=urn:ietf:params:oauth:token-type:saml2 로 교환하여 SAML assertion 반환.
+// samlClientAudience: Keycloak에 등록된 SAML 클라이언트 ID (e.g., "mciam-alibaba-saml")
+func (s *keycloakService) GetSamlAssertionByServiceAccount(ctx context.Context, samlClientAudience string) (string, error) {
+	if config.KC == nil || config.KC.Client == nil {
+		return "", fmt.Errorf("keycloak configuration not initialized")
+	}
+
+	clientName := config.KC.OIDCClientName
+	clientSecret := config.KC.OIDCClientSecret
+	if clientName == "" || clientSecret == "" {
+		return "", fmt.Errorf("OIDC client credentials not configured")
+	}
+
+	// Step 1: OIDC client_credentials로 access token 발급
+	oidcToken, err := config.KC.Client.LoginClient(ctx, clientName, clientSecret, config.KC.Realm)
+	if err != nil {
+		return "", fmt.Errorf("failed to get OIDC client token: %w", err)
+	}
+
+	// Step 2: RFC 8693 토큰 교환 — access token → SAML2 assertion
+	tokenURL := fmt.Sprintf("%s/realms/%s/protocol/openid-connect/token", config.KC.Host, config.KC.Realm)
+
+	formData := url.Values{}
+	formData.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
+	formData.Set("client_id", clientName)
+	formData.Set("client_secret", clientSecret)
+	formData.Set("subject_token", oidcToken.AccessToken)
+	formData.Set("subject_token_type", "urn:ietf:params:oauth:token-type:access_token")
+	formData.Set("requested_token_type", "urn:ietf:params:oauth:token-type:saml2")
+	formData.Set("audience", samlClientAudience)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(formData.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("failed to create SAML exchange request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("SAML token exchange request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read SAML exchange response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Keycloak SAML exchange returned HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResp struct {
+		AccessToken     string `json:"access_token"`
+		IssuedTokenType string `json:"issued_token_type"`
+	}
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return "", fmt.Errorf("failed to parse SAML exchange response: %w", err)
+	}
+
+	if tokenResp.AccessToken == "" {
+		return "", fmt.Errorf("Keycloak returned empty SAML assertion")
+	}
+
+	log.Printf("[KEYCLOAK] SAML assertion exchange succeeded for audience: %s", samlClientAudience)
+	return tokenResp.AccessToken, nil
 }
 
 // AssignRealmRoleToUser assigns a realm role to a user


### PR DESCRIPTION
## Summary

- `alibaba_credential_service.go` 신규 생성: Alibaba RAM `AssumeRoleWithSAML` HTTP 직접 호출
- `keycloak_service.go`: `GetSamlAssertionByServiceAccount()` 추가 — RFC 8693 token exchange로 OIDC JWT → SAML2 assertion 교환
- `csp_credential_service.go`: `case "alibaba":` 분기 추가, SAML assertion 취득 후 STS 호출
- `constants/constants.go`: `CSPTypeAlibaba = "alibaba"` 추가
- `model/csp_credential.go`: `accessKeySecret`, `securityToken` 필드 추가 (omitempty)
- `handler/csp_account_handler.go`: CSP 타입 enum에 `"alibaba"` 추가

### GCP WIF와의 차이점

| 항목 | GCP (PR #72) | Alibaba (이 PR) |
|------|-------------|----------------|
| Keycloak 토큰 | OIDC JWT | **SAML2 assertion** (RFC 8693 교환) |
| STS 호출 | 2단계 (STS exchange + SA impersonation) | 1단계 (`AssumeRoleWithSAML`) |
| 응답 필드 | `accessToken`/`tokenType` | `accessKeySecret`/`securityToken` |

## Test plan

- [x] `go build ./...` 빌드 성공
- [x] TC-M4-CSP-ALIBABA-032-02: 인증 토큰 없음 → 401 PASS
- [x] TC-M4-CSP-ALIBABA-032-01: Alibaba SAML 환경 필요 — SKIP (코드 검토 완료)
- [x] 기존 AWS/GCP 플로우 회귀 없음 확인

## Related

- FR-M4-CSP-ALIBABA-01
- ENV-SETUP-ALIBABA-SAML-033.md (환경 설정 가이드)