### PR TITLE
fix(IAM-BUG-004): validateCspAccount 실제 CSP 인프라 검증 구현

### DIFF
--- a/src/handler/csp_account_handler.go
+++ b/src/handler/csp_account_handler.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/labstack/echo/v4"
 	"github.com/m-cmp/mc-iam-manager/model"
@@ -198,15 +199,15 @@ func (h *CspAccountHandler) DeleteCspAccount(c echo.Context) error {
 
 // ValidateCspAccount godoc
 // @Summary Validate CSP account
-// @Description Validate CSP account configuration
+// @Description Validate CSP account by checking actual CSP infrastructure (IDP provider existence, role trust policy, or credential validity) for each linked CspRole
 // @Tags csp-accounts
 // @Accept json
 // @Produce json
 // @Param accountId path string true "Account ID"
-// @Success 200 {object} map[string]string
+// @Success 200 {object} model.CspAccountValidationResponse
 // @Failure 400 {object} map[string]string
 // @Failure 404 {object} map[string]string
-// @Failure 500 {object} map[string]string
+// @Failure 503 {object} map[string]string
 // @Security BearerAuth
 // @Router /api/csp-accounts/id/{accountId}/validate [post]
 // @Id validateCspAccount
@@ -216,14 +217,22 @@ func (h *CspAccountHandler) ValidateCspAccount(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid account ID"})
 	}
 
-	if err := h.cspAccountService.ValidateCspAccount(accountID); err != nil {
-		if err.Error() == fmt.Sprintf("CSP account not found with ID: %d", accountID) {
-			return c.JSON(http.StatusNotFound, map[string]string{"error": err.Error()})
+	result, err := h.cspAccountService.ValidateCspAccount(c.Request().Context(), accountID)
+	if err != nil {
+		msg := err.Error()
+		if strings.Contains(msg, "not found") {
+			return c.JSON(http.StatusNotFound, map[string]string{"error": msg})
 		}
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("Validation failed: %v", err)})
+		if strings.Contains(msg, "no CSP roles") {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": msg})
+		}
+		if c.Request().Context().Err() != nil {
+			return c.JSON(http.StatusServiceUnavailable, map[string]string{"error": "CSP validation timeout"})
+		}
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": msg})
 	}
 
-	return c.JSON(http.StatusOK, map[string]string{"message": "CSP account is valid"})
+	return c.JSON(http.StatusOK, result)
 }
 
 // ActivateCspAccount godoc

--- a/src/model/csp_account.go
+++ b/src/model/csp_account.go
@@ -108,3 +108,22 @@ type UpdateCspAccountRequest struct {
 	IsActive    *bool             `json:"is_active"`
 	Description string            `json:"description"`
 }
+
+// CspAccountValidationResult 개별 CspRole(provider+method) 검증 결과
+type CspAccountValidationResult struct {
+	CspRoleID   uint   `json:"csp_role_id"`
+	CspRoleName string `json:"csp_role_name"`
+	CspType     string `json:"csp_type"`
+	AuthMethod  string `json:"auth_method"`
+	Valid       bool   `json:"valid"`
+	Detail      string `json:"detail,omitempty"`
+	Error       string `json:"error,omitempty"`
+}
+
+// CspAccountValidationResponse CSP 계정 인프라 검증 응답
+type CspAccountValidationResponse struct {
+	AccountID   uint                         `json:"account_id"`
+	AccountName string                       `json:"account_name"`
+	CspType     string                       `json:"csp_type"`
+	Results     []CspAccountValidationResult `json:"results"`
+}

--- a/src/repository/csp_role_repository.go
+++ b/src/repository/csp_role_repository.go
@@ -568,3 +568,12 @@ func (r *CspRoleRepository) getAwsIamClient(issuedBy string) (*iam.Client, error
 
 	return iam.NewFromConfig(cfg), nil
 }
+
+// GetByCspAccountID CspAccountID로 CspRole 목록 조회 (CspIdpConfig Preload)
+func (r *CspRoleRepository) GetByCspAccountID(accountID uint) ([]*model.CspRole, error) {
+	var roles []*model.CspRole
+	if err := r.db.Preload("CspIdpConfig").Where("csp_account_id = ?", accountID).Find(&roles).Error; err != nil {
+		return nil, fmt.Errorf("failed to get CSP roles by account ID: %w", err)
+	}
+	return roles, nil
+}

--- a/src/service/csp_account_service.go
+++ b/src/service/csp_account_service.go
@@ -1,8 +1,10 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/m-cmp/mc-iam-manager/model"
 	"github.com/m-cmp/mc-iam-manager/repository"
@@ -11,19 +13,23 @@ import (
 
 // CspAccountService CSP 계정 서비스
 type CspAccountService struct {
-	db              *gorm.DB
-	cspAccountRepo  *repository.CspAccountRepository
+	db               *gorm.DB
+	cspAccountRepo   *repository.CspAccountRepository
 	cspIdpConfigRepo *repository.CspIdpConfigRepository
 	cspPolicyRepo    *repository.CspPolicyRepository
+	cspRoleRepo      *repository.CspRoleRepository
+	awsCredService   AwsCredentialService
 }
 
 // NewCspAccountService 새 CspAccountService 인스턴스 생성
 func NewCspAccountService(db *gorm.DB) *CspAccountService {
 	return &CspAccountService{
-		db:              db,
-		cspAccountRepo:  repository.NewCspAccountRepository(db),
+		db:               db,
+		cspAccountRepo:   repository.NewCspAccountRepository(db),
 		cspIdpConfigRepo: repository.NewCspIdpConfigRepository(db),
 		cspPolicyRepo:    repository.NewCspPolicyRepository(db),
+		cspRoleRepo:      repository.NewCspRoleRepository(db),
+		awsCredService:   NewAwsCredentialService(),
 	}
 }
 
@@ -165,39 +171,169 @@ func (s *CspAccountService) DeleteCspAccount(id uint) error {
 	return nil
 }
 
-// ValidateCspAccount CSP 계정 유효성 검증
-func (s *CspAccountService) ValidateCspAccount(id uint) error {
+// ValidateCspAccount CSP 계정 인프라 검증 — 연결된 CspRole의 IDP/IAM 설정을 실제 CSP API로 확인
+func (s *CspAccountService) ValidateCspAccount(ctx context.Context, id uint) (*model.CspAccountValidationResponse, error) {
 	account, err := s.cspAccountRepo.GetByID(id)
 	if err != nil {
-		return fmt.Errorf("failed to get CSP account: %w", err)
+		return nil, fmt.Errorf("failed to get CSP account: %w", err)
 	}
 	if account == nil {
-		return fmt.Errorf("CSP account not found with ID: %d", id)
+		return nil, fmt.Errorf("CSP account not found with ID: %d", id)
 	}
 
-	// CSP 타입별 필수 필드 검증
-	switch account.CspType {
+	roles, err := s.cspRoleRepo.GetByCspAccountID(id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get CSP roles: %w", err)
+	}
+	if len(roles) == 0 {
+		return nil, fmt.Errorf("no CSP roles found for account ID: %d", id)
+	}
+
+	resp := &model.CspAccountValidationResponse{
+		AccountID:   account.ID,
+		AccountName: account.Name,
+		CspType:     account.CspType,
+		Results:     make([]model.CspAccountValidationResult, 0, len(roles)),
+	}
+
+	for _, role := range roles {
+		result := s.validateCspRole(ctx, role)
+		resp.Results = append(resp.Results, result)
+	}
+
+	log.Printf("Validated CSP account: %s (ID: %d), roles: %d", account.Name, account.ID, len(roles))
+	return resp, nil
+}
+
+// validateCspRole CspRole 단위로 CSP 인프라 검증
+func (s *CspAccountService) validateCspRole(ctx context.Context, role *model.CspRole) model.CspAccountValidationResult {
+	result := model.CspAccountValidationResult{
+		CspRoleID:   role.ID,
+		CspRoleName: role.Name,
+		CspType:     role.CspType,
+	}
+
+	if role.CspIdpConfig == nil {
+		result.AuthMethod = "UNKNOWN"
+		result.Valid = false
+		result.Error = "CspIdpConfig not linked to this CspRole"
+		return result
+	}
+
+	result.AuthMethod = string(role.CspIdpConfig.AuthMethod)
+
+	valCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	switch role.CspType {
 	case "aws":
-		if account.GetAccountID() == "" {
-			return fmt.Errorf("AWS account_id is required")
-		}
-	case "gcp":
-		if account.GetProjectID() == "" {
-			return fmt.Errorf("GCP project_id is required")
-		}
-	case "azure":
-		if account.GetSubscriptionID() == "" {
-			return fmt.Errorf("Azure subscription_id is required")
-		}
-		if account.GetTenantID() == "" {
-			return fmt.Errorf("Azure tenant_id is required")
-		}
+		s.validateAWSRole(valCtx, role, &result)
 	default:
-		return fmt.Errorf("unsupported CSP type: %s", account.CspType)
+		s.validateGenericRole(valCtx, role, &result)
 	}
 
-	log.Printf("Validated CSP account: %s (ID: %d)", account.Name, account.ID)
-	return nil
+	return result
+}
+
+// validateAWSRole AWS CspRole 검증 (OIDC/SAML: IDP+RoleTrust, SECRET_KEY: CallerIdentity)
+func (s *CspAccountService) validateAWSRole(ctx context.Context, role *model.CspRole, result *model.CspAccountValidationResult) {
+	cfg := role.CspIdpConfig
+	idpIdentifier := role.IdpIdentifier
+	iamIdentifier := role.IamIdentifier
+
+	switch cfg.AuthMethod {
+	case model.AuthMethodOIDC:
+		if idpIdentifier == "" {
+			result.Valid = false
+			result.Error = "IdpIdentifier (OIDC Provider ARN) is empty"
+			return
+		}
+		detail, err := s.awsCredService.CheckOIDCProvider(ctx, idpIdentifier)
+		if err != nil {
+			result.Valid = false
+			result.Error = fmt.Sprintf("OIDC provider check failed: %v", err)
+			return
+		}
+		if iamIdentifier != "" {
+			trustDetail, err := s.awsCredService.CheckRoleTrust(ctx, iamIdentifier, "sts:AssumeRoleWithWebIdentity", idpIdentifier)
+			if err != nil {
+				result.Valid = false
+				result.Error = fmt.Sprintf("Role trust check failed: %v", err)
+				return
+			}
+			detail += " | " + trustDetail
+		}
+		result.Valid = true
+		result.Detail = detail
+
+	case model.AuthMethodSAML:
+		if idpIdentifier == "" {
+			result.Valid = false
+			result.Error = "IdpIdentifier (SAML Provider ARN) is empty"
+			return
+		}
+		detail, err := s.awsCredService.CheckSAMLProvider(ctx, idpIdentifier)
+		if err != nil {
+			result.Valid = false
+			result.Error = fmt.Sprintf("SAML provider check failed: %v", err)
+			return
+		}
+		if iamIdentifier != "" {
+			trustDetail, err := s.awsCredService.CheckRoleTrust(ctx, iamIdentifier, "sts:AssumeRoleWithSAML", idpIdentifier)
+			if err != nil {
+				result.Valid = false
+				result.Error = fmt.Sprintf("Role trust check failed: %v", err)
+				return
+			}
+			detail += " | " + trustDetail
+		}
+		result.Valid = true
+		result.Detail = detail
+
+	case model.AuthMethodSecretKey:
+		accessKeyID := cfg.GetAccessKeyID()
+		secretKey := cfg.GetSecretAccessKey()
+		if accessKeyID == "" || secretKey == "" {
+			result.Valid = false
+			result.Error = "access_key_id or secret_access_key is empty in CspIdpConfig"
+			return
+		}
+		detail, err := s.awsCredService.CheckCallerIdentity(ctx, accessKeyID, secretKey)
+		if err != nil {
+			result.Valid = false
+			result.Error = fmt.Sprintf("CallerIdentity check failed: %v", err)
+			return
+		}
+		result.Valid = true
+		result.Detail = detail
+
+	default:
+		result.Valid = false
+		result.Error = fmt.Sprintf("unsupported auth method for AWS: %s", cfg.AuthMethod)
+	}
+}
+
+// validateGenericRole GCP/Azure 등 — config 필수 필드 존재 확인 (인프라 레벨 체크 미구현)
+func (s *CspAccountService) validateGenericRole(ctx context.Context, role *model.CspRole, result *model.CspAccountValidationResult) {
+	cfg := role.CspIdpConfig
+	if cfg.AuthMethod == model.AuthMethodSecretKey {
+		if cfg.GetAccessKeyID() == "" || cfg.GetSecretAccessKey() == "" {
+			result.Valid = false
+			result.Error = "access_key_id or secret_access_key is empty in CspIdpConfig"
+			return
+		}
+		result.Valid = true
+		result.Detail = "SECRET_KEY config fields present (live validation not implemented for this CSP)"
+		return
+	}
+	// OIDC/SAML: IdpIdentifier + IamIdentifier 존재 확인
+	if role.IdpIdentifier == "" {
+		result.Valid = false
+		result.Error = "IdpIdentifier is empty"
+		return
+	}
+	result.Valid = true
+	result.Detail = fmt.Sprintf("%s config fields present (live infrastructure check not implemented for %s)", cfg.AuthMethod, role.CspType)
 }
 
 // GetActiveCspAccounts 활성 CSP 계정 목록 조회


### PR DESCRIPTION
## Summary

- `POST /api/csp-accounts/id/{accountId}/validate` API가 DB 레코드 존재 여부만 확인하고 실제 CSP API를 호출하지 않아 항상 200 valid를 반환하던 버그 수정
- CspRole 기반으로 실제 CSP 인프라(IDP provider 존재, Role trust 정책)를 검증
- 각 provider+method별 `valid: true/false` 결과를 구조화된 응답으로 반환

## Changes

| 파일 | 변경 내용 |
|------|----------|
| `src/repository/csp_role_repository.go` | `GetByCspAccountID()` 추가 (CspIdpConfig Preload) |
| `src/model/csp_account.go` | `CspAccountValidationResult`, `CspAccountValidationResponse` 추가 |
| `src/service/csp_account_service.go` | `ValidateCspAccount` 재작성 — AWS OIDC/SAML/SECRET_KEY 실제 CSP 호출 |
| `src/handler/csp_account_handler.go` | context 전달, 구조화된 응답, 에러 분기 (404/400/503) |

## Validation Logic

- **AWS OIDC**: `CheckOIDCProvider(idpIdentifier)` + `CheckRoleTrust(iamIdentifier)`
- **AWS SAML**: `CheckSAMLProvider(idpIdentifier)` + `CheckRoleTrust(iamIdentifier)`
- **AWS SECRET_KEY**: `CheckCallerIdentity(accessKeyId, secretKey)`
- **GCP/Azure**: config 필수 필드 존재 확인 (인프라 레벨 체크 미구현)

## Response Example

```json
{
  "account_id": 1,
  "account_name": "test-aws-account",
  "csp_type": "aws",
  "results": [
    {"csp_role_id": 3, "csp_role_name": "mciam-platformadmin-oidc", "csp_type": "aws", "auth_method": "OIDC", "valid": true, "detail": "..."},
    {"csp_role_id": 2, "csp_role_name": "mciam-platformadmin-saml", "csp_type": "aws", "auth_method": "SAML", "valid": false, "error": "..."}
  ]
}
```

## Related

- Bug: IAM-BUG-004
- FR: FR-CLOUD-ADMIN-006-05
- E2E: TC-CRED-05