### PR TITLE
feat(M4-CSP-035): CSP별 임시자격증명 인증방식 확장 (GCP SAML, Alibaba OIDC, Azure, Tencent, IBM)

### DIFF
--- a/src/service/alibaba_credential_service.go
+++ b/src/service/alibaba_credential_service.go
@@ -15,13 +15,21 @@ import (
 )
 
 // AlibabaCredentialService defines operations for obtaining Alibaba Cloud
-// temporary credentials via RAM AssumeRoleWithSAML.
+// temporary credentials via RAM federation.
 type AlibabaCredentialService interface {
 	AssumeRoleWithSAML(
 		ctx context.Context,
 		samlProviderArn string,
 		roleArn string,
 		samlAssertion string,
+		region string,
+	) (*model.CspCredentialResponse, error)
+
+	AssumeRoleWithOIDC(
+		ctx context.Context,
+		oidcProviderArn string,
+		roleArn string,
+		oidcToken string,
 		region string,
 	) (*model.CspCredentialResponse, error)
 }
@@ -132,6 +140,89 @@ func (s *alibabaCredentialService) AssumeRoleWithSAML(
 	}
 
 	log.Printf("[ALIBABA_CREDENTIAL] AssumeRoleWithSAML succeeded, Expiration: %s", expiration)
+
+	return &model.CspCredentialResponse{
+		CspType:         "alibaba",
+		AccessKeyId:     creds.AccessKeyId,
+		AccessKeySecret: creds.AccessKeySecret,
+		SecurityToken:   creds.SecurityToken,
+		Expiration:      expiration,
+		Region:          region,
+	}, nil
+}
+
+// AssumeRoleWithOIDC calls Alibaba Cloud STS to exchange an OIDC token
+// for temporary credentials (AccessKeyId + AccessKeySecret + SecurityToken).
+//
+// oidcProviderArn: Alibaba RAM OIDC provider ARN (e.g., acs:ram::123456:oidc-idp/myProvider)
+// roleArn:         Alibaba RAM Role ARN (e.g., acs:ram::123456:role/myRole)
+// oidcToken:       OIDC ID token (JWT) from Keycloak
+// region:          Alibaba Cloud region (e.g., cn-hangzhou); used in response only
+func (s *alibabaCredentialService) AssumeRoleWithOIDC(
+	ctx context.Context,
+	oidcProviderArn string,
+	roleArn string,
+	oidcToken string,
+	region string,
+) (*model.CspCredentialResponse, error) {
+	log.Printf("[ALIBABA_CREDENTIAL] AssumeRoleWithOIDC - RoleArn: %s, OIDCProviderArn: %s", roleArn, oidcProviderArn)
+
+	sessionName := fmt.Sprintf("mciam-%d", time.Now().Unix())
+	if len(sessionName) > 32 {
+		sessionName = sessionName[:32]
+	}
+
+	formData := url.Values{}
+	formData.Set("Action", "AssumeRoleWithOIDC")
+	formData.Set("Version", alibabaStsVersion)
+	formData.Set("RoleArn", roleArn)
+	formData.Set("OIDCProviderArn", oidcProviderArn)
+	formData.Set("OIDCToken", oidcToken)
+	formData.Set("RoleSessionName", sessionName)
+	formData.Set("Format", "JSON")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, alibabaStsEndpoint, strings.NewReader(formData.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Alibaba STS OIDC request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("Alibaba STS OIDC request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Alibaba STS OIDC response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp alibabaErrorResponse
+		if jsonErr := json.Unmarshal(body, &errResp); jsonErr == nil && errResp.Code != "" {
+			return nil, fmt.Errorf("Alibaba STS OIDC error [%s]: %s", errResp.Code, errResp.Message)
+		}
+		return nil, fmt.Errorf("Alibaba STS OIDC returned HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	var stsResp alibabaStsResponse
+	if err := json.Unmarshal(body, &stsResp); err != nil {
+		return nil, fmt.Errorf("failed to parse Alibaba STS OIDC response: %w", err)
+	}
+
+	creds := stsResp.Credentials
+	if creds.AccessKeyId == "" || creds.AccessKeySecret == "" {
+		return nil, fmt.Errorf("Alibaba STS OIDC returned empty credentials")
+	}
+
+	expiration, err := time.Parse(time.RFC3339, creds.Expiration)
+	if err != nil {
+		log.Printf("[ALIBABA_CREDENTIAL] Warning: failed to parse Expiration %q: %v, using 1h from now", creds.Expiration, err)
+		expiration = time.Now().Add(time.Hour)
+	}
+
+	log.Printf("[ALIBABA_CREDENTIAL] AssumeRoleWithOIDC succeeded, Expiration: %s", expiration)
 
 	return &model.CspCredentialResponse{
 		CspType:         "alibaba",

--- a/src/service/azure_credential_service.go
+++ b/src/service/azure_credential_service.go
@@ -1,0 +1,114 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/m-cmp/mc-iam-manager/model"
+)
+
+// AzureCredentialService defines operations for obtaining Azure temporary
+// access tokens via Workload Identity Federation (Federated Credential).
+type AzureCredentialService interface {
+	GetTokenByFederatedCredential(
+		ctx context.Context,
+		tenantID string,
+		clientID string,
+		keycloakJWT string,
+	) (*model.CspCredentialResponse, error)
+}
+
+type azureCredentialService struct{}
+
+// NewAzureCredentialService creates a new AzureCredentialService.
+func NewAzureCredentialService() AzureCredentialService {
+	return &azureCredentialService{}
+}
+
+// azureTokenResponse represents the OAuth2 token response from Azure AD.
+type azureTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
+}
+
+// azureErrorResponse represents an OAuth2 error response from Azure AD.
+type azureErrorResponse struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+// GetTokenByFederatedCredential exchanges a Keycloak OIDC JWT for an Azure
+// access token using the OAuth2 Federated Credential (Workload Identity Federation) flow.
+//
+// tenantID:    Azure AD tenant ID
+// clientID:    Azure AD application (client) ID registered with a federated credential
+// keycloakJWT: OIDC ID token / access token issued by Keycloak
+func (s *azureCredentialService) GetTokenByFederatedCredential(
+	ctx context.Context,
+	tenantID string,
+	clientID string,
+	keycloakJWT string,
+) (*model.CspCredentialResponse, error) {
+	log.Printf("[AZURE_CREDENTIAL] GetTokenByFederatedCredential - tenantID: %s, clientID: %s", tenantID, clientID)
+
+	tokenURL := fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", tenantID)
+
+	formData := url.Values{}
+	formData.Set("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer")
+	formData.Set("client_id", clientID)
+	formData.Set("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+	formData.Set("client_assertion", keycloakJWT)
+	formData.Set("scope", "https://management.azure.com/.default")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(formData.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Azure token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("Azure token request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Azure token response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp azureErrorResponse
+		if jsonErr := json.Unmarshal(body, &errResp); jsonErr == nil && errResp.Error != "" {
+			return nil, fmt.Errorf("Azure token error [%s]: %s", errResp.Error, errResp.ErrorDescription)
+		}
+		return nil, fmt.Errorf("Azure token endpoint returned HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResp azureTokenResponse
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return nil, fmt.Errorf("failed to parse Azure token response: %w", err)
+	}
+
+	if tokenResp.AccessToken == "" {
+		return nil, fmt.Errorf("Azure token endpoint returned empty access_token")
+	}
+
+	expiration := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+	log.Printf("[AZURE_CREDENTIAL] GetTokenByFederatedCredential succeeded, expires in %ds", tokenResp.ExpiresIn)
+
+	return &model.CspCredentialResponse{
+		CspType:     "azure",
+		AccessToken: tokenResp.AccessToken,
+		TokenType:   tokenResp.TokenType,
+		Expiration:  expiration,
+	}, nil
+}

--- a/src/service/csp_credential_service.go
+++ b/src/service/csp_credential_service.go
@@ -207,8 +207,20 @@ func (s *CspCredentialService) GetTemporaryCredentials(ctx context.Context, user
 				log.Printf("[CSP_CREDENTIAL] Error getting impersonation token: %v", err)
 				return nil, fmt.Errorf("failed to get impersonation token: %w", err)
 			}
-			log.Printf("[CSP_CREDENTIAL] Calling GCP WIF ExchangeTokenAndImpersonate...")
-			return s.gcpCredService.ExchangeTokenAndImpersonate(ctx, idpArn, roleArn, impersonationToken.AccessToken)
+			log.Printf("[CSP_CREDENTIAL] Calling GCP WIF ExchangeTokenAndImpersonate (OIDC)...")
+			return s.gcpCredService.ExchangeTokenAndImpersonate(ctx, idpArn, roleArn, impersonationToken.AccessToken, "jwt")
+		case model.AuthMethodSAML:
+			samlClientAudience := idpArn
+			if extConfig, ok := targetCspRole.ExtendedConfig["saml_client_id"].(string); ok && extConfig != "" {
+				samlClientAudience = extConfig
+			}
+			samlAssertion, err := s.keycloakService.GetSamlAssertionByServiceAccount(ctx, samlClientAudience)
+			if err != nil {
+				log.Printf("[CSP_CREDENTIAL] Error getting SAML assertion for GCP: %v", err)
+				return nil, fmt.Errorf("failed to get SAML assertion for GCP: %w", err)
+			}
+			log.Printf("[CSP_CREDENTIAL] Calling GCP WIF ExchangeTokenAndImpersonate (SAML)...")
+			return s.gcpCredService.ExchangeTokenAndImpersonate(ctx, idpArn, roleArn, samlAssertion, "saml2")
 		case model.AuthMethodSecretKey:
 			return getSecretKeyCredentials(cspType, targetCspRole.CspIdpConfig, region)
 		default:

--- a/src/service/csp_credential_service.go
+++ b/src/service/csp_credential_service.go
@@ -32,15 +32,18 @@ var (
 
 // CspCredentialService CSP 임시 자격 증명 발급 조율 서비스
 type CspCredentialService struct {
-	db                 *gorm.DB
-	userRepo           *repository.UserRepository       // 프로덕션 용
-	mappingRepo        *repository.CspMappingRepository // 프로덕션 용
-	userRepoIface      credUserRepo                     // 테스트 주입용 (nil이면 userRepo 사용)
-	mappingRepoIface   credMappingRepo                  // 테스트 주입용 (nil이면 mappingRepo 사용)
-	awsCredService     AwsCredentialService
-	gcpCredService     GcpCredentialService
-	alibabaCredService AlibabaCredentialService
-	keycloakService    KeycloakService
+	db                  *gorm.DB
+	userRepo            *repository.UserRepository       // 프로덕션 용
+	mappingRepo         *repository.CspMappingRepository // 프로덕션 용
+	userRepoIface       credUserRepo                     // 테스트 주입용 (nil이면 userRepo 사용)
+	mappingRepoIface    credMappingRepo                  // 테스트 주입용 (nil이면 mappingRepo 사용)
+	awsCredService      AwsCredentialService
+	gcpCredService      GcpCredentialService
+	alibabaCredService  AlibabaCredentialService
+	azureCredService    AzureCredentialService
+	tencentCredService  TencentCredentialService
+	ibmCredService      IbmCredentialService
+	keycloakService     KeycloakService
 }
 
 // NewCspCredentialService 새 CspCredentialService 인스턴스 생성
@@ -50,6 +53,9 @@ func NewCspCredentialService(db *gorm.DB) *CspCredentialService {
 	awsCredService := NewAwsCredentialService()
 	gcpCredService := NewGcpCredentialService()
 	alibabaCredService := NewAlibabaCredentialService()
+	azureCredService := NewAzureCredentialService()
+	tencentCredService := NewTencentCredentialService()
+	ibmCredService := NewIbmCredentialService()
 	keycloakService := NewKeycloakService()
 	return &CspCredentialService{
 		db:                 db,
@@ -58,6 +64,9 @@ func NewCspCredentialService(db *gorm.DB) *CspCredentialService {
 		awsCredService:     awsCredService,
 		gcpCredService:     gcpCredService,
 		alibabaCredService: alibabaCredService,
+		azureCredService:   azureCredService,
+		tencentCredService: tencentCredService,
+		ibmCredService:     ibmCredService,
 		keycloakService:    keycloakService,
 	}
 }
@@ -251,7 +260,81 @@ func (s *CspCredentialService) GetTemporaryCredentials(ctx context.Context, user
 		default:
 			return nil, ErrUnsupportedAuthMethod
 		}
-	case "azure", "tencent", "ibm", "ncp", "nhn", "kt", "openstack":
+	case "azure":
+		switch authMethod {
+		case model.AuthMethodOIDC:
+			tenantID := ""
+			clientID := ""
+			if targetCspRole.CspIdpConfig != nil {
+				tenantID = targetCspRole.CspIdpConfig.Config["tenant_id"]
+				clientID = targetCspRole.CspIdpConfig.Config["client_id"]
+			}
+			if tenantID == "" || clientID == "" {
+				return nil, fmt.Errorf("Azure OIDC requires tenant_id and client_id in CspIdpConfig")
+			}
+			impersonationToken, err := s.keycloakService.GetImpersonationTokenByServiceAccount(ctx)
+			if err != nil {
+				log.Printf("[CSP_CREDENTIAL] Error getting impersonation token for Azure: %v", err)
+				return nil, fmt.Errorf("failed to get impersonation token for Azure: %w", err)
+			}
+			log.Printf("[CSP_CREDENTIAL] Calling Azure GetTokenByFederatedCredential...")
+			return s.azureCredService.GetTokenByFederatedCredential(ctx, tenantID, clientID, impersonationToken.AccessToken)
+		case model.AuthMethodSecretKey:
+			return getSecretKeyCredentials(cspType, targetCspRole.CspIdpConfig, region)
+		default:
+			return nil, ErrUnsupportedAuthMethod
+		}
+	case "tencent":
+		switch authMethod {
+		case model.AuthMethodSAML:
+			secretID := ""
+			secretKey := ""
+			if targetCspRole.CspIdpConfig != nil {
+				secretID = targetCspRole.CspIdpConfig.Config["secret_id"]
+				secretKey = targetCspRole.CspIdpConfig.Config["secret_key"]
+			}
+			if secretID == "" || secretKey == "" {
+				return nil, fmt.Errorf("Tencent SAML requires secret_id and secret_key in CspIdpConfig")
+			}
+			samlClientAudience := idpArn
+			if extConfig, ok := targetCspRole.ExtendedConfig["saml_client_id"].(string); ok && extConfig != "" {
+				samlClientAudience = extConfig
+			}
+			samlAssertion, err := s.keycloakService.GetSamlAssertionByServiceAccount(ctx, samlClientAudience)
+			if err != nil {
+				log.Printf("[CSP_CREDENTIAL] Error getting SAML assertion for Tencent: %v", err)
+				return nil, fmt.Errorf("failed to get SAML assertion for Tencent: %w", err)
+			}
+			log.Printf("[CSP_CREDENTIAL] Calling Tencent AssumeRoleWithSAML...")
+			return s.tencentCredService.AssumeRoleWithSAML(ctx, secretID, secretKey, roleArn, idpArn, samlAssertion, region)
+		case model.AuthMethodSecretKey:
+			return getSecretKeyCredentials(cspType, targetCspRole.CspIdpConfig, region)
+		default:
+			return nil, ErrUnsupportedAuthMethod
+		}
+	case "ibm":
+		switch authMethod {
+		case model.AuthMethodOIDC:
+			profileID := ""
+			if targetCspRole.CspIdpConfig != nil {
+				profileID = targetCspRole.CspIdpConfig.Config["profile_id"]
+			}
+			if profileID == "" {
+				return nil, fmt.Errorf("IBM OIDC requires profile_id in CspIdpConfig")
+			}
+			impersonationToken, err := s.keycloakService.GetImpersonationTokenByServiceAccount(ctx)
+			if err != nil {
+				log.Printf("[CSP_CREDENTIAL] Error getting impersonation token for IBM: %v", err)
+				return nil, fmt.Errorf("failed to get impersonation token for IBM: %w", err)
+			}
+			log.Printf("[CSP_CREDENTIAL] Calling IBM GetTokenByTrustedProfile...")
+			return s.ibmCredService.GetTokenByTrustedProfile(ctx, profileID, impersonationToken.AccessToken)
+		case model.AuthMethodSecretKey:
+			return getSecretKeyCredentials(cspType, targetCspRole.CspIdpConfig, region)
+		default:
+			return nil, ErrUnsupportedAuthMethod
+		}
+	case "ncp", "nhn", "kt", "openstack":
 		switch authMethod {
 		case model.AuthMethodSecretKey:
 			return getSecretKeyCredentials(cspType, targetCspRole.CspIdpConfig, region)

--- a/src/service/csp_credential_service.go
+++ b/src/service/csp_credential_service.go
@@ -162,10 +162,8 @@ func (s *CspCredentialService) GetTemporaryCredentials(ctx context.Context, user
 	}
 	if authMethod == "" {
 		switch cspType {
-		case "aws", "gcp":
+		case "aws", "gcp", "alibaba":
 			authMethod = model.AuthMethodOIDC
-		case "alibaba":
-			authMethod = model.AuthMethodSAML
 		}
 	}
 	log.Printf("[CSP_CREDENTIAL] Auth method resolved: cspType=%s, authMethod=%s", cspType, authMethod)
@@ -228,6 +226,14 @@ func (s *CspCredentialService) GetTemporaryCredentials(ctx context.Context, user
 		}
 	case "alibaba":
 		switch authMethod {
+		case model.AuthMethodOIDC:
+			impersonationToken, err := s.keycloakService.GetImpersonationTokenByServiceAccount(ctx)
+			if err != nil {
+				log.Printf("[CSP_CREDENTIAL] Error getting impersonation token for Alibaba: %v", err)
+				return nil, fmt.Errorf("failed to get impersonation token for Alibaba: %w", err)
+			}
+			log.Printf("[CSP_CREDENTIAL] Calling Alibaba AssumeRoleWithOIDC...")
+			return s.alibabaCredService.AssumeRoleWithOIDC(ctx, idpArn, roleArn, impersonationToken.AccessToken, region)
 		case model.AuthMethodSAML:
 			samlClientAudience := idpArn
 			if extConfig, ok := targetCspRole.ExtendedConfig["saml_client_id"].(string); ok && extConfig != "" {

--- a/src/service/csp_credential_service_test.go
+++ b/src/service/csp_credential_service_test.go
@@ -341,7 +341,7 @@ func TestGetTemporaryCredentials_Alibaba_OIDC_KeycloakFail(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to get impersonation token for Alibaba")
 }
 
-// ── Azure / 기타 ──────────────────────────────────────────────────────────────
+// ── Azure ─────────────────────────────────────────────────────────────────────
 
 // TC-CRED-15: Azure SECRET_KEY — 정상 반환
 func TestGetTemporaryCredentials_Azure_SecretKey_Success(t *testing.T) {
@@ -353,6 +353,9 @@ func TestGetTemporaryCredentials_Azure_SecretKey_Success(t *testing.T) {
 		aws:      &mockAwsCredService{},
 		gcp:      &mockGcpCredService{},
 		alibaba:  &mockAlibabaCredService{},
+		azure:    &mockAzureCredService{},
+		tencent:  &mockTencentCredService{},
+		ibm:      &mockIbmCredService{},
 		kc:       &mockKeycloakForCred{},
 		userRepo: &mockUserRepoForCred{role: stdUserRole()},
 		mapRepo:  &mockCspMappingRepo{mapping: buildMapping(constants.AuthMethodSecretKey, idpArn, roleArn, model.AuthMethodSecretKey, config)},
@@ -363,30 +366,172 @@ func TestGetTemporaryCredentials_Azure_SecretKey_Success(t *testing.T) {
 	assert.Equal(t, "azure_client_id", cred.AccessKeyId)
 }
 
-// TC-CRED-16: Azure OIDC — 미구현 → ErrUnsupportedAuthMethod
-func TestGetTemporaryCredentials_Azure_OIDC_Unsupported(t *testing.T) {
+// TC-CRED-16: Azure OIDC — 정상 발급
+func TestGetTemporaryCredentials_Azure_OIDC_Success(t *testing.T) {
+	config := map[string]string{
+		"tenant_id": "my-tenant-id",
+		"client_id": "my-client-id",
+	}
 	svc := newCredServiceWithMocks(credServiceDeps{
 		aws:      &mockAwsCredService{},
 		gcp:      &mockGcpCredService{},
 		alibaba:  &mockAlibabaCredService{},
-		kc:       &mockKeycloakForCred{},
+		azure:    &mockAzureCredService{result: azureOidcCred},
+		tencent:  &mockTencentCredService{},
+		ibm:      &mockIbmCredService{},
+		kc:       oidcKC(),
+		userRepo: &mockUserRepoForCred{role: stdUserRole()},
+		mapRepo:  &mockCspMappingRepo{mapping: buildMapping(constants.AuthMethodOIDC, idpArn, roleArn, model.AuthMethodOIDC, config)},
+	})
+
+	cred, err := svc.GetTemporaryCredentials(context.Background(), 1, "kc_user_id", req("azure", "OIDC"))
+	require.NoError(t, err)
+	assert.Equal(t, "azure_access_token", cred.AccessToken)
+	assert.Equal(t, "azure", cred.CspType)
+}
+
+// TC-CRED-16b: Azure OIDC — config 누락 → 에러
+func TestGetTemporaryCredentials_Azure_OIDC_MissingConfig(t *testing.T) {
+	svc := newCredServiceWithMocks(credServiceDeps{
+		aws:      &mockAwsCredService{},
+		gcp:      &mockGcpCredService{},
+		alibaba:  &mockAlibabaCredService{},
+		azure:    &mockAzureCredService{},
+		tencent:  &mockTencentCredService{},
+		ibm:      &mockIbmCredService{},
+		kc:       oidcKC(),
 		userRepo: &mockUserRepoForCred{role: stdUserRole()},
 		mapRepo:  &mockCspMappingRepo{mapping: buildMapping(constants.AuthMethodOIDC, idpArn, roleArn, model.AuthMethodOIDC, nil)},
 	})
 
 	_, err := svc.GetTemporaryCredentials(context.Background(), 1, "kc_user_id", req("azure", "OIDC"))
 	require.Error(t, err)
-	assert.Equal(t, ErrUnsupportedAuthMethod, err)
+	assert.Contains(t, err.Error(), "Azure OIDC requires tenant_id and client_id")
+}
+
+// TC-CRED-16c: Azure OIDC — Keycloak 실패
+func TestGetTemporaryCredentials_Azure_OIDC_KeycloakFail(t *testing.T) {
+	config := map[string]string{
+		"tenant_id": "my-tenant-id",
+		"client_id": "my-client-id",
+	}
+	svc := newCredServiceWithMocks(credServiceDeps{
+		aws:      &mockAwsCredService{},
+		gcp:      &mockGcpCredService{},
+		alibaba:  &mockAlibabaCredService{},
+		azure:    &mockAzureCredService{},
+		tencent:  &mockTencentCredService{},
+		ibm:      &mockIbmCredService{},
+		kc:       failOidcKC(),
+		userRepo: &mockUserRepoForCred{role: stdUserRole()},
+		mapRepo:  &mockCspMappingRepo{mapping: buildMapping(constants.AuthMethodOIDC, idpArn, roleArn, model.AuthMethodOIDC, config)},
+	})
+
+	_, err := svc.GetTemporaryCredentials(context.Background(), 1, "kc_user_id", req("azure", "OIDC"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get impersonation token for Azure")
+}
+
+// ── Tencent ───────────────────────────────────────────────────────────────────
+
+// TC-CRED-17: Tencent SAML — 정상 발급
+func TestGetTemporaryCredentials_Tencent_SAML_Success(t *testing.T) {
+	config := map[string]string{
+		"secret_id":  "my-secret-id",
+		"secret_key": "my-secret-key",
+	}
+	svc := newCredServiceWithMocks(credServiceDeps{
+		aws:      &mockAwsCredService{},
+		gcp:      &mockGcpCredService{},
+		alibaba:  &mockAlibabaCredService{},
+		azure:    &mockAzureCredService{},
+		tencent:  &mockTencentCredService{result: tencentSamlCred},
+		ibm:      &mockIbmCredService{},
+		kc:       samlKC(),
+		userRepo: &mockUserRepoForCred{role: stdUserRole()},
+		mapRepo:  &mockCspMappingRepo{mapping: buildMapping(constants.AuthMethodSAML, idpArn, roleArn, model.AuthMethodSAML, config)},
+	})
+
+	cred, err := svc.GetTemporaryCredentials(context.Background(), 1, "kc_user_id", req("tencent", "SAML"))
+	require.NoError(t, err)
+	assert.Equal(t, "STS_TENCENT", cred.AccessKeyId)
+	assert.Equal(t, "tencent", cred.CspType)
+}
+
+// TC-CRED-17b: Tencent SAML — config 누락 → 에러
+func TestGetTemporaryCredentials_Tencent_SAML_MissingConfig(t *testing.T) {
+	svc := newCredServiceWithMocks(credServiceDeps{
+		aws:      &mockAwsCredService{},
+		gcp:      &mockGcpCredService{},
+		alibaba:  &mockAlibabaCredService{},
+		azure:    &mockAzureCredService{},
+		tencent:  &mockTencentCredService{},
+		ibm:      &mockIbmCredService{},
+		kc:       samlKC(),
+		userRepo: &mockUserRepoForCred{role: stdUserRole()},
+		mapRepo:  &mockCspMappingRepo{mapping: buildMapping(constants.AuthMethodSAML, idpArn, roleArn, model.AuthMethodSAML, nil)},
+	})
+
+	_, err := svc.GetTemporaryCredentials(context.Background(), 1, "kc_user_id", req("tencent", "SAML"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Tencent SAML requires secret_id and secret_key")
+}
+
+// ── IBM ───────────────────────────────────────────────────────────────────────
+
+// TC-CRED-18: IBM OIDC — 정상 발급
+func TestGetTemporaryCredentials_IBM_OIDC_Success(t *testing.T) {
+	config := map[string]string{
+		"profile_id": "Profile-xxxx-yyyy-zzzz",
+	}
+	svc := newCredServiceWithMocks(credServiceDeps{
+		aws:      &mockAwsCredService{},
+		gcp:      &mockGcpCredService{},
+		alibaba:  &mockAlibabaCredService{},
+		azure:    &mockAzureCredService{},
+		tencent:  &mockTencentCredService{},
+		ibm:      &mockIbmCredService{result: ibmOidcCred},
+		kc:       oidcKC(),
+		userRepo: &mockUserRepoForCred{role: stdUserRole()},
+		mapRepo:  &mockCspMappingRepo{mapping: buildMapping(constants.AuthMethodOIDC, idpArn, roleArn, model.AuthMethodOIDC, config)},
+	})
+
+	cred, err := svc.GetTemporaryCredentials(context.Background(), 1, "kc_user_id", req("ibm", "OIDC"))
+	require.NoError(t, err)
+	assert.Equal(t, "ibm_access_token", cred.AccessToken)
+	assert.Equal(t, "ibm", cred.CspType)
+}
+
+// TC-CRED-18b: IBM OIDC — config 누락 → 에러
+func TestGetTemporaryCredentials_IBM_OIDC_MissingConfig(t *testing.T) {
+	svc := newCredServiceWithMocks(credServiceDeps{
+		aws:      &mockAwsCredService{},
+		gcp:      &mockGcpCredService{},
+		alibaba:  &mockAlibabaCredService{},
+		azure:    &mockAzureCredService{},
+		tencent:  &mockTencentCredService{},
+		ibm:      &mockIbmCredService{},
+		kc:       oidcKC(),
+		userRepo: &mockUserRepoForCred{role: stdUserRole()},
+		mapRepo:  &mockCspMappingRepo{mapping: buildMapping(constants.AuthMethodOIDC, idpArn, roleArn, model.AuthMethodOIDC, nil)},
+	})
+
+	_, err := svc.GetTemporaryCredentials(context.Background(), 1, "kc_user_id", req("ibm", "OIDC"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "IBM OIDC requires profile_id")
 }
 
 // ── 에러 경로 ─────────────────────────────────────────────────────────────────
 
-// TC-CRED-17: 워크스페이스에 역할 없음
+// TC-CRED-19: 워크스페이스에 역할 없음
 func TestGetTemporaryCredentials_NoWorkspaceRole(t *testing.T) {
 	svc := newCredServiceWithMocks(credServiceDeps{
 		aws:      &mockAwsCredService{},
 		gcp:      &mockGcpCredService{},
 		alibaba:  &mockAlibabaCredService{},
+		azure:    &mockAzureCredService{},
+		tencent:  &mockTencentCredService{},
+		ibm:      &mockIbmCredService{},
 		kc:       &mockKeycloakForCred{},
 		userRepo: &mockUserRepoForCred{role: nil}, // 역할 없음
 		mapRepo:  &mockCspMappingRepo{},
@@ -397,12 +542,15 @@ func TestGetTemporaryCredentials_NoWorkspaceRole(t *testing.T) {
 	assert.Contains(t, err.Error(), "no role assigned")
 }
 
-// TC-CRED-18: CSP 역할 매핑 없음 → ErrNoCspRoleMappingFound
+// TC-CRED-20: CSP 역할 매핑 없음 → ErrNoCspRoleMappingFound
 func TestGetTemporaryCredentials_NoCspRoleMapping(t *testing.T) {
 	svc := newCredServiceWithMocks(credServiceDeps{
 		aws:      &mockAwsCredService{},
 		gcp:      &mockGcpCredService{},
 		alibaba:  &mockAlibabaCredService{},
+		azure:    &mockAzureCredService{},
+		tencent:  &mockTencentCredService{},
+		ibm:      &mockIbmCredService{},
 		kc:       &mockKeycloakForCred{},
 		userRepo: &mockUserRepoForCred{role: stdUserRole()},
 		mapRepo:  &mockCspMappingRepo{mapping: nil}, // 매핑 없음
@@ -413,12 +561,15 @@ func TestGetTemporaryCredentials_NoCspRoleMapping(t *testing.T) {
 	assert.Equal(t, ErrNoCspRoleMappingFound, err)
 }
 
-// TC-CRED-19: 미지원 CSP 타입 → ErrUnsupportedCspType
+// TC-CRED-21: 미지원 CSP 타입 → ErrUnsupportedCspType
 func TestGetTemporaryCredentials_UnsupportedCspType(t *testing.T) {
 	svc := newCredServiceWithMocks(credServiceDeps{
 		aws:      &mockAwsCredService{},
 		gcp:      &mockGcpCredService{},
 		alibaba:  &mockAlibabaCredService{},
+		azure:    &mockAzureCredService{},
+		tencent:  &mockTencentCredService{},
+		ibm:      &mockIbmCredService{},
 		kc:       &mockKeycloakForCred{},
 		userRepo: &mockUserRepoForCred{role: stdUserRole()},
 		mapRepo:  &mockCspMappingRepo{mapping: buildMapping(constants.AuthMethodOIDC, idpArn, roleArn, model.AuthMethodOIDC, nil)},

--- a/src/service/csp_credential_service_test.go
+++ b/src/service/csp_credential_service_test.go
@@ -256,19 +256,37 @@ func TestGetTemporaryCredentials_GCP_SecretKey_Success(t *testing.T) {
 }
 
 // TC-CRED-12: GCP SAML — 미구현 → ErrUnsupportedAuthMethod
-func TestGetTemporaryCredentials_GCP_SAML_Unsupported(t *testing.T) {
+// TC-CRED-11 (updated): GCP SAML — 정상 발급 (Phase 1 구현)
+func TestGetTemporaryCredentials_GCP_SAML_Success(t *testing.T) {
+	svc := newCredServiceWithMocks(credServiceDeps{
+		aws:      &mockAwsCredService{},
+		gcp:      &mockGcpCredService{result: gcpSamlCred},
+		alibaba:  &mockAlibabaCredService{},
+		kc:       samlKC(),
+		userRepo: &mockUserRepoForCred{role: stdUserRole()},
+		mapRepo:  &mockCspMappingRepo{mapping: buildMapping(constants.AuthMethodSAML, idpArn, roleArn, model.AuthMethodSAML, nil)},
+	})
+
+	cred, err := svc.GetTemporaryCredentials(context.Background(), 1, "kc_user_id", req("gcp", "SAML"))
+	require.NoError(t, err)
+	assert.Equal(t, "gcp_saml_access_token", cred.AccessToken)
+	assert.Equal(t, "gcp", cred.CspType)
+}
+
+// TC-CRED-11b: GCP SAML — Keycloak SAML assertion 실패 → 에러 전파
+func TestGetTemporaryCredentials_GCP_SAML_KeycloakFail(t *testing.T) {
 	svc := newCredServiceWithMocks(credServiceDeps{
 		aws:      &mockAwsCredService{},
 		gcp:      &mockGcpCredService{},
 		alibaba:  &mockAlibabaCredService{},
-		kc:       &mockKeycloakForCred{},
+		kc:       failSamlKC(),
 		userRepo: &mockUserRepoForCred{role: stdUserRole()},
 		mapRepo:  &mockCspMappingRepo{mapping: buildMapping(constants.AuthMethodSAML, idpArn, roleArn, model.AuthMethodSAML, nil)},
 	})
 
 	_, err := svc.GetTemporaryCredentials(context.Background(), 1, "kc_user_id", req("gcp", "SAML"))
 	require.Error(t, err)
-	assert.Equal(t, ErrUnsupportedAuthMethod, err)
+	assert.Contains(t, err.Error(), "failed to get SAML assertion for GCP")
 }
 
 // ── Alibaba SAML ──────────────────────────────────────────────────────────────

--- a/src/service/csp_credential_service_test.go
+++ b/src/service/csp_credential_service_test.go
@@ -308,20 +308,37 @@ func TestGetTemporaryCredentials_Alibaba_SAML_Success(t *testing.T) {
 	assert.Equal(t, "alibaba", cred.CspType)
 }
 
-// TC-CRED-14: Alibaba OIDC — 미구현 → ErrUnsupportedAuthMethod
-func TestGetTemporaryCredentials_Alibaba_OIDC_Unsupported(t *testing.T) {
+// TC-CRED-14: Alibaba OIDC — 정상 발급
+func TestGetTemporaryCredentials_Alibaba_OIDC_Success(t *testing.T) {
+	svc := newCredServiceWithMocks(credServiceDeps{
+		aws:      &mockAwsCredService{},
+		gcp:      &mockGcpCredService{},
+		alibaba:  &mockAlibabaCredService{oidcResult: alibabaOidcCred},
+		kc:       oidcKC(),
+		userRepo: &mockUserRepoForCred{role: stdUserRole()},
+		mapRepo:  &mockCspMappingRepo{mapping: buildMapping(constants.AuthMethodOIDC, idpArn, roleArn, model.AuthMethodOIDC, nil)},
+	})
+
+	cred, err := svc.GetTemporaryCredentials(context.Background(), 1, "kc_user_id", req("alibaba", "OIDC"))
+	require.NoError(t, err)
+	assert.Equal(t, "STS_ALIBABA_OIDC", cred.AccessKeyId)
+	assert.Equal(t, "alibaba", cred.CspType)
+}
+
+// TC-CRED-14b: Alibaba OIDC — Keycloak 실패
+func TestGetTemporaryCredentials_Alibaba_OIDC_KeycloakFail(t *testing.T) {
 	svc := newCredServiceWithMocks(credServiceDeps{
 		aws:      &mockAwsCredService{},
 		gcp:      &mockGcpCredService{},
 		alibaba:  &mockAlibabaCredService{},
-		kc:       &mockKeycloakForCred{},
+		kc:       failOidcKC(),
 		userRepo: &mockUserRepoForCred{role: stdUserRole()},
 		mapRepo:  &mockCspMappingRepo{mapping: buildMapping(constants.AuthMethodOIDC, idpArn, roleArn, model.AuthMethodOIDC, nil)},
 	})
 
 	_, err := svc.GetTemporaryCredentials(context.Background(), 1, "kc_user_id", req("alibaba", "OIDC"))
 	require.Error(t, err)
-	assert.Equal(t, ErrUnsupportedAuthMethod, err)
+	assert.Contains(t, err.Error(), "failed to get impersonation token for Alibaba")
 }
 
 // ── Azure / 기타 ──────────────────────────────────────────────────────────────

--- a/src/service/csp_validation_service.go
+++ b/src/service/csp_validation_service.go
@@ -508,7 +508,7 @@ func (s *CspValidationService) validateGCPWithOIDC(ctx context.Context, userID u
 	}
 
 	if !stepRunner(steps, 5, func() (string, error) {
-		creds, err := gcpCredService.ExchangeTokenAndImpersonate(ctx, wifProvider, saEmail, accessToken)
+		creds, err := gcpCredService.ExchangeTokenAndImpersonate(ctx, wifProvider, saEmail, accessToken, "jwt")
 		if err != nil {
 			return "", fmt.Errorf("GCP 자격증명 발급 실패: %v — WIF Pool/Provider 설정 또는 SA 권한 확인", err)
 		}

--- a/src/service/gcp_credential_service.go
+++ b/src/service/gcp_credential_service.go
@@ -21,7 +21,8 @@ type GcpCredentialService interface {
 		ctx context.Context,
 		wifProviderResourceName string,
 		serviceAccountEmail string,
-		webIdentityToken string,
+		subjectToken string,
+		subjectTokenType string, // "jwt" (OIDC) or "saml2" (SAML)
 	) (*model.CspCredentialResponse, error)
 }
 
@@ -60,12 +61,13 @@ func (s *gcpCredentialService) ExchangeTokenAndImpersonate(
 	ctx context.Context,
 	wifProviderResourceName string,
 	serviceAccountEmail string,
-	webIdentityToken string,
+	subjectToken string,
+	subjectTokenType string,
 ) (*model.CspCredentialResponse, error) {
-	log.Printf("[GCP_CREDENTIAL] Starting WIF token exchange for SA: %s", serviceAccountEmail)
+	log.Printf("[GCP_CREDENTIAL] Starting WIF token exchange for SA: %s (tokenType: %s)", serviceAccountEmail, subjectTokenType)
 
-	// Step 1: Exchange Keycloak JWT for GCP federated access token via GCP STS
-	federatedToken, err := s.exchangeToken(ctx, wifProviderResourceName, webIdentityToken)
+	// Step 1: Exchange Keycloak token for GCP federated access token via GCP STS
+	federatedToken, err := s.exchangeToken(ctx, wifProviderResourceName, subjectToken, subjectTokenType)
 	if err != nil {
 		log.Printf("[GCP_CREDENTIAL] STS token exchange failed: %v", err)
 		return nil, fmt.Errorf("GCP STS token exchange failed: %w", err)
@@ -88,14 +90,20 @@ func (s *gcpCredentialService) ExchangeTokenAndImpersonate(
 	}, nil
 }
 
-// exchangeToken calls GCP STS to exchange a Keycloak JWT for a federated access token.
-func (s *gcpCredentialService) exchangeToken(ctx context.Context, audience, webIdentityToken string) (string, error) {
+// exchangeToken calls GCP STS to exchange a subject token for a federated access token.
+// subjectTokenType: "jwt" for OIDC, "saml2" for SAML2 assertion.
+func (s *gcpCredentialService) exchangeToken(ctx context.Context, audience, subjectToken, subjectTokenType string) (string, error) {
 	stsURL := "https://sts.googleapis.com/v1/token"
+
+	tokenTypeURN := "urn:ietf:params:oauth:token-type:jwt"
+	if subjectTokenType == "saml2" {
+		tokenTypeURN = "urn:ietf:params:oauth:token-type:saml2"
+	}
 
 	formData := url.Values{}
 	formData.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
-	formData.Set("subject_token", webIdentityToken)
-	formData.Set("subject_token_type", "urn:ietf:params:oauth:token-type:jwt")
+	formData.Set("subject_token", subjectToken)
+	formData.Set("subject_token_type", tokenTypeURN)
 	formData.Set("requested_token_type", "urn:ietf:params:oauth:token-type:access_token")
 	formData.Set("audience", audience)
 	formData.Set("scope", "https://www.googleapis.com/auth/cloud-platform")

--- a/src/service/ibm_credential_service.go
+++ b/src/service/ibm_credential_service.go
@@ -1,0 +1,118 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/m-cmp/mc-iam-manager/model"
+)
+
+// IbmCredentialService defines operations for obtaining IBM Cloud IAM
+// access tokens via Trusted Profile (CR token exchange).
+type IbmCredentialService interface {
+	GetTokenByTrustedProfile(
+		ctx context.Context,
+		profileID string,
+		crToken string,
+	) (*model.CspCredentialResponse, error)
+}
+
+type ibmCredentialService struct{}
+
+// NewIbmCredentialService creates a new IbmCredentialService.
+func NewIbmCredentialService() IbmCredentialService {
+	return &ibmCredentialService{}
+}
+
+// ibmTokenResponse represents the IBM IAM token endpoint response.
+type ibmTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
+	Expiration  int64  `json:"expiration"`
+}
+
+// ibmErrorResponse represents an IBM IAM token endpoint error response.
+type ibmErrorResponse struct {
+	ErrorCode        string `json:"errorCode"`
+	ErrorMessage     string `json:"errorMessage"`
+	Context          string `json:"context"`
+}
+
+const ibmIamTokenURL = "https://iam.cloud.ibm.com/identity/token"
+
+// GetTokenByTrustedProfile exchanges a Keycloak OIDC JWT for an IBM Cloud IAM
+// access token using the Trusted Profile (CR token) flow.
+//
+// profileID: IBM Cloud Trusted Profile ID (e.g., Profile-xxxx-yyyy-zzzz)
+// crToken:   OIDC access token / ID token from Keycloak (used as CR token)
+func (s *ibmCredentialService) GetTokenByTrustedProfile(
+	ctx context.Context,
+	profileID string,
+	crToken string,
+) (*model.CspCredentialResponse, error) {
+	log.Printf("[IBM_CREDENTIAL] GetTokenByTrustedProfile - profileID: %s", profileID)
+
+	formData := url.Values{}
+	formData.Set("grant_type", "urn:ibm:params:oauth:grant-type:cr-token")
+	formData.Set("cr_token", crToken)
+	formData.Set("profile_id", profileID)
+	formData.Set("response_type", "cloud_iam")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ibmIamTokenURL, strings.NewReader(formData.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create IBM IAM token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("IBM IAM token request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read IBM IAM token response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp ibmErrorResponse
+		if jsonErr := json.Unmarshal(body, &errResp); jsonErr == nil && errResp.ErrorCode != "" {
+			return nil, fmt.Errorf("IBM IAM error [%s]: %s", errResp.ErrorCode, errResp.ErrorMessage)
+		}
+		return nil, fmt.Errorf("IBM IAM token endpoint returned HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResp ibmTokenResponse
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return nil, fmt.Errorf("failed to parse IBM IAM token response: %w", err)
+	}
+
+	if tokenResp.AccessToken == "" {
+		return nil, fmt.Errorf("IBM IAM token endpoint returned empty access_token")
+	}
+
+	var expiration time.Time
+	if tokenResp.Expiration != 0 {
+		expiration = time.Unix(tokenResp.Expiration, 0)
+	} else {
+		expiration = time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+	}
+	log.Printf("[IBM_CREDENTIAL] GetTokenByTrustedProfile succeeded, expires: %s", expiration)
+
+	return &model.CspCredentialResponse{
+		CspType:     "ibm",
+		AccessToken: tokenResp.AccessToken,
+		TokenType:   tokenResp.TokenType,
+		Expiration:  expiration,
+	}, nil
+}

--- a/src/service/mock_csp_credential_deps_test.go
+++ b/src/service/mock_csp_credential_deps_test.go
@@ -44,7 +44,7 @@ type mockGcpCredService struct {
 	err    error
 }
 
-func (m *mockGcpCredService) ExchangeTokenAndImpersonate(_ context.Context, wif, sa, token string) (*model.CspCredentialResponse, error) {
+func (m *mockGcpCredService) ExchangeTokenAndImpersonate(_ context.Context, wif, sa, token, tokenType string) (*model.CspCredentialResponse, error) {
 	return m.result, m.err
 }
 
@@ -100,6 +100,12 @@ var awsSamlCred = &model.CspCredentialResponse{
 var gcpOidcCred = &model.CspCredentialResponse{
 	CspType:     "gcp",
 	AccessToken: "gcp_access_token",
+	TokenType:   "Bearer",
+}
+
+var gcpSamlCred = &model.CspCredentialResponse{
+	CspType:     "gcp",
+	AccessToken: "gcp_saml_access_token",
 	TokenType:   "Bearer",
 }
 

--- a/src/service/mock_csp_credential_deps_test.go
+++ b/src/service/mock_csp_credential_deps_test.go
@@ -51,11 +51,20 @@ func (m *mockGcpCredService) ExchangeTokenAndImpersonate(_ context.Context, wif,
 // ── Alibaba ──────────────────────────────────────────────────────────────────
 
 type mockAlibabaCredService struct {
-	result *model.CspCredentialResponse
-	err    error
+	result    *model.CspCredentialResponse
+	err       error
+	oidcResult *model.CspCredentialResponse
+	oidcErr    error
 }
 
 func (m *mockAlibabaCredService) AssumeRoleWithSAML(_ context.Context, samlProviderArn, roleArn, samlAssertion, region string) (*model.CspCredentialResponse, error) {
+	return m.result, m.err
+}
+
+func (m *mockAlibabaCredService) AssumeRoleWithOIDC(_ context.Context, oidcProviderArn, roleArn, oidcToken, region string) (*model.CspCredentialResponse, error) {
+	if m.oidcResult != nil || m.oidcErr != nil {
+		return m.oidcResult, m.oidcErr
+	}
 	return m.result, m.err
 }
 
@@ -114,6 +123,13 @@ var alibabaSamlCred = &model.CspCredentialResponse{
 	AccessKeyId:     "STS_ALIBABA",
 	SecretAccessKey: "alibaba_secret",
 	SecurityToken:   "alibaba_token",
+}
+
+var alibabaOidcCred = &model.CspCredentialResponse{
+	CspType:         "alibaba",
+	AccessKeyId:     "STS_ALIBABA_OIDC",
+	SecretAccessKey: "alibaba_oidc_secret",
+	SecurityToken:   "alibaba_oidc_token",
 }
 
 // ── 헬퍼: CspCredentialService 생성 ──────────────────────────────────────────

--- a/src/service/mock_csp_credential_deps_test.go
+++ b/src/service/mock_csp_credential_deps_test.go
@@ -68,6 +68,39 @@ func (m *mockAlibabaCredService) AssumeRoleWithOIDC(_ context.Context, oidcProvi
 	return m.result, m.err
 }
 
+// ── Azure ─────────────────────────────────────────────────────────────────────
+
+type mockAzureCredService struct {
+	result *model.CspCredentialResponse
+	err    error
+}
+
+func (m *mockAzureCredService) GetTokenByFederatedCredential(_ context.Context, tenantID, clientID, keycloakJWT string) (*model.CspCredentialResponse, error) {
+	return m.result, m.err
+}
+
+// ── Tencent ───────────────────────────────────────────────────────────────────
+
+type mockTencentCredService struct {
+	result *model.CspCredentialResponse
+	err    error
+}
+
+func (m *mockTencentCredService) AssumeRoleWithSAML(_ context.Context, secretID, secretKey, roleArn, principalArn, samlAssertion, region string) (*model.CspCredentialResponse, error) {
+	return m.result, m.err
+}
+
+// ── IBM ───────────────────────────────────────────────────────────────────────
+
+type mockIbmCredService struct {
+	result *model.CspCredentialResponse
+	err    error
+}
+
+func (m *mockIbmCredService) GetTokenByTrustedProfile(_ context.Context, profileID, crToken string) (*model.CspCredentialResponse, error) {
+	return m.result, m.err
+}
+
 // ── UserRepository (필요한 메서드만) ─────────────────────────────────────────
 
 type mockUserRepoForCred struct {
@@ -132,12 +165,34 @@ var alibabaOidcCred = &model.CspCredentialResponse{
 	SecurityToken:   "alibaba_oidc_token",
 }
 
+var azureOidcCred = &model.CspCredentialResponse{
+	CspType:     "azure",
+	AccessToken: "azure_access_token",
+	TokenType:   "Bearer",
+}
+
+var tencentSamlCred = &model.CspCredentialResponse{
+	CspType:         "tencent",
+	AccessKeyId:     "STS_TENCENT",
+	SecretAccessKey: "tencent_secret",
+	SessionToken:    "tencent_token",
+}
+
+var ibmOidcCred = &model.CspCredentialResponse{
+	CspType:     "ibm",
+	AccessToken: "ibm_access_token",
+	TokenType:   "Bearer",
+}
+
 // ── 헬퍼: CspCredentialService 생성 ──────────────────────────────────────────
 
 type credServiceDeps struct {
 	aws      *mockAwsCredService
 	gcp      *mockGcpCredService
 	alibaba  *mockAlibabaCredService
+	azure    *mockAzureCredService
+	tencent  *mockTencentCredService
+	ibm      *mockIbmCredService
 	kc       KeycloakService // 인터페이스 — mockKeycloakService 또는 mockKeycloakForCred 모두 허용
 	userRepo *mockUserRepoForCred
 	mapRepo  *mockCspMappingRepo
@@ -148,6 +203,9 @@ func newCredServiceWithMocks(deps credServiceDeps) *CspCredentialService {
 		awsCredService:     deps.aws,
 		gcpCredService:     deps.gcp,
 		alibabaCredService: deps.alibaba,
+		azureCredService:   deps.azure,
+		tencentCredService: deps.tencent,
+		ibmCredService:     deps.ibm,
 		keycloakService:    deps.kc,
 		userRepoIface:      deps.userRepo,
 		mappingRepoIface:   deps.mapRepo,

--- a/src/service/tencent_credential_service.go
+++ b/src/service/tencent_credential_service.go
@@ -1,0 +1,232 @@
+package service
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/m-cmp/mc-iam-manager/model"
+)
+
+// TencentCredentialService defines operations for obtaining Tencent Cloud
+// temporary credentials via CAM AssumeRoleWithSAML.
+type TencentCredentialService interface {
+	AssumeRoleWithSAML(
+		ctx context.Context,
+		secretID string,
+		secretKey string,
+		roleArn string,
+		principalArn string,
+		samlAssertion string,
+		region string,
+	) (*model.CspCredentialResponse, error)
+}
+
+type tencentCredentialService struct{}
+
+// NewTencentCredentialService creates a new TencentCredentialService.
+func NewTencentCredentialService() TencentCredentialService {
+	return &tencentCredentialService{}
+}
+
+// tencentCredentials represents the Credentials block in Tencent STS response.
+type tencentCredentials struct {
+	TmpSecretId  string `json:"TmpSecretId"`
+	TmpSecretKey string `json:"TmpSecretKey"`
+	Token        string `json:"Token"`
+}
+
+// tencentStsResponseBody represents the inner Response in Tencent STS response.
+type tencentStsResponseBody struct {
+	Credentials tencentCredentials `json:"Credentials"`
+	ExpiredTime int64              `json:"ExpiredTime"`
+	Expiration  string             `json:"Expiration"`
+	RequestId   string             `json:"RequestId"`
+}
+
+// tencentStsResponse wraps the Tencent API response envelope.
+type tencentStsResponse struct {
+	Response tencentStsResponseBody `json:"Response"`
+}
+
+// tencentErrorBody represents the Error block in Tencent API error response.
+type tencentErrorBody struct {
+	Code    string `json:"Code"`
+	Message string `json:"Message"`
+}
+
+// tencentErrorResponse represents a Tencent API error response.
+type tencentErrorResponse struct {
+	Response struct {
+		Error     tencentErrorBody `json:"Error"`
+		RequestId string           `json:"RequestId"`
+	} `json:"Response"`
+}
+
+const (
+	tencentStsEndpoint = "https://sts.tencentcloudapi.com/"
+	tencentStsVersion  = "2018-08-13"
+	tencentStsService  = "sts"
+	tencentStsHost     = "sts.tencentcloudapi.com"
+)
+
+// AssumeRoleWithSAML calls Tencent Cloud CAM STS to exchange a SAML assertion
+// for temporary credentials (TmpSecretId + TmpSecretKey + Token).
+//
+// The request is signed with TC3-HMAC-SHA256 using the provided secretID/secretKey.
+//
+// secretID:      Tencent Cloud API Secret ID (for signing; sub-account with STS permission)
+// secretKey:     Tencent Cloud API Secret Key (for signing)
+// roleArn:       Tencent CAM Role ARN (e.g., qcs::cam::uin/123:roleName/myRole)
+// principalArn:  Tencent CAM SAML provider ARN (e.g., qcs::cam::uin/123:saml-provider/myIdP)
+// samlAssertion: Base64-encoded SAML2 assertion from Keycloak
+// region:        Tencent Cloud region (used in response only; STS itself is global)
+func (s *tencentCredentialService) AssumeRoleWithSAML(
+	ctx context.Context,
+	secretID string,
+	secretKey string,
+	roleArn string,
+	principalArn string,
+	samlAssertion string,
+	region string,
+) (*model.CspCredentialResponse, error) {
+	log.Printf("[TENCENT_CREDENTIAL] AssumeRoleWithSAML - RoleArn: %s, PrincipalArn: %s", roleArn, principalArn)
+
+	sessionName := fmt.Sprintf("mciam-%d", time.Now().Unix())
+
+	payload := map[string]string{
+		"RoleArn":         roleArn,
+		"PrincipalArn":    principalArn,
+		"SAMLAssertion":   samlAssertion,
+		"RoleSessionName": sessionName,
+	}
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal Tencent STS request: %w", err)
+	}
+
+	now := time.Now().UTC()
+	timestamp := fmt.Sprintf("%d", now.Unix())
+	date := now.Format("2006-01-02")
+
+	authHeader, err := buildTencentTC3Auth(secretID, secretKey, date, timestamp, string(payloadBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to build Tencent TC3 signature: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tencentStsEndpoint, strings.NewReader(string(payloadBytes)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Tencent STS request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Host", tencentStsHost)
+	req.Header.Set("X-TC-Action", "AssumeRoleWithSAML")
+	req.Header.Set("X-TC-Version", tencentStsVersion)
+	req.Header.Set("X-TC-Timestamp", timestamp)
+	req.Header.Set("Authorization", authHeader)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("Tencent STS request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Tencent STS response: %w", err)
+	}
+
+	// Check for Tencent API error in response body (Tencent always returns 200 for API-level errors)
+	var errResp tencentErrorResponse
+	if jsonErr := json.Unmarshal(body, &errResp); jsonErr == nil && errResp.Response.Error.Code != "" {
+		return nil, fmt.Errorf("Tencent STS error [%s]: %s", errResp.Response.Error.Code, errResp.Response.Error.Message)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Tencent STS returned HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	var stsResp tencentStsResponse
+	if err := json.Unmarshal(body, &stsResp); err != nil {
+		return nil, fmt.Errorf("failed to parse Tencent STS response: %w", err)
+	}
+
+	creds := stsResp.Response.Credentials
+	if creds.TmpSecretId == "" || creds.TmpSecretKey == "" {
+		return nil, fmt.Errorf("Tencent STS returned empty credentials")
+	}
+
+	expiration := time.Unix(stsResp.Response.ExpiredTime, 0)
+	if stsResp.Response.ExpiredTime == 0 {
+		log.Printf("[TENCENT_CREDENTIAL] Warning: ExpiredTime is 0, using 1h from now")
+		expiration = time.Now().Add(time.Hour)
+	}
+
+	log.Printf("[TENCENT_CREDENTIAL] AssumeRoleWithSAML succeeded, Expiration: %s", expiration)
+
+	return &model.CspCredentialResponse{
+		CspType:         "tencent",
+		AccessKeyId:     creds.TmpSecretId,
+		SecretAccessKey: creds.TmpSecretKey,
+		SessionToken:    creds.Token,
+		Expiration:      expiration,
+		Region:          region,
+	}, nil
+}
+
+// buildTencentTC3Auth constructs the TC3-HMAC-SHA256 Authorization header.
+func buildTencentTC3Auth(secretID, secretKey, date, timestamp, payload string) (string, error) {
+	// Step 1: Build canonical request
+	httpMethod := "POST"
+	canonicalURI := "/"
+	canonicalQueryString := ""
+	canonicalHeaders := fmt.Sprintf("content-type:application/json\nhost:%s\nx-tc-action:%s\n",
+		tencentStsHost, strings.ToLower("AssumeRoleWithSAML"))
+	signedHeaders := "content-type;host;x-tc-action"
+	hashedPayload := sha256hex(payload)
+	canonicalRequest := strings.Join([]string{
+		httpMethod, canonicalURI, canonicalQueryString,
+		canonicalHeaders, signedHeaders, hashedPayload,
+	}, "\n")
+
+	// Step 2: Build string to sign
+	algorithm := "TC3-HMAC-SHA256"
+	credentialScope := fmt.Sprintf("%s/%s/tc3_request", date, tencentStsService)
+	stringToSign := strings.Join([]string{
+		algorithm, timestamp, credentialScope, sha256hex(canonicalRequest),
+	}, "\n")
+
+	// Step 3: Derive signing key
+	secretDate := hmacSHA256([]byte("TC3"+secretKey), date)
+	secretService := hmacSHA256(secretDate, tencentStsService)
+	secretSigning := hmacSHA256(secretService, "tc3_request")
+
+	// Step 4: Calculate signature
+	signature := hex.EncodeToString(hmacSHA256(secretSigning, stringToSign))
+
+	// Step 5: Build Authorization header
+	auth := fmt.Sprintf("%s Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+		algorithm, secretID, credentialScope, signedHeaders, signature)
+
+	return auth, nil
+}
+
+func sha256hex(s string) string {
+	h := sha256.New()
+	h.Write([]byte(s))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func hmacSHA256(key []byte, data string) []byte {
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte(data))
+	return mac.Sum(nil)
+}


### PR DESCRIPTION
## Summary

- **GCP SAML**: `ExchangeTokenAndImpersonate`에 `subjectTokenType` 파라미터 추가 ("jwt" for OIDC, "saml2" for SAML)
- **Alibaba OIDC**: `AlibabaCredentialService`에 `AssumeRoleWithOIDC` 메서드 추가
- **Azure OIDC**: 신규 `azure_credential_service.go` - OAuth2 Federated Credential 방식 (tenant_id + client_id)
- **Tencent SAML**: 신규 `tencent_credential_service.go` - TC3-HMAC-SHA256 서명 + CAM AssumeRoleWithSAML
- **IBM OIDC**: 신규 `ibm_credential_service.go` - IBM IAM Trusted Profile CR token 방식
- dispatch matrix 단위 테스트 27개 전체 PASS

## CSP × 인증방식 매트릭스 (구현 완료)

| CSP | OIDC | SAML | SECRET_KEY |
|-----|------|------|------------|
| AWS | ✅ | ✅ | ✅ |
| GCP | ✅ | ✅ | ✅ |
| Alibaba | ✅ | ✅ | ✅ |
| Azure | ✅ | — | ✅ |
| Tencent | — | ✅ | ✅ |
| IBM | ✅ | — | ✅ |
| NCP/NHN/KT/OpenStack | — | — | ✅ |

## Test plan

- [x] `go test ./service/... -run TestGetTemporaryCredentials` — 27 tests PASS
- [x] `go build ./...` — clean build
- [ ] 통합 테스트: 실제 CSP 환경에서 각 인증방식 검증 (ST4 대상)

## 관련 이슈

- 035_CSP인증방식확장 ST3 구현