### PR TITLE
fix/refactor(M4-CSP): Alibaba STS fix, SAML pre-check gate, CspRole service layer refactoring

### DIFF
--- a/.env
+++ b/.env
@@ -101,3 +101,7 @@ IDENTITY_ROLE_ARN_AWS=arn:aws:iam::${MC_IAM_MANAGER_KEYCLOAK_DOMAIN}:role/mciam-
 
 
 CSP_ROLE_PREFIX=mciam
+
+# SAML Client ID (CSP별 Keycloak SAML 클라이언트 ID)
+SAML_CLIENT_ID_AWS=urn:amazon:webservices
+SAML_CLIENT_ID_ALIBABA=

--- a/.env_sample
+++ b/.env_sample
@@ -101,3 +101,7 @@ IDENTITY_ROLE_ARN_AWS=arn:aws:iam::${MC_IAM_MANAGER_KEYCLOAK_DOMAIN}:role/mciam-
 
 
 CSP_ROLE_PREFIX=mciam
+
+# SAML Client ID (CSP별 Keycloak SAML 클라이언트 ID)
+SAML_CLIENT_ID_AWS=urn:amazon:webservices
+SAML_CLIENT_ID_ALIBABA=

--- a/src/repository/csp_role_repository.go
+++ b/src/repository/csp_role_repository.go
@@ -1,15 +1,11 @@
 package repository
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"log"
-	"os"
 	"strings"
-	"text/template"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -17,8 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/google/uuid"
-	mciamConfig "github.com/m-cmp/mc-iam-manager/config"
-	"github.com/m-cmp/mc-iam-manager/constants"
 	"github.com/m-cmp/mc-iam-manager/csp"
 	"github.com/m-cmp/mc-iam-manager/model"
 	"gorm.io/gorm"
@@ -140,317 +134,34 @@ func (r *CspRoleRepository) FindMciamRoleFromCsp(cspType string) ([]*model.CspRo
 	return roles, nil
 }
 
-type PolicyValues struct {
-	AccountID        string
-	KeycloakHostname string
-	Subject          string
-	Audience         string
+// CreateCspRoleRecord DB에 CSP 역할 레코드를 생성합니다. (DB 전용)
+func (r *CspRoleRepository) CreateCspRoleRecord(role *model.CspRole) error {
+	if err := r.db.Create(role).Error; err != nil {
+		return fmt.Errorf("failed to create CSP role in database: %v", err)
+	}
+	return nil
 }
 
-// getRoleManagerAssumeRolePolicyDocument 플랫폼 관리자용 AssumeRole 정책 문서를 반환합니다.
-func getRoleManagerAssumeRolePolicyDocument(role *model.CspRole) (string, error) {
-	const policyTemplate = `{
-		"Version": "2012-10-17",
-		"Statement": [
-			{
-				"Effect": "Allow",
-				"Principal": {
-					"Federated": "arn:aws:iam::{{.AccountID}}:oidc-provider/{{.KeycloakHostname}}"
-				},
-				"Action": "sts:AssumeRoleWithWebIdentity",
-				"Condition": {
-					"StringEquals": {					
-						"{{.KeycloakHostname}}:aud": "{{.Audience}}"
-					}
-				}
-			}
-		]
-	}`
-	// "{{.KeycloakHostname}}:sub": "{{.Subject}}",
-
-	// 환경 변수에서 OIDC 클라이언트 ID 가져오기
-	oidcClientID := os.Getenv("KEYCLOAK_OIDC_CLIENT_ID")
-	if oidcClientID == "" {
-		return "", fmt.Errorf("KEYCLOAK_OIDC_CLIENT environment variable is not set")
+// UpdateCspRoleRecord DB의 CSP 역할 레코드를 업데이트합니다. (DB 전용)
+func (r *CspRoleRepository) UpdateCspRoleRecord(role *model.CspRole) error {
+	if err := r.db.Save(role).Error; err != nil {
+		return fmt.Errorf("failed to update CSP role in database: %v", err)
 	}
-
-	values := PolicyValues{
-		AccountID: "050864702683",
-		//KeycloakHostname: "mciam.onecloudcon.com",
-		KeycloakHostname: mciamConfig.KC.Host,
-		//Subject:          "user@example.com",
-		Audience: oidcClientID, // 하드코딩된 값 대신 환경 변수 사용
-	}
-
-	tmpl, err := template.New("policy").Parse(policyTemplate)
-	if err != nil {
-		return "", err
-	}
-
-	var buf bytes.Buffer
-	err = tmpl.Execute(&buf, values)
-	if err != nil {
-		return "", err
-	}
-	return buf.String(), nil
-
-	// return `{
-	// 	"Version": "2012-10-17",
-	// 	"Statement": [
-	// 		{
-	// 			"Effect": "Allow",
-	// 			"Principal": {
-	// 				"Federated": "arn:aws:iam::ACCOUNT_ID:oidc-provider/KEYCLOAK_HOSTNAME"
-	// 			},
-	// 			"Action": "sts:AssumeRoleWithWebIdentity",
-	// 			"Condition": {
-	// 				"StringEquals": {
-	// 					"KEYCLOAK_HOSTNAME:sub": "SUBJECT",
-	// 					"KEYCLOAK_HOSTNAME:aud": "AUDIENCE"
-	// 				}
-	// 			}
-	// 		}
-	// 	]
-	// }`
-}
-
-// getUserAssumeRolePolicyDocument 일반 사용자용 AssumeRole 정책 문서를 반환합니다.
-func getUserAssumeRolePolicyDocument() string {
-	return `{
-		"Version": "2012-10-17",
-		"Statement": [
-			{
-				"Effect": "Allow",
-				"Principal": {
-					"Federated": "arn:aws:iam::ACCOUNT_ID:oidc-provider/KEYCLOAK_HOSTNAME"
-				},
-				"Action": "sts:AssumeRoleWithWebIdentity",
-				"Condition": {
-					"StringEquals": {
-						"KEYCLOAK_HOSTNAME:sub": "SUBJECT",
-						"KEYCLOAK_HOSTNAME:aud": "AUDIENCE"
-					}
-				}
-			}
-		]
-	}`
-}
-
-// CreateCspRole AWS IAM Role을 생성하고 생성 완료를 기다린 후 상세 정보를 반환합니다.
-// 내부에서 임시 자격 증명을 관리합니다.
-func (r *CspRoleRepository) CreateCspRole(req *model.CreateCspRoleRequest, issuedBy string) (*model.CspRole, error) {
-	// 1. 유효한 임시 자격 증명 조회 또는 생성 (RoleMaster ID 없이 시스템 레벨 자격 증명 사용)
-	credential, err := r.tempCredentialRepo.GetOrCreateValidCredential("aws", "oidc", "ap-northeast-2", nil, issuedBy, func() (*model.TempCredential, error) {
-		// 새로운 자격 증명 생성 로직 (service 계층에서 처리되어야 하지만, 여기서는 기본값 사용)
-		return &model.TempCredential{
-			Provider:        "aws",
-			AuthType:        "oidc",
-			AccessKeyId:     "temp-access-key",    // 실제로는 service에서 생성
-			SecretAccessKey: "temp-secret-key",    // 실제로는 service에서 생성
-			SessionToken:    "temp-session-token", // 실제로는 service에서 생성
-			Region:          "ap-northeast-2",
-			IssuedAt:        time.Now(),
-			ExpiresAt:       time.Now().Add(1 * time.Hour), // 1시간 후 만료
-			IsActive:        true,
-			IssuedBy:        issuedBy,
-		}, nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to get or create valid credential: %v", err)
-	}
-
-	// 2. 임시 자격 증명으로 AWS IAM 클라이언트 생성
-	awsCfg, err := r.createAwsConfigWithTempCredential(credential)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create AWS config with temp credential: %v", err)
-	}
-	iamClient := iam.NewFromConfig(awsCfg)
-
-	// 3. 기존 CreateCspRoleWithIamClient 로직 실행
-	return r.CreateCspRoleWithIamClient(req, iamClient)
-}
-
-// CreateCspRoleWithIamClient 내부 메서드로 변경
-func (r *CspRoleRepository) CreateCspRoleWithIamClient(req *model.CreateCspRoleRequest, awsIamClient *iam.Client) (*model.CspRole, error) {
-	idpIdentifier := ""
-	var existingRole model.CspRole
-
-	// roleName이 prefix로 시작하지 않으면 자동으로 prefix를 붙여서 cspRoleName 생성
-	if !strings.HasPrefix(req.CspRoleName, constants.CspRoleNamePrefix) {
-		req.CspRoleName = constants.CspRoleNamePrefix + req.CspRoleName
-	}
-
-	newRole := &model.CspRole{
-		Name:    req.CspRoleName,
-		CspType: req.CspType,
-	}
-	if err := r.db.Where("name = ? AND csp_type = ?", req.CspRoleName, req.CspType).First(&existingRole).Error; err != nil {
-		if err != gorm.ErrRecordNotFound {
-			return nil, fmt.Errorf("이미 존재합니다. 중복 생성 불가: %v", err)
-		}
-		log.Printf("db existing role: %v", existingRole)
-		getRoleInput := &iam.GetRoleInput{RoleName: aws.String(req.CspRoleName)}
-		var targetCspRole *iam.GetRoleOutput
-		if cspRoleResponse, err := awsIamClient.GetRole(context.TODO(), getRoleInput); err == nil {
-			newRole.Status = "created"
-			targetCspRole = cspRoleResponse
-		} else {
-			newRole.Status = "creating"
-		}
-		if err := r.db.Create(newRole).Error; err != nil {
-			return nil, fmt.Errorf("failed to create CSP role in database: %v", err)
-		}
-		if newRole.Status == "creating" {
-			assumeRolePolicyDocument, err := getRoleManagerAssumeRolePolicyDocument(newRole)
-			if err != nil {
-				newRole.Status = "failed"
-				r.db.Save(newRole)
-				return nil, fmt.Errorf("failed to generate assume role policy document: %v", err)
-			}
-			var policyDoc map[string]interface{}
-			if err := json.Unmarshal([]byte(assumeRolePolicyDocument), &policyDoc); err != nil {
-				newRole.Status = "failed"
-				r.db.Save(newRole)
-				return nil, fmt.Errorf("failed to parse assume role policy document: %v", err)
-			}
-			if statements, ok := policyDoc["Statement"].([]interface{}); ok && len(statements) > 0 {
-				if statement, ok := statements[0].(map[string]interface{}); ok {
-					if principal, ok := statement["Principal"].(map[string]interface{}); ok {
-						if federated, ok := principal["Federated"].(string); ok {
-							idpIdentifier = federated
-						}
-					}
-				}
-			}
-			input := &iam.CreateRoleInput{
-				RoleName:                 aws.String(req.CspRoleName),
-				AssumeRolePolicyDocument: aws.String(assumeRolePolicyDocument),
-				Description:              aws.String(newRole.Description),
-			}
-			_, err = awsIamClient.CreateRole(context.TODO(), input)
-			if err != nil {
-				newRole.Status = "failed"
-				r.db.Save(newRole)
-				return nil, fmt.Errorf("failed to create IAM role: %v", err)
-			}
-			for i := 0; i < 30; i++ {
-				time.Sleep(1 * time.Second)
-				getRoleResult, err := awsIamClient.GetRole(context.TODO(), getRoleInput)
-				if err == nil && getRoleResult != nil && getRoleResult.Role != nil {
-					createdRole := &model.CspRole{
-						ID:            newRole.ID,
-						Name:          *getRoleResult.Role.RoleName,
-						Description:   *getRoleResult.Role.Description,
-						CspType:       newRole.CspType,
-						IdpIdentifier: idpIdentifier,
-						Status:        "created",
-						CreateDate:    *getRoleResult.Role.CreateDate,
-						Path:          *getRoleResult.Role.Path,
-						IamRoleId:     *getRoleResult.Role.RoleId,
-						IamIdentifier: *getRoleResult.Role.Arn,
-					}
-					if getRoleResult.Role.MaxSessionDuration != nil {
-						createdRole.MaxSessionDuration = getRoleResult.Role.MaxSessionDuration
-					}
-					if getRoleResult.Role.PermissionsBoundary != nil && getRoleResult.Role.PermissionsBoundary.PermissionsBoundaryArn != nil {
-						createdRole.PermissionsBoundary = *getRoleResult.Role.PermissionsBoundary.PermissionsBoundaryArn
-					}
-					if getRoleResult.Role.RoleLastUsed != nil {
-						roleLastUsed := &model.RoleLastUsed{}
-						if getRoleResult.Role.RoleLastUsed.LastUsedDate != nil {
-							roleLastUsed.LastUsedDate = *getRoleResult.Role.RoleLastUsed.LastUsedDate
-						}
-						if getRoleResult.Role.RoleLastUsed.Region != nil {
-							roleLastUsed.Region = *getRoleResult.Role.RoleLastUsed.Region
-						}
-						createdRole.RoleLastUsed = roleLastUsed
-					}
-					if len(getRoleResult.Role.Tags) > 0 {
-						tags := make([]model.Tag, len(getRoleResult.Role.Tags))
-						for i, tag := range getRoleResult.Role.Tags {
-							if tag.Key != nil && tag.Value != nil {
-								tags[i] = model.Tag{
-									Key:   *tag.Key,
-									Value: *tag.Value,
-								}
-							}
-						}
-						createdRole.Tags = tags
-					}
-					if err := r.db.Save(createdRole).Error; err != nil {
-						return nil, fmt.Errorf("failed to update CSP role in database: %v", err)
-					}
-					return createdRole, nil
-				}
-			}
-			newRole.Status = "failed"
-			if err := r.db.Save(newRole).Error; err != nil {
-				return nil, fmt.Errorf("failed to update CSP role status to failed: %v", err)
-			}
-			return nil, fmt.Errorf("failed to verify IAM role creation after 5 attempts")
-		} else {
-			newRole.Status = "created"
-			newRole.IamIdentifier = *targetCspRole.Role.Arn
-			newRole.CreateDate = *targetCspRole.Role.CreateDate
-			newRole.Path = *targetCspRole.Role.Path
-			newRole.IamRoleId = *targetCspRole.Role.RoleId
-			newRole.Description = getRoleDescription(*targetCspRole.Role)
-			if targetCspRole.Role.MaxSessionDuration != nil {
-				newRole.MaxSessionDuration = targetCspRole.Role.MaxSessionDuration
-			}
-			if targetCspRole.Role.PermissionsBoundary != nil && targetCspRole.Role.PermissionsBoundary.PermissionsBoundaryArn != nil {
-				newRole.PermissionsBoundary = *targetCspRole.Role.PermissionsBoundary.PermissionsBoundaryArn
-			}
-			if targetCspRole.Role.RoleLastUsed != nil {
-				roleLastUsed := &model.RoleLastUsed{}
-				if targetCspRole.Role.RoleLastUsed.LastUsedDate != nil {
-					roleLastUsed.LastUsedDate = *targetCspRole.Role.RoleLastUsed.LastUsedDate
-				}
-				if targetCspRole.Role.RoleLastUsed.Region != nil {
-					roleLastUsed.Region = *targetCspRole.Role.RoleLastUsed.Region
-				}
-				newRole.RoleLastUsed = roleLastUsed
-			}
-			if len(targetCspRole.Role.Tags) > 0 {
-				tags := make([]model.Tag, len(targetCspRole.Role.Tags))
-				for i, tag := range targetCspRole.Role.Tags {
-					if tag.Key != nil && tag.Value != nil {
-						tags[i] = model.Tag{
-							Key:   *tag.Key,
-							Value: *tag.Value,
-						}
-					}
-				}
-				newRole.Tags = tags
-			}
-			if err := r.db.Save(newRole).Error; err != nil {
-				return nil, fmt.Errorf("failed to update CSP role in database: %v", err)
-			}
-			return newRole, nil
-		}
-	} else {
-		return nil, fmt.Errorf("csp role already exists in database")
-	}
+	return nil
 }
 
 // createAwsConfigWithTempCredential 임시 자격 증명으로 AWS 설정을 생성합니다.
 func (r *CspRoleRepository) createAwsConfigWithTempCredential(credential *model.TempCredential) (aws.Config, error) {
-	// AWS SDK v2 설정 생성
 	cfg, err := config.LoadDefaultConfig(context.TODO())
 	if err != nil {
 		return aws.Config{}, fmt.Errorf("failed to load default AWS config: %v", err)
 	}
-
-	// 임시 자격 증명으로 설정 업데이트
 	cfg.Credentials = aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(
 		credential.AccessKeyId,
 		credential.SecretAccessKey,
 		credential.SessionToken,
 	))
-
-	// 리전 설정
 	cfg.Region = credential.Region
-
 	return cfg, nil
 }
 

--- a/src/service/alibaba_credential_service.go
+++ b/src/service/alibaba_credential_service.go
@@ -89,6 +89,8 @@ func (s *alibabaCredentialService) AssumeRoleWithSAML(
 	formData.Set("SAMLAssertion", samlAssertion)
 	formData.Set("RoleSessionName", sessionName)
 	formData.Set("Format", "JSON")
+	formData.Set("Timestamp", time.Now().UTC().Format("2006-01-02T15:04:05Z"))
+	formData.Set("SignatureNonce", fmt.Sprintf("%d", time.Now().UnixNano()))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, alibabaStsEndpoint, strings.NewReader(formData.Encode()))
 	if err != nil {

--- a/src/service/csp_credential_service.go
+++ b/src/service/csp_credential_service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/m-cmp/mc-iam-manager/model"
 	"github.com/m-cmp/mc-iam-manager/repository"
@@ -183,14 +184,42 @@ func (s *CspCredentialService) GetTemporaryCredentials(ctx context.Context, user
 			log.Printf("[CSP_CREDENTIAL] Calling AWS AssumeRoleWithWebIdentity...")
 			return s.awsCredService.AssumeRoleWithWebIdentity(ctx, roleArn, kcUserId, impersonationToken.AccessToken, idpArn, region)
 		case model.AuthMethodSAML:
+			// === 사전 체크 게이트: DB / Keycloak / CSP 설정 상태 확인 ===
+
+			// Check 1: DB — extended_config.saml_client_id 등록 여부
 			samlClientAudience := idpArn
 			if extConfig, ok := targetCspRole.ExtendedConfig["saml_client_id"].(string); ok && extConfig != "" {
 				samlClientAudience = extConfig
+			} else {
+				defaultClientID := os.Getenv("SAML_CLIENT_ID_AWS")
+				return nil, fmt.Errorf("[설정 누락: DB] CspRole(id=%d)에 saml_client_id 미등록. "+
+					"조치: UPDATE mcmp_role_csp_roles SET extended_config='{\"saml_client_id\":\"%s\"}' WHERE id=%d",
+					targetCspRole.ID, defaultClientID, targetCspRole.ID)
 			}
+			log.Printf("[CSP_CREDENTIAL] Check 1 PASS: saml_client_id=%s (CspRole %d)", samlClientAudience, targetCspRole.ID)
+
+			// Check 2: Keycloak — SAML 클라이언트 존재 확인
+			if _, err := s.keycloakService.CheckSAMLClientConfig(ctx, samlClientAudience); err != nil {
+				return nil, fmt.Errorf("[설정 누락: Keycloak] SAML 클라이언트 '%s' 확인 실패: %w. "+
+					"조치: (1) Keycloak Clients에서 '%s' SAML 클라이언트 등록 "+
+					"(2) token-exchange permission에서 mciam-oidc-Client policy 연결",
+					samlClientAudience, err, samlClientAudience)
+			}
+			log.Printf("[CSP_CREDENTIAL] Check 2 PASS: Keycloak SAML client '%s' 확인", samlClientAudience)
+
+			// Check 3: CSP — AWS SAML Provider 존재 확인 (IAM 읽기 권한 있을 때만 검증, 없으면 경고 후 진행)
+			if _, err := s.awsCredService.CheckSAMLProvider(ctx, idpArn); err != nil {
+				log.Printf("[CSP_CREDENTIAL] Check 3 WARN: AWS SAML Provider 확인 불가 (IAM 읽기 권한 미보유) — idpArn=%s, err=%v. "+
+					"미등록 시 조치: AWS IAM → Identity providers에서 SAML Provider 등록 및 Keycloak metadata XML 업로드", idpArn, err)
+			} else {
+				log.Printf("[CSP_CREDENTIAL] Check 3 PASS: AWS SAML Provider '%s' 확인", idpArn)
+			}
+
+			// 모든 체크 통과 — SAML Assertion 발급 및 STS 호출
 			samlAssertion, err := s.keycloakService.GetSamlAssertionByServiceAccount(ctx, samlClientAudience)
 			if err != nil {
 				log.Printf("[CSP_CREDENTIAL] Error getting SAML assertion for AWS: %v", err)
-				return nil, fmt.Errorf("failed to get SAML assertion for AWS: %w", err)
+				return nil, fmt.Errorf("SAML Assertion 발급 실패: %w", err)
 			}
 			log.Printf("[CSP_CREDENTIAL] Calling AWS AssumeRoleWithSAML...")
 			return s.awsCredService.AssumeRoleWithSAML(ctx, roleArn, idpArn, samlAssertion, region)
@@ -217,14 +246,37 @@ func (s *CspCredentialService) GetTemporaryCredentials(ctx context.Context, user
 	case "alibaba":
 		switch authMethod {
 		case model.AuthMethodSAML:
+			// === 사전 체크 게이트: DB / Keycloak / CSP 설정 상태 확인 ===
+
+			// Check 1: DB — extended_config.saml_client_id 등록 여부
 			samlClientAudience := idpArn
 			if extConfig, ok := targetCspRole.ExtendedConfig["saml_client_id"].(string); ok && extConfig != "" {
 				samlClientAudience = extConfig
+			} else {
+				defaultClientID := os.Getenv("SAML_CLIENT_ID_ALIBABA")
+				return nil, fmt.Errorf("[설정 누락: DB] CspRole(id=%d)에 saml_client_id 미등록. "+
+					"조치: UPDATE mcmp_role_csp_roles SET extended_config='{\"saml_client_id\":\"%s\"}' WHERE id=%d",
+					targetCspRole.ID, defaultClientID, targetCspRole.ID)
 			}
+			log.Printf("[CSP_CREDENTIAL] Check 1 PASS: saml_client_id=%s (CspRole %d)", samlClientAudience, targetCspRole.ID)
+
+			// Check 2: Keycloak — SAML 클라이언트 존재 확인
+			if _, err := s.keycloakService.CheckSAMLClientConfig(ctx, samlClientAudience); err != nil {
+				return nil, fmt.Errorf("[설정 누락: Keycloak] SAML 클라이언트 '%s' 확인 실패: %w. "+
+					"조치: (1) Keycloak Clients에서 '%s' SAML 클라이언트 등록 "+
+					"(2) token-exchange permission에서 mciam-oidc-Client policy 연결",
+					samlClientAudience, err, samlClientAudience)
+			}
+			log.Printf("[CSP_CREDENTIAL] Check 2 PASS: Keycloak SAML client '%s' 확인", samlClientAudience)
+
+			// Check 3: CSP — Alibaba SAML Provider 존재 확인 (미구현 시 경고 로그 후 진행)
+			log.Printf("[CSP_CREDENTIAL] Check 3 SKIP: Alibaba SAML Provider 확인 미구현 — idpArn=%s", idpArn)
+
+			// 모든 체크 통과 — SAML Assertion 발급 및 STS 호출
 			samlAssertion, err := s.keycloakService.GetSamlAssertionByServiceAccount(ctx, samlClientAudience)
 			if err != nil {
 				log.Printf("[CSP_CREDENTIAL] Error getting SAML assertion for Alibaba: %v", err)
-				return nil, fmt.Errorf("failed to get SAML assertion for Alibaba: %w", err)
+				return nil, fmt.Errorf("SAML Assertion 발급 실패: %w", err)
 			}
 			log.Printf("[CSP_CREDENTIAL] Calling Alibaba AssumeRoleWithSAML...")
 			return s.alibabaCredService.AssumeRoleWithSAML(ctx, idpArn, roleArn, samlAssertion, region)

--- a/src/service/csp_role_service.go
+++ b/src/service/csp_role_service.go
@@ -1,10 +1,14 @@
 package service
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
+	"strings"
+	"text/template"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -12,6 +16,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	mciamConfig "github.com/m-cmp/mc-iam-manager/config"
+	"github.com/m-cmp/mc-iam-manager/constants"
 	"github.com/m-cmp/mc-iam-manager/csp"
 	"github.com/m-cmp/mc-iam-manager/model"
 	"github.com/m-cmp/mc-iam-manager/repository"
@@ -60,9 +66,56 @@ func (s *CspRoleService) GetMciamCSPRoles(ctx context.Context, cspType string) (
 }
 
 // CreateCspRole CSP 역할을 생성합니다.
+// CSP role(클라우드 IAM 역할) + Keycloak client 설정을 추상적으로 처리합니다.
+// CSP별 구현은 private 메서드로 디스패치합니다.
 func (s *CspRoleService) CreateCspRole(req *model.CreateCspRoleRequest) (*model.CspRole, error) {
-	// 1. 유효한 임시 자격 증명이 있는지 확인하고, 없으면 새로 생성
-	issuedBy := "system" // cspRole 생성은 system만 한다.
+	// 1. prefix 정규화
+	if !strings.HasPrefix(req.CspRoleName, constants.CspRoleNamePrefix) {
+		req.CspRoleName = constants.CspRoleNamePrefix + req.CspRoleName
+	}
+
+	// 2. DB 중복 확인
+	existing, err := s.cspRoleRepo.GetCspRoleByName(req.CspRoleName, req.CspType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check existing CSP role: %w", err)
+	}
+	if existing != nil {
+		return existing, nil
+	}
+
+	// 3. CSP별 역할 생성 디스패치
+	var cspRole *model.CspRole
+	switch req.CspType {
+	case "aws":
+		cspRole, err = s.createAwsIamRole(req)
+	default:
+		// AWS 이외 CSP: DB 등록만 수행 (클라우드 역할 생성은 향후 확장)
+		cspRole = &model.CspRole{
+			Name:        req.CspRoleName,
+			Description: req.Description,
+			CspType:     req.CspType,
+			Status:      "created",
+		}
+		if err := s.cspRoleRepo.CreateCspRoleRecord(cspRole); err != nil {
+			return nil, fmt.Errorf("failed to create CSP role record: %w", err)
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// 4. Keycloak 클라이언트 확인
+	if kcErr := s.ensureKeycloakClientForCspRole(req, cspRole); kcErr != nil {
+		log.Printf("Warning: Keycloak client check failed for CSP role %s: %v", cspRole.Name, kcErr)
+	}
+
+	return cspRole, nil
+}
+
+// createAwsIamRole AWS IAM 역할을 생성합니다. (private, AWS 전용)
+func (s *CspRoleService) createAwsIamRole(req *model.CreateCspRoleRequest) (*model.CspRole, error) {
+	// 1. 임시 자격 증명 획득
+	issuedBy := "system"
 	credential, err := s.tempCredentialRepo.GetOrCreateValidCredential("aws", "oidc", "ap-northeast-2", nil, issuedBy, func() (*model.TempCredential, error) {
 		return s.createNewAwsCredential(issuedBy)
 	})
@@ -70,43 +123,297 @@ func (s *CspRoleService) CreateCspRole(req *model.CreateCspRoleRequest) (*model.
 		return nil, fmt.Errorf("failed to get or create valid credential: %v", err)
 	}
 
-	// 2. 임시 자격 증명으로 AWS IAM 클라이언트 생성
+	// 2. AWS IAM 클라이언트 생성
 	awsCfg, err := s.createAwsConfigWithTempCredential(credential)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create AWS config with temp credential: %v", err)
 	}
-	iamClient := iam.NewFromConfig(awsCfg)
+	awsIamClient := iam.NewFromConfig(awsCfg)
 
-	// 3. CspRoleRepository의 내부 메서드 호출 (임시 자격 증명 관리 로직 제거)
-	return s.cspRoleRepo.CreateCspRoleWithIamClient(req, iamClient)
+	// 3. DB에 초기 레코드 생성
+	newRole := &model.CspRole{
+		Name:    req.CspRoleName,
+		CspType: req.CspType,
+	}
+
+	// AWS에서 역할 존재 여부 확인
+	getRoleInput := &iam.GetRoleInput{RoleName: aws.String(req.CspRoleName)}
+	var targetCspRole *iam.GetRoleOutput
+	if cspRoleResponse, getErr := awsIamClient.GetRole(context.TODO(), getRoleInput); getErr == nil {
+		newRole.Status = "created"
+		targetCspRole = cspRoleResponse
+	} else {
+		newRole.Status = "creating"
+	}
+
+	if err := s.cspRoleRepo.CreateCspRoleRecord(newRole); err != nil {
+		return nil, fmt.Errorf("failed to create CSP role in database: %v", err)
+	}
+
+	if newRole.Status == "creating" {
+		// 4. AssumeRolePolicyDocument 생성 및 AWS IAM Role 생성
+		return s.createAndPollAwsIamRole(awsIamClient, newRole, req)
+	}
+
+	// 이미 AWS에 존재하는 경우 정보 동기화
+	return s.syncAwsRoleToDb(newRole, targetCspRole)
 }
 
-// createNewAwsCredential 새로운 AWS 임시 자격 증명을 생성합니다.
+// createAndPollAwsIamRole AWS IAM Role을 생성하고 polling으로 완료를 대기합니다. (private)
+func (s *CspRoleService) createAndPollAwsIamRole(awsIamClient *iam.Client, newRole *model.CspRole, req *model.CreateCspRoleRequest) (*model.CspRole, error) {
+	idpIdentifier := ""
+
+	assumeRolePolicyDocument, err := getAwsAssumeRolePolicyDocument(newRole)
+	if err != nil {
+		newRole.Status = "failed"
+		s.cspRoleRepo.UpdateCspRoleRecord(newRole)
+		return nil, fmt.Errorf("failed to generate assume role policy document: %v", err)
+	}
+
+	// IdP identifier 추출
+	var policyDoc map[string]interface{}
+	if err := json.Unmarshal([]byte(assumeRolePolicyDocument), &policyDoc); err != nil {
+		newRole.Status = "failed"
+		s.cspRoleRepo.UpdateCspRoleRecord(newRole)
+		return nil, fmt.Errorf("failed to parse assume role policy document: %v", err)
+	}
+	if statements, ok := policyDoc["Statement"].([]interface{}); ok && len(statements) > 0 {
+		if statement, ok := statements[0].(map[string]interface{}); ok {
+			if principal, ok := statement["Principal"].(map[string]interface{}); ok {
+				if federated, ok := principal["Federated"].(string); ok {
+					idpIdentifier = federated
+				}
+			}
+		}
+	}
+
+	// AWS IAM Role 생성
+	input := &iam.CreateRoleInput{
+		RoleName:                 aws.String(req.CspRoleName),
+		AssumeRolePolicyDocument: aws.String(assumeRolePolicyDocument),
+		Description:              aws.String(newRole.Description),
+	}
+	_, err = awsIamClient.CreateRole(context.TODO(), input)
+	if err != nil {
+		newRole.Status = "failed"
+		s.cspRoleRepo.UpdateCspRoleRecord(newRole)
+		return nil, fmt.Errorf("failed to create IAM role: %v", err)
+	}
+
+	// Polling: 역할 생성 완료 대기
+	getRoleInput := &iam.GetRoleInput{RoleName: aws.String(req.CspRoleName)}
+	for i := 0; i < 30; i++ {
+		time.Sleep(1 * time.Second)
+		getRoleResult, err := awsIamClient.GetRole(context.TODO(), getRoleInput)
+		if err == nil && getRoleResult != nil && getRoleResult.Role != nil {
+			createdRole := mapAwsRoleToModel(newRole.ID, newRole.CspType, idpIdentifier, getRoleResult)
+			if err := s.cspRoleRepo.UpdateCspRoleRecord(createdRole); err != nil {
+				return nil, fmt.Errorf("failed to update CSP role in database: %v", err)
+			}
+			return createdRole, nil
+		}
+	}
+
+	newRole.Status = "failed"
+	s.cspRoleRepo.UpdateCspRoleRecord(newRole)
+	return nil, fmt.Errorf("failed to verify IAM role creation after 30 attempts")
+}
+
+// syncAwsRoleToDb 이미 AWS에 존재하는 역할 정보를 DB에 동기화합니다. (private)
+func (s *CspRoleService) syncAwsRoleToDb(newRole *model.CspRole, targetCspRole *iam.GetRoleOutput) (*model.CspRole, error) {
+	newRole.Status = "created"
+	newRole.IamIdentifier = *targetCspRole.Role.Arn
+	newRole.CreateDate = *targetCspRole.Role.CreateDate
+	newRole.Path = *targetCspRole.Role.Path
+	newRole.IamRoleId = *targetCspRole.Role.RoleId
+	if targetCspRole.Role.Description != nil {
+		newRole.Description = *targetCspRole.Role.Description
+	}
+	if targetCspRole.Role.MaxSessionDuration != nil {
+		newRole.MaxSessionDuration = targetCspRole.Role.MaxSessionDuration
+	}
+	if targetCspRole.Role.PermissionsBoundary != nil && targetCspRole.Role.PermissionsBoundary.PermissionsBoundaryArn != nil {
+		newRole.PermissionsBoundary = *targetCspRole.Role.PermissionsBoundary.PermissionsBoundaryArn
+	}
+	if targetCspRole.Role.RoleLastUsed != nil {
+		roleLastUsed := &model.RoleLastUsed{}
+		if targetCspRole.Role.RoleLastUsed.LastUsedDate != nil {
+			roleLastUsed.LastUsedDate = *targetCspRole.Role.RoleLastUsed.LastUsedDate
+		}
+		if targetCspRole.Role.RoleLastUsed.Region != nil {
+			roleLastUsed.Region = *targetCspRole.Role.RoleLastUsed.Region
+		}
+		newRole.RoleLastUsed = roleLastUsed
+	}
+	if len(targetCspRole.Role.Tags) > 0 {
+		tags := make([]model.Tag, len(targetCspRole.Role.Tags))
+		for i, tag := range targetCspRole.Role.Tags {
+			if tag.Key != nil && tag.Value != nil {
+				tags[i] = model.Tag{
+					Key:   *tag.Key,
+					Value: *tag.Value,
+				}
+			}
+		}
+		newRole.Tags = tags
+	}
+	if err := s.cspRoleRepo.UpdateCspRoleRecord(newRole); err != nil {
+		return nil, fmt.Errorf("failed to update CSP role in database: %v", err)
+	}
+	return newRole, nil
+}
+
+// ensureKeycloakClientForCspRole CSP 역할에 대응하는 Keycloak 클라이언트 설정을 확인합니다. (private)
+func (s *CspRoleService) ensureKeycloakClientForCspRole(req *model.CreateCspRoleRequest, role *model.CspRole) error {
+	if s.keycloakService == nil {
+		return nil
+	}
+
+	ctx := context.TODO()
+
+	// AuthMethod에 따라 SAML/OIDC 클라이언트 확인
+	switch req.AuthMethod {
+	case constants.AuthMethodSAML:
+		// CSP별 SAML 클라이언트 ID 환경변수
+		samlClientID := ""
+		switch req.CspType {
+		case "aws":
+			samlClientID = os.Getenv("SAML_CLIENT_ID_AWS")
+		case "alibaba":
+			samlClientID = os.Getenv("SAML_CLIENT_ID_ALIBABA")
+		}
+		if samlClientID != "" {
+			if _, err := s.keycloakService.CheckSAMLClientConfig(ctx, samlClientID); err != nil {
+				return fmt.Errorf("SAML client check failed for %s: %w", req.CspType, err)
+			}
+		}
+	case constants.AuthMethodOIDC:
+		// OIDC 클라이언트는 공용 mciam 클라이언트를 사용하므로 별도 확인 불필요
+		log.Printf("OIDC client for CSP role %s: using shared mciam OIDC client", role.Name)
+	}
+
+	return nil
+}
+
+// --- AWS 전용 헬퍼 함수 (private) ---
+
+type awsPolicyValues struct {
+	AccountID        string
+	KeycloakHostname string
+	Subject          string
+	Audience         string
+}
+
+// getAwsAssumeRolePolicyDocument 플랫폼 관리자용 AssumeRole 정책 문서를 반환합니다.
+func getAwsAssumeRolePolicyDocument(role *model.CspRole) (string, error) {
+	const policyTemplate = `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::{{.AccountID}}:oidc-provider/{{.KeycloakHostname}}"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"{{.KeycloakHostname}}:aud": "{{.Audience}}"
+					}
+				}
+			}
+		]
+	}`
+
+	oidcClientID := os.Getenv("KEYCLOAK_OIDC_CLIENT_ID")
+	if oidcClientID == "" {
+		return "", fmt.Errorf("KEYCLOAK_OIDC_CLIENT environment variable is not set")
+	}
+
+	values := awsPolicyValues{
+		AccountID:        "050864702683",
+		KeycloakHostname: mciamConfig.KC.Host,
+		Audience:         oidcClientID,
+	}
+
+	tmpl, err := template.New("policy").Parse(policyTemplate)
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, values)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// mapAwsRoleToModel AWS IAM GetRole 응답을 CspRole 모델로 매핑합니다.
+func mapAwsRoleToModel(id uint, cspType string, idpIdentifier string, getRoleResult *iam.GetRoleOutput) *model.CspRole {
+	createdRole := &model.CspRole{
+		ID:            id,
+		Name:          *getRoleResult.Role.RoleName,
+		Description:   *getRoleResult.Role.Description,
+		CspType:       cspType,
+		IdpIdentifier: idpIdentifier,
+		Status:        "created",
+		CreateDate:    *getRoleResult.Role.CreateDate,
+		Path:          *getRoleResult.Role.Path,
+		IamRoleId:     *getRoleResult.Role.RoleId,
+		IamIdentifier: *getRoleResult.Role.Arn,
+	}
+	if getRoleResult.Role.MaxSessionDuration != nil {
+		createdRole.MaxSessionDuration = getRoleResult.Role.MaxSessionDuration
+	}
+	if getRoleResult.Role.PermissionsBoundary != nil && getRoleResult.Role.PermissionsBoundary.PermissionsBoundaryArn != nil {
+		createdRole.PermissionsBoundary = *getRoleResult.Role.PermissionsBoundary.PermissionsBoundaryArn
+	}
+	if getRoleResult.Role.RoleLastUsed != nil {
+		roleLastUsed := &model.RoleLastUsed{}
+		if getRoleResult.Role.RoleLastUsed.LastUsedDate != nil {
+			roleLastUsed.LastUsedDate = *getRoleResult.Role.RoleLastUsed.LastUsedDate
+		}
+		if getRoleResult.Role.RoleLastUsed.Region != nil {
+			roleLastUsed.Region = *getRoleResult.Role.RoleLastUsed.Region
+		}
+		createdRole.RoleLastUsed = roleLastUsed
+	}
+	if len(getRoleResult.Role.Tags) > 0 {
+		tags := make([]model.Tag, len(getRoleResult.Role.Tags))
+		for i, tag := range getRoleResult.Role.Tags {
+			if tag.Key != nil && tag.Value != nil {
+				tags[i] = model.Tag{
+					Key:   *tag.Key,
+					Value: *tag.Value,
+				}
+			}
+		}
+		createdRole.Tags = tags
+	}
+	return createdRole
+}
+
+// createNewAwsCredential 새로운 AWS 임시 자격 증명을 생성합니다. (private)
 func (s *CspRoleService) createNewAwsCredential(issuedBy string) (*model.TempCredential, error) {
-	// Keycloak에서 OIDC 토큰 획득
 	token, err := s.keycloakService.GetClientCredentialsToken(context.TODO())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Keycloak token: %v", err)
 	}
 
-	// AWS STS AssumeRoleWithWebIdentity 호출
 	stsClient := sts.NewFromConfig(aws.Config{
 		Region: "ap-northeast-2",
 	})
 
-	// AWS Identity Provider ARN (환경 변수에서 가져오기)
 	identityProviderArn := os.Getenv("IDENTITY_PROVIDER_ARN_AWS")
 	if identityProviderArn == "" {
 		return nil, fmt.Errorf("IDENTITY_PROVIDER_ARN_AWS environment variable is not set")
 	}
 
-	// Role ARN (환경 변수에서 가져오기)
 	roleArn := os.Getenv("IDENTITY_ROLE_ARN_AWS")
 	if roleArn == "" {
 		return nil, fmt.Errorf("IDENTITY_ROLE_ARN_AWS environment variable is not set")
 	}
 
-	// AssumeRoleWithWebIdentity 호출
 	input := &sts.AssumeRoleWithWebIdentityInput{
 		RoleArn:          aws.String(roleArn),
 		RoleSessionName:  aws.String("mcmp-iam-manager-session"),
@@ -118,7 +425,6 @@ func (s *CspRoleService) createNewAwsCredential(issuedBy string) (*model.TempCre
 		return nil, fmt.Errorf("failed to assume role with web identity: %v", err)
 	}
 
-	// 임시 자격 증명 모델 생성
 	credential := &model.TempCredential{
 		Provider:        "aws",
 		AuthType:        "oidc",
@@ -135,26 +441,24 @@ func (s *CspRoleService) createNewAwsCredential(issuedBy string) (*model.TempCre
 	return credential, nil
 }
 
-// createAwsConfigWithTempCredential 임시 자격 증명으로 AWS 설정을 생성합니다.
+// createAwsConfigWithTempCredential 임시 자격 증명으로 AWS 설정을 생성합니다. (private)
 func (s *CspRoleService) createAwsConfigWithTempCredential(credential *model.TempCredential) (aws.Config, error) {
-	// AWS SDK v2 설정 생성
 	cfg, err := config.LoadDefaultConfig(context.TODO())
 	if err != nil {
 		return aws.Config{}, fmt.Errorf("failed to load default AWS config: %v", err)
 	}
 
-	// 임시 자격 증명으로 설정 업데이트
 	cfg.Credentials = aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(
 		credential.AccessKeyId,
 		credential.SecretAccessKey,
 		credential.SessionToken,
 	))
-
-	// 리전 설정
 	cfg.Region = credential.Region
 
 	return cfg, nil
 }
+
+// --- 기존 public 메서드 (변경 없음) ---
 
 // GetCspRoles CSP 역할 목록을 조회합니다.
 func (s *CspRoleService) GetCspRoles(cspType string) ([]*model.CspRole, error) {
@@ -168,16 +472,12 @@ func (s *CspRoleService) GetCspRoleByID(id uint) (*model.CspRole, error) {
 
 // UpdateCspRole CSP 역할을 수정합니다.
 func (s *CspRoleService) UpdateCspRole(id uint, req *model.CreateCspRoleRequest) error {
-	// ID로 기존 역할 조회
 	existingRole, err := s.cspRoleRepo.GetRoleByID(id)
 	if err != nil {
 		return fmt.Errorf("failed to get existing role: %v", err)
 	}
-
-	// 요청 데이터로 업데이트
 	existingRole.Name = req.CspRoleName
 	existingRole.Description = req.Description
-
 	return s.cspRoleRepo.UpdateCSPRole(existingRole)
 }
 
@@ -198,7 +498,6 @@ func (s *CspRoleService) UpdateCSPRole(role *model.CspRole) error {
 		log.Printf("Failed to update CSP role: %v", err)
 		return err
 	}
-
 	return nil
 }
 
@@ -209,7 +508,6 @@ func (s *CspRoleService) DeleteCSPRole(id string) error {
 		log.Printf("Failed to delete CSP role: %v", err)
 		return err
 	}
-
 	return nil
 }
 
@@ -245,19 +543,16 @@ func (s *CspRoleService) GetCSPRolePermissions(roleID string) ([]string, error) 
 
 // GetRolePolicies 역할의 정책 목록 조회
 func (s *CspRoleService) GetRolePolicies(ctx context.Context, roleName string, cspType string) (*model.CspRole, error) {
-	// 1. 역할 존재 여부 확인
 	role, err := s.cspRoleRepo.GetCspRoleByName(roleName, cspType)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get role: %w", err)
 	}
 
-	// 2. 관리형 정책 목록 조회
 	managedPolicies, err := s.cspRoleRepo.ListAttachedRolePolicies(ctx, roleName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list attached role policies: %w", err)
 	}
 
-	// 3. 인라인 정책 목록 조회
 	inlinePolicies, err := s.cspRoleRepo.ListRolePolicies(ctx, roleName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list role policies: %w", err)
@@ -265,7 +560,6 @@ func (s *CspRoleService) GetRolePolicies(ctx context.Context, roleName string, c
 
 	role.Permissions = managedPolicies
 	role.Permissions = append(role.Permissions, inlinePolicies...)
-
 	return role, nil
 }
 
@@ -285,12 +579,8 @@ func (s *CspRoleService) DeleteRolePolicy(ctx context.Context, roleName string, 
 }
 
 // CreateOrUpdateCspRole CSP 역할을 생성하거나 업데이트합니다.
-// ID가 비어있으면 새로 생성하고, ID가 있으면 기존 것을 업데이트합니다.
 func (s *CspRoleService) CreateOrUpdateCspRole(req *model.CreateCspRoleRequest) (*model.CspRole, error) {
-
 	if req.ID == "" {
-		// ID 가 없더라고 type이 다른 cspRole이 있을 수 있으므로 조회
-
 		cspRole, err := s.GetCspRoleByName(req.CspRoleName, req.CspType)
 		if err != nil {
 			if err != gorm.ErrRecordNotFound {
@@ -299,39 +589,35 @@ func (s *CspRoleService) CreateOrUpdateCspRole(req *model.CreateCspRoleRequest) 
 		}
 		if cspRole != nil {
 			return cspRole, nil
-		} else {
-			return s.CreateCspRole(req)
 		}
-
-	} else {
-		id, err := util.StringToUint(req.ID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert ID to uint: %w", err)
-		}
-		// ID가 있으면 업데이트
-		cspRole := &model.CspRole{
-			ID:            id,
-			Name:          req.CspRoleName,
-			Description:   req.Description,
-			CspType:       req.CspType,
-			IdpIdentifier: req.IdpIdentifier,
-			IamIdentifier: req.IamIdentifier,
-			Status:        req.Status,
-			Path:          req.Path,
-			IamRoleId:     req.IamRoleId,
-		}
-		err = s.UpdateCSPRole(cspRole)
-		if err != nil {
-			return nil, err
-		}
-		return cspRole, nil
+		return s.CreateCspRole(req)
 	}
+
+	id, err := util.StringToUint(req.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert ID to uint: %w", err)
+	}
+	cspRole := &model.CspRole{
+		ID:            id,
+		Name:          req.CspRoleName,
+		Description:   req.Description,
+		CspType:       req.CspType,
+		IdpIdentifier: req.IdpIdentifier,
+		IamIdentifier: req.IamIdentifier,
+		Status:        req.Status,
+		Path:          req.Path,
+		IamRoleId:     req.IamRoleId,
+	}
+	err = s.UpdateCSPRole(cspRole)
+	if err != nil {
+		return nil, err
+	}
+	return cspRole, nil
 }
 
 // CreateCspRoles 복수 CSP 역할을 생성합니다.
 func (s *CspRoleService) CreateCspRoles(req *model.CreateCspRolesRequest) ([]*model.CspRole, error) {
 	var createdRoles []*model.CspRole
-
 	for _, cspRoleReq := range req.CspRoles {
 		createdRole, err := s.CreateCspRole(&cspRoleReq)
 		if err != nil {
@@ -339,7 +625,6 @@ func (s *CspRoleService) CreateCspRoles(req *model.CreateCspRolesRequest) ([]*mo
 		}
 		createdRoles = append(createdRoles, createdRole)
 	}
-
 	return createdRoles, nil
 }
 
@@ -357,7 +642,7 @@ func (s *CspRoleService) GetCspRolesByName(roleName string, cspType string) ([]*
 	roles, err := s.cspRoleRepo.GetCspRolesByName(roleName)
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
-			return nil, nil // 역할이 존재하지 않음
+			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to get CSP role by name at GetCspRolesByName: %w", err)
 	}

--- a/src/service/csp_validation_service.go
+++ b/src/service/csp_validation_service.go
@@ -315,11 +315,10 @@ func (s *CspValidationService) validateAWSWithSAML(ctx context.Context, userID u
 	}
 
 	// Step 3: Keycloak SAML 클라이언트 확인
-	// AWS SAML 클라이언트 ID는 urn:amazon:webservices (AWS 규약)
-	// extendedConfig["saml_client_id"]가 없으면 urn:amazon:webservices로 조회
+	// AWS SAML 클라이언트 ID: extendedConfig["saml_client_id"] 우선, 없으면 SAML_CLIENT_ID_AWS 환경변수 사용
 	kcSamlClientID := samlClientAudience
 	if cspType == "aws" && !strings.Contains(kcSamlClientID, "urn:amazon") {
-		kcSamlClientID = "urn:amazon:webservices"
+		kcSamlClientID = os.Getenv("SAML_CLIENT_ID_AWS")
 	}
 	if !stepRunner(steps, 2, func() (string, error) {
 		return s.keycloakService.CheckSAMLClientConfig(ctx, kcSamlClientID)

--- a/src/service/keycloak_service.go
+++ b/src/service/keycloak_service.go
@@ -1852,20 +1852,16 @@ func (s *keycloakService) CheckSAMLClientConfig(ctx context.Context, clientID st
 		return "", fmt.Errorf("Protocol mapper 파싱 실패: %v", err)
 	}
 
-	// Role attribute mapper 확인 (AWS SAML Role 전달용)
+	// Role attribute mapper 확인 (CSP SAML Role 전달용)
 	hasRoleMapper := false
 	for _, m := range mappers {
 		if m.ProtocolMapper == "saml-role-list-mapper" || m.ProtocolMapper == "saml-hardcode-attribute-mapper" {
-			attrName := m.Config["attribute.name"]
-			if strings.Contains(attrName, "aws.amazon.com/SAML/Attributes/Role") ||
-				m.ProtocolMapper == "saml-role-list-mapper" {
-				hasRoleMapper = true
-				break
-			}
+			hasRoleMapper = true
+			break
 		}
 	}
 	if !hasRoleMapper {
-		return "", fmt.Errorf("Role attribute mapper 없음 — saml-role-list-mapper 또는 saml-hardcode-attribute-mapper에 https://aws.amazon.com/SAML/Attributes/Role 설정 필요")
+		return "", fmt.Errorf("Role attribute mapper 없음 — saml-role-list-mapper 또는 saml-hardcode-attribute-mapper 설정 필요")
 	}
 
 	mapperNames := make([]string, 0, len(mappers))


### PR DESCRIPTION
## Summary

- **fix(M4-CSP-033)**: Alibaba STS `AssumeRoleWithSAML`에 누락된 `Timestamp`/`SignatureNonce` 파라미터 추가. `CheckSAMLClientConfig` Role mapper 체크를 AWS 전용에서 CSP-agnostic으로 변경
- **feat(M4-CSP-034)**: SAML 자격증명 발급 전 3단계 pre-check gate 추가 (DB saml_client_id 등록 여부 → Keycloak SAML 클라이언트 존재 → CSP SAML Provider 존재), 각 실패 시 조치 가이드 에러 메시지 반환. `SAML_CLIENT_ID_AWS` / `SAML_CLIENT_ID_ALIBABA` 환경변수 추가
- **refactor(M4-CSP)**: `CreateCspRoleWithIamClient` 및 AWS trust policy 생성 로직을 `CspRoleRepository`에서 `CspRoleService`로 이동. Repository는 DB 전용 `CreateCspRoleRecord`/`UpdateCspRoleRecord`만 제공. Service는 `switch(cspType)` CSP-agnostic 디스패처 구조로 재편

## Changes

| 파일 | 변경 내용 |
|------|----------|
| `src/service/alibaba_credential_service.go` | Timestamp, SignatureNonce 파라미터 추가 |
| `src/service/keycloak_service.go` | CheckSAMLClientConfig CSP-agnostic 처리 |
| `src/service/csp_credential_service.go` | SAML 3단계 pre-check gate 삽입 (AWS, Alibaba) |
| `src/service/csp_validation_service.go` | 하드코딩 ARN → 환경변수 `SAML_CLIENT_ID_AWS` |
| `src/service/csp_role_service.go` | CSP-agnostic 디스패처, AWS IAM 로직 private 메서드로 분리 |
| `src/repository/csp_role_repository.go` | AWS IAM 로직 제거, DB 전용 메서드만 유지 |
| `.env` / `.env_sample` | `SAML_CLIENT_ID_AWS`, `SAML_CLIENT_ID_ALIBABA` 추가 |

## Test plan

- [x] TC-M4-CSP-033: Alibaba SAML 통합 테스트 — feat-iam-csp-035 ST4에서 HTTP 200 확인 (Confluence ST4 v4)
- [x] TC-M4-CSP-034-02: AWS OIDC 회귀 테스트 — HTTP 200 확인
- [x] TC-M4-CSP-034-03: AWS SAML 통합 테스트 — HTTP 200 확인
- [x] TC-M4-CSP-034-05/06: SAML Check Gate 1/2 예외 처리 — HTTP 400 + 조치 가이드 확인
- [x] `go build ./...` 빌드 성공