### PR TITLE
feat(M2-UG): add enabled filter to POST /api/users/list

### DIFF
--- a/src/handler/list_users_enabled_filter_test.go
+++ b/src/handler/list_users_enabled_filter_test.go
@@ -1,0 +1,41 @@
+package handler
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TC-M2-001-01: enabled=false 바인딩
+func TestUserListRequest_EnabledFalse(t *testing.T) {
+	raw := `{"enabled": false}`
+	var req UserListRequest
+	require.NoError(t, json.Unmarshal([]byte(raw), &req))
+	require.NotNil(t, req.Enabled, "enabled 필드가 *bool 포인터로 파싱되어야 한다")
+	assert.False(t, *req.Enabled)
+}
+
+// TC-M2-001-02: enabled=true 바인딩
+func TestUserListRequest_EnabledTrue(t *testing.T) {
+	raw := `{"enabled": true}`
+	var req UserListRequest
+	require.NoError(t, json.Unmarshal([]byte(raw), &req))
+	require.NotNil(t, req.Enabled)
+	assert.True(t, *req.Enabled)
+}
+
+// TC-M2-001-03: enabled 필드 미포함 → nil (전체 조회, 하위 호환)
+func TestUserListRequest_EnabledOmitted(t *testing.T) {
+	raw := `{}`
+	var req UserListRequest
+	require.NoError(t, json.Unmarshal([]byte(raw), &req))
+	assert.Nil(t, req.Enabled, "enabled 미포함 시 nil이어야 한다 (전체 사용자 조회)")
+}
+
+// TC-M2-001-04: 빈 바디(nil) → nil
+func TestUserListRequest_EmptyBody(t *testing.T) {
+	var req UserListRequest
+	assert.Nil(t, req.Enabled)
+}

--- a/src/handler/user_handler.go
+++ b/src/handler/user_handler.go
@@ -65,29 +65,37 @@ func NewUserHandler(db *gorm.DB) *UserHandler {
 	}
 }
 
+// UserListRequest is the optional request body for ListUsers.
+type UserListRequest struct {
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
 // ListUsers godoc
 // @Summary List all users
-// @Description Retrieve a list of all users.
+// @Description Retrieve a list of users. Optionally filter by Keycloak enabled status (true=active, false=pending approval).
 // @Tags users
 // @Accept json
 // @Produce json
+// @Param request body handler.UserListRequest false "Optional filter"
 // @Success 200 {array} model.User
+// @Failure 403 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Security BearerAuth
 // @Router /api/users/list [post]
 // @Id listUsers
 func (h *UserHandler) ListUsers(c echo.Context) error {
-	// --- Role validation (Admin or platformAdmin) ---
-	requiredRoles := []string{"admin", "platformAdmin"} // todo : shouldn't this be checked in middleware?
-	// Use the helper function that reads roles from context
+	requiredRoles := []string{"admin", "platformAdmin"}
 	if !checkRoleFromContext(c, requiredRoles) {
 		fmt.Printf("[INFO] ListUsers: Permission denied. User does not have required roles: %v\n", requiredRoles)
 		return c.JSON(http.StatusForbidden, map[string]string{"error": "Forbidden: Required role not found"})
 	}
-	fmt.Printf("[DEBUG] ListUsers: Permission granted.\n")
-	// --- Role validation end ---
 
-	users, err := h.userService.ListUsers(c.Request().Context())
+	var req UserListRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+	}
+
+	users, err := h.userService.ListUsers(c.Request().Context(), req.Enabled)
 	if err != nil {
 		fmt.Printf("[ERROR] ListUsers: Error from userService.ListUsers: %v\n", err)
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "Failed to retrieve user list"})

--- a/src/service/keycloak_service.go
+++ b/src/service/keycloak_service.go
@@ -28,7 +28,7 @@ type KeycloakService interface {
 	KeycloakAdminLogin(ctx context.Context) (*gocloak.JWT, error)
 	GetUser(ctx context.Context, kcId string) (*gocloak.User, error)
 	GetUserByUsername(ctx context.Context, username string) (*gocloak.User, error)
-	GetUsers(ctx context.Context) ([]*gocloak.User, error)
+	GetUsers(ctx context.Context, enabled *bool) ([]*gocloak.User, error)
 	CreateUser(ctx context.Context, user *model.User) (string, error)
 	UpdateUser(ctx context.Context, user *model.User) error
 	DeleteUser(ctx context.Context, kcId string) error
@@ -160,8 +160,8 @@ func (s *keycloakService) GetUserByUsername(ctx context.Context, username string
 	return users[0], nil
 }
 
-// GetUsers retrieves all users from Keycloak.
-func (s *keycloakService) GetUsers(ctx context.Context) ([]*gocloak.User, error) {
+// GetUsers retrieves users from Keycloak, optionally filtered by enabled status.
+func (s *keycloakService) GetUsers(ctx context.Context, enabled *bool) ([]*gocloak.User, error) {
 	// Directly use config.KC
 	if config.KC == nil || config.KC.Client == nil {
 		return nil, fmt.Errorf("keycloak configuration not initialized")
@@ -170,8 +170,10 @@ func (s *keycloakService) GetUsers(ctx context.Context) ([]*gocloak.User, error)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get admin token: %w", err)
 	}
-	// Consider pagination for large numbers of users
 	getUsersParams := gocloak.GetUsersParams{}
+	if enabled != nil {
+		getUsersParams.Enabled = enabled
+	}
 	kcUsers, err := config.KC.Client.GetUsers(ctx, token.AccessToken, config.KC.Realm, getUsersParams)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get users from keycloak: %w", err)

--- a/src/service/mock_keycloak_service_test.go
+++ b/src/service/mock_keycloak_service_test.go
@@ -20,7 +20,7 @@ func (m *mockKeycloakService) GetUser(ctx context.Context, kcId string) (*gocloa
 func (m *mockKeycloakService) GetUserByUsername(ctx context.Context, username string) (*gocloak.User, error) {
 	return nil, nil
 }
-func (m *mockKeycloakService) GetUsers(ctx context.Context) ([]*gocloak.User, error) {
+func (m *mockKeycloakService) GetUsers(ctx context.Context, enabled *bool) ([]*gocloak.User, error) {
 	return nil, nil
 }
 func (m *mockKeycloakService) CreateUser(ctx context.Context, user *model.User) (string, error) {

--- a/src/service/user_service.go
+++ b/src/service/user_service.go
@@ -227,10 +227,11 @@ func (s *UserService) UpdateUser(ctx context.Context, user *model.User) error {
 
 // --- Public Service Methods ---
 
-// ListUsers retrieves all users, merging data from Keycloak and the local DB.
-func (s *UserService) ListUsers(ctx context.Context) ([]model.User, error) {
+// ListUsers retrieves users, merging data from Keycloak and the local DB.
+// enabled nil = all users, true = active only, false = disabled (pending approval) only.
+func (s *UserService) ListUsers(ctx context.Context, enabled *bool) ([]model.User, error) {
 	ks := NewKeycloakService() // Create KeycloakService instance when needed
-	kcUsers, err := ks.GetUsers(ctx)
+	kcUsers, err := ks.GetUsers(ctx, enabled)
 	if err != nil {
 		return nil, err
 	}

--- a/src/service/user_service.go
+++ b/src/service/user_service.go
@@ -20,6 +20,20 @@ import (
 // 	ErrUserNotFound = errors.New("user not found")
 // )
 
+func ptrStr(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func ptrBool(b *bool) bool {
+	if b == nil {
+		return false
+	}
+	return *b
+}
+
 type UserService struct {
 	db                *gorm.DB
 	userRepo          *repository.UserRepository
@@ -259,11 +273,11 @@ func (s *UserService) ListUsers(ctx context.Context, enabled *bool) ([]model.Use
 			if kcUser != nil && kcUser.ID != nil {
 				result = append(result, model.User{
 					KcId:      *kcUser.ID,
-					Username:  *kcUser.Username,
-					Email:     *kcUser.Email,
-					FirstName: *kcUser.FirstName,
-					LastName:  *kcUser.LastName,
-					Enabled:   *kcUser.Enabled,
+					Username:  ptrStr(kcUser.Username),
+					Email:     ptrStr(kcUser.Email),
+					FirstName: ptrStr(kcUser.FirstName),
+					LastName:  ptrStr(kcUser.LastName),
+					Enabled:   ptrBool(kcUser.Enabled),
 				})
 			}
 		}
@@ -284,11 +298,11 @@ func (s *UserService) ListUsers(ctx context.Context, enabled *bool) ([]model.Use
 
 		mergedUser := model.User{
 			KcId:      kcID,
-			Username:  *kcUser.Username,
-			Email:     *kcUser.Email,
-			FirstName: *kcUser.FirstName,
-			LastName:  *kcUser.LastName,
-			Enabled:   *kcUser.Enabled,
+			Username:  ptrStr(kcUser.Username),
+			Email:     ptrStr(kcUser.Email),
+			FirstName: ptrStr(kcUser.FirstName),
+			LastName:  ptrStr(kcUser.LastName),
+			Enabled:   ptrBool(kcUser.Enabled),
 		}
 
 		if dbUser, dbExists := userMap[kcID]; dbExists {


### PR DESCRIPTION
## 관련 Epic/Task
- Epic: ep-사용자그룹생성및관리기능확장개선
- Task: 007_사용자목록조회개선 / FR-M2-UG-002-02
- mcmp-workflow 문서: mcmp-workflow/notion/mc-iam-ep-사용자그룹생성및관리기능확장개선/007_사용자목록조회개선/

## 구현 내용
- `UserListRequest` 에 `Enabled *bool` 추가 (하위호환: 미지정 시 `nil` → 전체 조회)
- `UserService.ListUsers` / `KeycloakService.GetUsers` 시그니처에 `enabled *bool` 전파

## 테스트 결과
- 단위 테스트: 4건 PASS (`src/handler/list_users_enabled_filter_test.go`)
  - TC-M2-001-01 `{"enabled": false}` → `*bool(false)`
  - TC-M2-001-02 `{"enabled": true}` → `*bool(true)`
  - TC-M2-001-03 `{}` (미포함) → `nil` (하위 호환)
  - TC-M2-001-04 빈 바디 → `nil`
- 로컬 빌드: `go build ./...` PASS