### PR TITLE
feat(WS-044): Project↔Namespace 수동 sync diff/apply API 추가

### DIFF
--- a/asset/mcmpapi/service-actions.yaml
+++ b/asset/mcmpapi/service-actions.yaml
@@ -1006,6 +1006,14 @@ serviceActions:
             method: post
             resourcePath: /api/setup/sync-projects
             description: mc-infra-manager의 네임스페이스 목록을 조회하여 로컬 DB에 없는 프로젝트를 추가합니다.
+        getProjectSyncDiff:
+            method: get
+            resourcePath: /api/setup/projects/sync-diff
+            description: mc-infra-manager의 namespace 목록과 로컬 프로젝트를 비교하여 불일치 목록을 반환합니다. DB 변경 없음.
+        applyProjectSync:
+            method: post
+            resourcePath: /api/setup/projects/sync
+            description: 지정된 nsId 목록의 project를 생성하거나 지정된 workspace에 할당합니다.
         testCallGetAllNs:
             method: get
             resourcePath: /api/mcmp-apis/test/mc-infra-manager/getallns

--- a/conf/mc-iam-manager/service-actions.yaml
+++ b/conf/mc-iam-manager/service-actions.yaml
@@ -1006,6 +1006,14 @@ serviceActions:
             method: post
             resourcePath: /api/setup/sync-projects
             description: mc-infra-manager의 네임스페이스 목록을 조회하여 로컬 DB에 없는 프로젝트를 추가합니다.
+        getProjectSyncDiff:
+            method: get
+            resourcePath: /api/setup/projects/sync-diff
+            description: mc-infra-manager의 namespace 목록과 로컬 프로젝트를 비교하여 불일치 목록을 반환합니다. DB 변경 없음.
+        applyProjectSync:
+            method: post
+            resourcePath: /api/setup/projects/sync
+            description: 지정된 nsId 목록의 project를 생성하거나 지정된 workspace에 할당합니다.
         testCallGetAllNs:
             method: get
             resourcePath: /api/mcmp-apis/test/mc-infra-manager/getallns

--- a/docs/PROJECT-NAMESPACE-SYNC-API.md
+++ b/docs/PROJECT-NAMESPACE-SYNC-API.md
@@ -1,0 +1,35 @@
+# Project ↔ Namespace 동기화 관리 API 설계 요약
+
+브랜치: `feat-iam-ws-044`
+
+## 신규 엔드포인트
+
+### GET /api/setup/projects/sync-diff
+- 인증: PlatformAdminMiddleware
+- mc-infra-manager namespace vs 로컬 project 불일치 목록 반환 (read-only)
+- 응답: `{ missingProjects: [...], unassignedProjects: [...] }`
+
+### POST /api/setup/projects/sync
+- 인증: PlatformAdminMiddleware
+- 요청: `{ workspaceId: "N", nsIds: ["..."] }`
+- 동작: 선택한 nsId를 로컬에 생성하거나 지정 workspace에 할당 (best-effort)
+- 응답: `{ created, assigned, skipped, failed }`
+
+## 변경 파일
+- `src/model/request.go` — DTO 9개 추가
+- `src/service/project_service.go` — `GetProjectSyncDiff`, `ApplyProjectSyncToWorkspace` 추가
+- `src/handler/project_handler.go` — `GetProjectSyncDiff`, `ApplyProjectSync` 핸들러 추가
+- `src/main.go` — setup 그룹에 두 라우트 등록
+- `conf/mc-iam-manager/service-actions.yaml`, `asset/mcmpapi/service-actions.yaml` — 액션 2개 추가
+- `src/docs/` — swagger 재생성
+
+## 주의
+- project 생성 시 `service.Create` 사용 금지 (mc-infra-manager PostNs 이중 호출). `projectRepo.CreateProject` 직접 사용.
+- 기존 `POST /api/setup/sync-projects` 동작 변경 없음.
+
+## 상세 문서
+- 분석: `mc-iam-manager-spec/mc-iam-manager/docs/features/FR-WS-044-PROJECT-NAMESPACE-SYNC-ANALYSIS.md`
+- 구현: `mc-iam-manager-spec/mc-iam-manager/docs/features/FR-WS-044-PROJECT-NAMESPACE-SYNC-IMPLEMENTATION.md`
+- 테스트: `mc-iam-manager-spec/mc-iam-manager/docs/features/FR-WS-044-PROJECT-NAMESPACE-SYNC-TEST-RESULTS.md`
+- 다이어그램: `mc-iam-manager-spec/mc-iam-manager/docs/diagrams/admin-setup/GET-projects-sync-diff.md`
+- 다이어그램: `mc-iam-manager-spec/mc-iam-manager/docs/diagrams/admin-setup/POST-projects-sync.md`

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -312,6 +312,266 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/company": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "플랫폼 회사 정보를 조회합니다. (싱글톤)",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "company"
+                ],
+                "summary": "Get company",
+                "operationId": "getCompany",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.CompanyResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "플랫폼 회사 이름/설명을 수정합니다. (platformAdmin 전용)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "company"
+                ],
+                "summary": "Update company",
+                "operationId": "updateCompany",
+                "parameters": [
+                    {
+                        "description": "Company Update Info",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CompanyUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.CompanyResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "플랫폼 회사 정보를 생성합니다. (싱글톤, platformAdmin 전용)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "company"
+                ],
+                "summary": "Create company",
+                "operationId": "createCompany",
+                "parameters": [
+                    {
+                        "description": "Company Info",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CompanyRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/model.CompanyResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "플랫폼 회사를 비활성화합니다. (platformAdmin 전용, 멱등 처리)",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "company"
+                ],
+                "summary": "Deactivate company",
+                "operationId": "deactivateCompany",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.CompanyResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/company/activate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "플랫폼 회사를 활성화합니다. (platformAdmin 전용, 멱등 처리)",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "company"
+                ],
+                "summary": "Activate company",
+                "operationId": "activateCompany",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.CompanyResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/csp-accounts": {
             "post": {
                 "security": [
@@ -710,7 +970,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Validate CSP account configuration",
+                "description": "Validate CSP account by checking actual CSP infrastructure (IDP provider existence, role trust policy, or credential validity) for each linked CspRole",
                 "consumes": [
                     "application/json"
                 ],
@@ -735,10 +995,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/model.CspAccountValidationResponse"
                         }
                     },
                     "400": {
@@ -759,8 +1016,8 @@ const docTemplate = `{
                             }
                         }
                     },
-                    "500": {
-                        "description": "Internal Server Error",
+                    "503": {
+                        "description": "Service Unavailable",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -1048,6 +1305,54 @@ const docTemplate = `{
                             "additionalProperties": {
                                 "type": "string"
                             }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/csp-idp-configs/health-check": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Check connection status of all active CSP IDP configurations concurrently",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-idp-configs"
+                ],
+                "summary": "Bulk health check for CSP IDP configs",
+                "operationId": "bulkHealthCheckCspIdpConfigs",
+                "parameters": [
+                    {
+                        "description": "Optional filter",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/model.BulkHealthCheckRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.BulkHealthCheckResponse"
                         }
                     },
                     "500": {
@@ -1499,6 +1804,47 @@ const docTemplate = `{
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/model.CspIdpConfig"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/csp-idp-configs/summary": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get IDP configuration count summary grouped by CSP account",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-idp-configs"
+                ],
+                "summary": "Get CSP IDP config summary",
+                "operationId": "getCspIdpSummary",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.CspIdpSummary"
                             }
                         }
                     },
@@ -2268,6 +2614,53 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/groups/id/{groupId}/platform-roles/available": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "그룹에 아직 할당되지 않은 플랫폼 역할 목록을 조회합니다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "groups"
+                ],
+                "summary": "그룹에 할당 가능한 Platform Role 목록 조회",
+                "operationId": "getAvailableGroupPlatformRoles",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "그룹 ID",
+                        "name": "groupId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.RoleMaster"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/groups/id/{groupId}/platform-roles/{roleId}": {
             "delete": {
                 "security": [
@@ -2296,6 +2689,137 @@ const docTemplate = `{
                         "type": "integer",
                         "description": "역할 ID",
                         "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/groups/id/{groupId}/users": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "그룹에 사용자 목록을 일괄 할당합니다. DB + Keycloak 그룹 동기화.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "groups"
+                ],
+                "summary": "그룹에 사용자 일괄 할당 (Keycloak 동기화 포함)",
+                "operationId": "assignGroupUsers",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "그룹 ID",
+                        "name": "groupId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "사용자 일괄 할당 요청",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.AssignGroupUsersRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/groups/id/{groupId}/users/{userId}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "그룹에서 특정 사용자를 제거합니다. DB + Keycloak 그룹 동기화.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "groups"
+                ],
+                "summary": "그룹에서 사용자 제거 (Keycloak 동기화 포함)",
+                "operationId": "removeGroupUser",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "그룹 ID",
+                        "name": "groupId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "사용자 ID",
+                        "name": "userId",
                         "in": "path",
                         "required": true
                     }
@@ -2432,8 +2956,64 @@ const docTemplate = `{
                             }
                         }
                     },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "409": {
                         "description": "Conflict",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/groups/id/{groupId}/workspaces/available": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "그룹에 아직 매핑되지 않은 워크스페이스 목록을 조회합니다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "groups"
+                ],
+                "summary": "그룹에 매핑 가능한 워크스페이스 목록 조회",
+                "operationId": "getAvailableGroupWorkspaces",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "그룹 ID",
+                        "name": "groupId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.Workspace"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -2610,6 +3190,146 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/invitations": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List all workspace invitations, optionally filtered by status",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "invitations"
+                ],
+                "summary": "List all invitations (admin)",
+                "operationId": "listAllInvitations",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Filter by status (PENDING_APPROVAL)",
+                        "name": "status",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.WorkspaceInvitation"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/invitations/{invitationId}/approve": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Admin approves a workspace invitation and registers the invitee as member",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "invitations"
+                ],
+                "summary": "Approve workspace invitation (admin)",
+                "operationId": "approveInvitation",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Invitation ID",
+                        "name": "invitationId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/invitations/{invitationId}/reject": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Admin rejects a workspace invitation",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "invitations"
+                ],
+                "summary": "Reject workspace invitation (admin)",
+                "operationId": "rejectInvitationByAdmin",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Invitation ID",
+                        "name": "invitationId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     }
                 }
@@ -3321,7 +4041,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Create a new menu",
+                "description": "Create a new menu. If roleIds is provided, the menu is mapped to those platform roles in a single transaction. platform_admin role is always automatically mapped.",
                 "consumes": [
                     "application/json"
                 ],
@@ -3340,7 +4060,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/model.Menu"
+                            "$ref": "#/definitions/model.CreateMenuRequest"
                         }
                     }
                 ],
@@ -3348,7 +4068,34 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/model.Menu"
+                            "$ref": "#/definitions/model.CreateMenuResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     }
                 }
@@ -3489,6 +4236,65 @@ const docTemplate = `{
                 ],
                 "summary": "List all menus",
                 "operationId": "listMenus",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.MenuTreeNode"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "error: Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "error: Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "error: 서버 내부 오류",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/menus/menus-tree/list": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List all menus as a tree structure. Admin permission required.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "menus"
+                ],
+                "summary": "List all menus Tree",
+                "operationId": "listMenusTree",
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -3827,65 +4633,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/menus/tree/list": {
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List all menus as a tree structure. Admin permission required.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "menus"
-                ],
-                "summary": "List all menus Tree",
-                "operationId": "listMenusTree",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/model.MenuTreeNode"
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "error: Unauthorized",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "error: Forbidden",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "error: 서버 내부 오류",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/api/menus/user-menu-tree": {
             "get": {
                 "security": [
@@ -3934,7 +4681,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "전체 조직 목록을 조회합니다. tree=true이면 Tree 구조로 반환.",
+                "description": "전체 조직 목록을 조회합니다. tree=true이면 Tree 구조로 반환. name/code로 검색 가능 (검색 시 tree 파라미터 무시).",
                 "produces": [
                     "application/json"
                 ],
@@ -3948,6 +4695,18 @@ const docTemplate = `{
                         "type": "boolean",
                         "description": "Tree 구조 반환 여부 (기본: false)",
                         "name": "tree",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "조직명 검색 (부분 일치, ILIKE)",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "조직 코드 검색 (부분 일치, ILIKE)",
+                        "name": "code",
                         "in": "query"
                     }
                 ],
@@ -7851,6 +8610,99 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/setup/projects/sync": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "지정된 nsId 목록의 project를 생성하거나 지정된 workspace에 할당합니다.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "summary": "선택한 namespace를 특정 workspace에 동기화",
+                "operationId": "applyProjectSync",
+                "parameters": [
+                    {
+                        "description": "Sync Apply Request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.ProjectSyncApplyRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.ProjectSyncApplyResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: 잘못된 요청",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "error: 서버 내부 오류",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/setup/projects/sync-diff": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "mc-infra-manager의 namespace 목록과 로컬 프로젝트를 비교하여 불일치 목록을 반환합니다. DB 변경 없음.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "summary": "mc-infra-manager와 프로젝트 동기화 차이 조회",
+                "operationId": "getProjectSyncDiff",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.ProjectSyncDiffResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "error: 서버 내부 오류",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/setup/sync-projects": {
             "post": {
                 "security": [
@@ -8007,6 +8859,63 @@ const docTemplate = `{
             }
         },
         "/api/users/id/{userId}/groups": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "사용자의 기존 그룹을 모두 제거하고 지정된 그룹으로 교체합니다.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "사용자 그룹 멤버십 전체 교체",
+                "operationId": "replaceUserGroups",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "사용자 ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "교체할 그룹 목록",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.AssignUserGroupsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
             "post": {
                 "security": [
                     {
@@ -8495,7 +9404,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Retrieve a list of all users.",
+                "description": "Retrieve a list of users. Optionally filter by Keycloak enabled status (true=active, false=pending approval).",
                 "consumes": [
                     "application/json"
                 ],
@@ -8507,6 +9416,16 @@ const docTemplate = `{
                 ],
                 "summary": "List all users",
                 "operationId": "listUsers",
+                "parameters": [
+                    {
+                        "description": "Optional filter",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/handler.UserListRequest"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -8517,8 +9436,220 @@ const docTemplate = `{
                             }
                         }
                     },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/users/me": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get the authenticated user's own profile information. No PlatformRole required.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Get my info",
+                "operationId": "getMyInfo",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.User"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/users/me/invitations": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List pending workspace invitations for the current user",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "List my invitations",
+                "operationId": "listMyInvitations",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.WorkspaceInvitation"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/users/me/invitations/{invitationId}/accept": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Accept a workspace invitation and join as member",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Accept workspace invitation",
+                "operationId": "acceptInvitation",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Invitation ID",
+                        "name": "invitationId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/users/me/invitations/{invitationId}/reject": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Reject a workspace invitation",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Reject workspace invitation",
+                "operationId": "rejectInvitation",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Invitation ID",
+                        "name": "invitationId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -8992,7 +10123,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "사용자가 소속된 조직 목록을 조회합니다.",
+                "description": "사용자가 소속된 조직 목록을 조회합니다. hierarchy=true이면 path/level 포함.",
                 "produces": [
                     "application/json"
                 ],
@@ -9008,6 +10139,12 @@ const docTemplate = `{
                         "name": "userId",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "계층 정보(path, level) 포함 여부 (기본: false)",
+                        "name": "hierarchy",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -9016,7 +10153,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/model.Organization"
+                                "$ref": "#/definitions/model.OrganizationTree"
                             }
                         }
                     },
@@ -9272,6 +10409,73 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "error: Workspace or Project not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/workspaces/credentials/validate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "워크스페이스 사용자의 CSP×AuthMethod 조합 인증 설정을 단계별로 검증하고 임시자격증명 발급까지 확인한다. 실패 여부와 무관하게 모든 단계를 응답에 포함한다.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-validation"
+                ],
+                "summary": "CSP 인증 설정 단계별 검증",
+                "operationId": "mciamValidateCredentials",
+                "parameters": [
+                    {
+                        "description": "검증 요청",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CspValidationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.CspValidationResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: invalid request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "error: Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "error: User not found",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -9648,6 +10852,116 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "error: Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/workspaces/id/{wsId}/invitations": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List invitations for a specific workspace",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "List workspace invitations",
+                "operationId": "listWorkspaceInvitations",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Workspace ID",
+                        "name": "wsId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by status (PENDING/ACCEPTED/REJECTED)",
+                        "name": "status",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.WorkspaceInvitation"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Send an invitation to a platform user to join the workspace",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "Send workspace invitation",
+                "operationId": "sendWorkspaceInvitation",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Workspace ID",
+                        "name": "wsId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Invitation request",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.SendInvitationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/model.WorkspaceInvitation"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -10284,11 +11598,13 @@ const docTemplate = `{
             "type": "string",
             "enum": [
                 "OIDC",
-                "SAML"
+                "SAML",
+                "SECRET_KEY"
             ],
             "x-enum-varnames": [
                 "AuthMethodOIDC",
-                "AuthMethodSAML"
+                "AuthMethodSAML",
+                "AuthMethodSecretKey"
             ]
         },
         "constants.CSPType": {
@@ -10296,12 +11612,26 @@ const docTemplate = `{
             "enum": [
                 "aws",
                 "gcp",
-                "azure"
+                "azure",
+                "alibaba",
+                "tencent",
+                "ibm",
+                "ncp",
+                "nhn",
+                "kt",
+                "openstack"
             ],
             "x-enum-varnames": [
                 "CSPTypeAWS",
                 "CSPTypeGCP",
-                "CSPTypeAzure"
+                "CSPTypeAzure",
+                "CSPTypeAlibaba",
+                "CSPTypeTencent",
+                "CSPTypeIBM",
+                "CSPTypeNCP",
+                "CSPTypeNHN",
+                "CSPTypeKT",
+                "CSPTypeOpenStack"
             ]
         },
         "constants.IAMRoleType": {
@@ -10326,6 +11656,14 @@ const docTemplate = `{
                 "RoleTypeWorkspace",
                 "RoleTypeCSP"
             ]
+        },
+        "handler.UserListRequest": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
         },
         "idp.UserLogin": {
             "type": "object",
@@ -10472,6 +11810,21 @@ const docTemplate = `{
                 }
             }
         },
+        "model.AssignGroupUsersRequest": {
+            "type": "object",
+            "required": [
+                "user_ids"
+            ],
+            "properties": {
+                "user_ids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "integer"
+                    }
+                }
+            }
+        },
         "model.AssignGroupWorkspaceRequest": {
             "type": "object",
             "required": [
@@ -10599,6 +11952,34 @@ const docTemplate = `{
                 "AuthMethodSecretKey"
             ]
         },
+        "model.BulkHealthCheckRequest": {
+            "type": "object",
+            "properties": {
+                "csp_account_id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "model.BulkHealthCheckResponse": {
+            "type": "object",
+            "properties": {
+                "connected_count": {
+                    "type": "integer"
+                },
+                "failed_count": {
+                    "type": "integer"
+                },
+                "results": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.HealthCheckResult"
+                    }
+                },
+                "total_count": {
+                    "type": "integer"
+                }
+            }
+        },
         "model.ChangeMyPasswordRequest": {
             "type": "object",
             "required": [
@@ -10612,6 +11993,75 @@ const docTemplate = `{
                 "newPassword": {
                     "type": "string",
                     "minLength": 8
+                }
+            }
+        },
+        "model.CompanyRequest": {
+            "type": "object",
+            "required": [
+                "kc_client_id",
+                "kc_client_secret",
+                "name",
+                "realm_name"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "kc_client_id": {
+                    "type": "string"
+                },
+                "kc_client_secret": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "realm_name": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.CompanyResponse": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "kc_client_id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "realm_name": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.CompanyUpdateRequest": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
                 }
             }
         },
@@ -10633,7 +12083,14 @@ const docTemplate = `{
                     "enum": [
                         "aws",
                         "gcp",
-                        "azure"
+                        "azure",
+                        "alibaba",
+                        "tencent",
+                        "ibm",
+                        "ncp",
+                        "nhn",
+                        "kt",
+                        "openstack"
                     ]
                 },
                 "description": {
@@ -10723,6 +12180,14 @@ const docTemplate = `{
         "model.CreateCspRoleRequest": {
             "type": "object",
             "properties": {
+                "authMethod": {
+                    "description": "인증방식 (OIDC/SAML/SECRET_KEY), 미지정 시 OIDC 기본값",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/constants.AuthMethod"
+                        }
+                    ]
+                },
                 "cspRoleName": {
                     "description": "csp의 RoleName. 여러 role이 있기때문에 csp에 정의한 role로 구분하기 위해 사용",
                     "type": "string"
@@ -10788,6 +12253,56 @@ const docTemplate = `{
                 },
                 "roleId": {
                     "type": "string"
+                }
+            }
+        },
+        "model.CreateMenuRequest": {
+            "type": "object",
+            "required": [
+                "id"
+            ],
+            "properties": {
+                "displayName": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isAction": {
+                    "type": "boolean"
+                },
+                "menuNumber": {
+                    "type": "string"
+                },
+                "parentId": {
+                    "type": "string"
+                },
+                "priority": {
+                    "type": "string"
+                },
+                "resType": {
+                    "type": "string"
+                },
+                "roleIds": {
+                    "description": "생성과 동시에 매핑할 역할 ID 목록 (platform_admin은 항상 자동 매핑)",
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                }
+            }
+        },
+        "model.CreateMenuResponse": {
+            "type": "object",
+            "properties": {
+                "menu": {
+                    "$ref": "#/definitions/model.Menu"
+                },
+                "roleMappings": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.RoleMenuMapping"
+                    }
                 }
             }
         },
@@ -10869,6 +12384,17 @@ const docTemplate = `{
                 }
             }
         },
+        "model.CredentialSummary": {
+            "type": "object",
+            "properties": {
+                "accessKeyId": {
+                    "type": "string"
+                },
+                "expiration": {
+                    "type": "string"
+                }
+            }
+        },
         "model.CspAccount": {
             "type": "object",
             "properties": {
@@ -10913,6 +12439,52 @@ const docTemplate = `{
                 },
                 "name": {
                     "type": "string"
+                }
+            }
+        },
+        "model.CspAccountValidationResponse": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "integer"
+                },
+                "account_name": {
+                    "type": "string"
+                },
+                "csp_type": {
+                    "type": "string"
+                },
+                "results": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.CspAccountValidationResult"
+                    }
+                }
+            }
+        },
+        "model.CspAccountValidationResult": {
+            "type": "object",
+            "properties": {
+                "auth_method": {
+                    "type": "string"
+                },
+                "csp_role_id": {
+                    "type": "integer"
+                },
+                "csp_role_name": {
+                    "type": "string"
+                },
+                "csp_type": {
+                    "type": "string"
+                },
+                "detail": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "valid": {
+                    "type": "boolean"
                 }
             }
         },
@@ -10973,6 +12545,32 @@ const docTemplate = `{
                 },
                 "name": {
                     "type": "string"
+                }
+            }
+        },
+        "model.CspIdpSummary": {
+            "type": "object",
+            "properties": {
+                "active_count": {
+                    "type": "integer"
+                },
+                "csp_account_id": {
+                    "type": "integer"
+                },
+                "csp_account_name": {
+                    "type": "string"
+                },
+                "csp_type": {
+                    "type": "string"
+                },
+                "method_counts": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer"
+                    }
+                },
+                "total_count": {
+                    "type": "integer"
                 }
             }
         },
@@ -11113,6 +12711,59 @@ const docTemplate = `{
                 }
             }
         },
+        "model.CspValidationRequest": {
+            "type": "object",
+            "properties": {
+                "authMethod": {
+                    "description": "인증방식 (OIDC, SAML, SECRET_KEY)",
+                    "type": "string"
+                },
+                "cspType": {
+                    "description": "CSP 유형 (aws, gcp, ...)",
+                    "type": "string"
+                },
+                "workspaceId": {
+                    "description": "대상 워크스페이스 ID",
+                    "type": "string"
+                }
+            }
+        },
+        "model.CspValidationResponse": {
+            "type": "object",
+            "properties": {
+                "authMethod": {
+                    "type": "string"
+                },
+                "credentials": {
+                    "description": "valid=true일 때만",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.CredentialSummary"
+                        }
+                    ]
+                },
+                "cspType": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "failedStep": {
+                    "description": "0=전체성공, N=N번 단계 실패",
+                    "type": "integer"
+                },
+                "steps": {
+                    "description": "항상 전체 단계 포함",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.ValidationStep"
+                    }
+                },
+                "valid": {
+                    "type": "boolean"
+                }
+            }
+        },
         "model.FilterRoleMasterMappingRequest": {
             "type": "object",
             "properties": {
@@ -11199,6 +12850,33 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "workspace_name": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.HealthCheckResult": {
+            "type": "object",
+            "properties": {
+                "auth_method": {
+                    "type": "string"
+                },
+                "checked_at": {
+                    "type": "string"
+                },
+                "config_id": {
+                    "type": "integer"
+                },
+                "config_name": {
+                    "type": "string"
+                },
+                "csp_type": {
+                    "type": "string"
+                },
+                "error_message": {
+                    "type": "string"
+                },
+                "status": {
+                    "description": "CONNECTED, FAILED, TIMEOUT",
                     "type": "string"
                 }
             }
@@ -11313,6 +12991,21 @@ const docTemplate = `{
                     "type": "integer"
                 }
             }
+        },
+        "model.InvitationStatus": {
+            "type": "string",
+            "enum": [
+                "PENDING",
+                "PENDING_APPROVAL",
+                "ACCEPTED",
+                "REJECTED"
+            ],
+            "x-enum-varnames": [
+                "InvitationStatusPending",
+                "InvitationStatusPendingApproval",
+                "InvitationStatusAccepted",
+                "InvitationStatusRejected"
+            ]
         },
         "model.MciamPermission": {
             "type": "object",
@@ -11597,6 +13290,151 @@ const docTemplate = `{
                 }
             }
         },
+        "model.ProjectSyncApplyAssignedItem": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "nsId": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.ProjectSyncApplyCreatedItem": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "nsId": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.ProjectSyncApplyFailedItem": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string"
+                },
+                "nsId": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.ProjectSyncApplyRequest": {
+            "type": "object",
+            "required": [
+                "nsIds",
+                "workspaceId"
+            ],
+            "properties": {
+                "nsIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "workspaceId": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.ProjectSyncApplyResponse": {
+            "type": "object",
+            "properties": {
+                "assigned": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.ProjectSyncApplyAssignedItem"
+                    }
+                },
+                "created": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.ProjectSyncApplyCreatedItem"
+                    }
+                },
+                "failed": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.ProjectSyncApplyFailedItem"
+                    }
+                },
+                "skipped": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.ProjectSyncApplySkippedItem"
+                    }
+                }
+            }
+        },
+        "model.ProjectSyncApplySkippedItem": {
+            "type": "object",
+            "properties": {
+                "nsId": {
+                    "type": "string"
+                },
+                "reason": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.ProjectSyncDiffMissingItem": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "nsId": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.ProjectSyncDiffResponse": {
+            "type": "object",
+            "properties": {
+                "missingProjects": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.ProjectSyncDiffMissingItem"
+                    }
+                },
+                "unassignedProjects": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.ProjectSyncDiffUnassignedItem"
+                    }
+                }
+            }
+        },
+        "model.ProjectSyncDiffUnassignedItem": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "nsId": {
+                    "type": "string"
+                }
+            }
+        },
         "model.ResetPasswordRequest": {
             "type": "object",
             "required": [
@@ -11794,6 +13632,28 @@ const docTemplate = `{
                 }
             }
         },
+        "model.RoleMenuMapping": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "menu_id": {
+                    "description": "메뉴 ID",
+                    "type": "string"
+                },
+                "role_id": {
+                    "description": "역할 ID",
+                    "type": "integer"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
         "model.RoleSub": {
             "type": "object",
             "properties": {
@@ -11811,6 +13671,20 @@ const docTemplate = `{
                 },
                 "updated_at": {
                     "type": "string"
+                }
+            }
+        },
+        "model.SendInvitationRequest": {
+            "type": "object",
+            "required": [
+                "inviteeUserId"
+            ],
+            "properties": {
+                "inviteeUserId": {
+                    "type": "integer"
+                },
+                "roleId": {
+                    "type": "integer"
                 }
             }
         },
@@ -12101,6 +13975,44 @@ const docTemplate = `{
                 }
             }
         },
+        "model.ValidationStep": {
+            "type": "object",
+            "properties": {
+                "detail": {
+                    "description": "수행 내역 또는 오류 안내 (skipped면 \"\")",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "단계명",
+                    "type": "string"
+                },
+                "status": {
+                    "description": "ok | failed | skipped",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.ValidationStepStatus"
+                        }
+                    ]
+                },
+                "step": {
+                    "description": "순번 (1부터)",
+                    "type": "integer"
+                }
+            }
+        },
+        "model.ValidationStepStatus": {
+            "type": "string",
+            "enum": [
+                "ok",
+                "failed",
+                "skipped"
+            ],
+            "x-enum-varnames": [
+                "ValidationStepOk",
+                "ValidationStepFailed",
+                "ValidationStepSkipped"
+            ]
+        },
         "model.Workspace": {
             "type": "object",
             "properties": {
@@ -12124,6 +14036,35 @@ const docTemplate = `{
                 },
                 "updated_at": {
                     "type": "string"
+                }
+            }
+        },
+        "model.WorkspaceInvitation": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "inviteeUserId": {
+                    "type": "integer"
+                },
+                "inviterUserId": {
+                    "type": "integer"
+                },
+                "roleId": {
+                    "type": "integer"
+                },
+                "status": {
+                    "$ref": "#/definitions/model.InvitationStatus"
+                },
+                "updatedAt": {
+                    "type": "string"
+                },
+                "workspaceId": {
+                    "type": "integer"
                 }
             }
         },

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -306,6 +306,266 @@
                 }
             }
         },
+        "/api/company": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "플랫폼 회사 정보를 조회합니다. (싱글톤)",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "company"
+                ],
+                "summary": "Get company",
+                "operationId": "getCompany",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.CompanyResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "플랫폼 회사 이름/설명을 수정합니다. (platformAdmin 전용)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "company"
+                ],
+                "summary": "Update company",
+                "operationId": "updateCompany",
+                "parameters": [
+                    {
+                        "description": "Company Update Info",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CompanyUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.CompanyResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "플랫폼 회사 정보를 생성합니다. (싱글톤, platformAdmin 전용)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "company"
+                ],
+                "summary": "Create company",
+                "operationId": "createCompany",
+                "parameters": [
+                    {
+                        "description": "Company Info",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CompanyRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/model.CompanyResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "플랫폼 회사를 비활성화합니다. (platformAdmin 전용, 멱등 처리)",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "company"
+                ],
+                "summary": "Deactivate company",
+                "operationId": "deactivateCompany",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.CompanyResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/company/activate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "플랫폼 회사를 활성화합니다. (platformAdmin 전용, 멱등 처리)",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "company"
+                ],
+                "summary": "Activate company",
+                "operationId": "activateCompany",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.CompanyResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/csp-accounts": {
             "post": {
                 "security": [
@@ -704,7 +964,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Validate CSP account configuration",
+                "description": "Validate CSP account by checking actual CSP infrastructure (IDP provider existence, role trust policy, or credential validity) for each linked CspRole",
                 "consumes": [
                     "application/json"
                 ],
@@ -729,10 +989,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/model.CspAccountValidationResponse"
                         }
                     },
                     "400": {
@@ -753,8 +1010,8 @@
                             }
                         }
                     },
-                    "500": {
-                        "description": "Internal Server Error",
+                    "503": {
+                        "description": "Service Unavailable",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -1042,6 +1299,54 @@
                             "additionalProperties": {
                                 "type": "string"
                             }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/csp-idp-configs/health-check": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Check connection status of all active CSP IDP configurations concurrently",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-idp-configs"
+                ],
+                "summary": "Bulk health check for CSP IDP configs",
+                "operationId": "bulkHealthCheckCspIdpConfigs",
+                "parameters": [
+                    {
+                        "description": "Optional filter",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/model.BulkHealthCheckRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.BulkHealthCheckResponse"
                         }
                     },
                     "500": {
@@ -1493,6 +1798,47 @@
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/model.CspIdpConfig"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/csp-idp-configs/summary": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get IDP configuration count summary grouped by CSP account",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-idp-configs"
+                ],
+                "summary": "Get CSP IDP config summary",
+                "operationId": "getCspIdpSummary",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.CspIdpSummary"
                             }
                         }
                     },
@@ -2262,6 +2608,53 @@
                 }
             }
         },
+        "/api/groups/id/{groupId}/platform-roles/available": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "그룹에 아직 할당되지 않은 플랫폼 역할 목록을 조회합니다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "groups"
+                ],
+                "summary": "그룹에 할당 가능한 Platform Role 목록 조회",
+                "operationId": "getAvailableGroupPlatformRoles",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "그룹 ID",
+                        "name": "groupId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.RoleMaster"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/groups/id/{groupId}/platform-roles/{roleId}": {
             "delete": {
                 "security": [
@@ -2290,6 +2683,137 @@
                         "type": "integer",
                         "description": "역할 ID",
                         "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/groups/id/{groupId}/users": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "그룹에 사용자 목록을 일괄 할당합니다. DB + Keycloak 그룹 동기화.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "groups"
+                ],
+                "summary": "그룹에 사용자 일괄 할당 (Keycloak 동기화 포함)",
+                "operationId": "assignGroupUsers",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "그룹 ID",
+                        "name": "groupId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "사용자 일괄 할당 요청",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.AssignGroupUsersRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/groups/id/{groupId}/users/{userId}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "그룹에서 특정 사용자를 제거합니다. DB + Keycloak 그룹 동기화.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "groups"
+                ],
+                "summary": "그룹에서 사용자 제거 (Keycloak 동기화 포함)",
+                "operationId": "removeGroupUser",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "그룹 ID",
+                        "name": "groupId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "사용자 ID",
+                        "name": "userId",
                         "in": "path",
                         "required": true
                     }
@@ -2426,8 +2950,64 @@
                             }
                         }
                     },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "409": {
                         "description": "Conflict",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/groups/id/{groupId}/workspaces/available": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "그룹에 아직 매핑되지 않은 워크스페이스 목록을 조회합니다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "groups"
+                ],
+                "summary": "그룹에 매핑 가능한 워크스페이스 목록 조회",
+                "operationId": "getAvailableGroupWorkspaces",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "그룹 ID",
+                        "name": "groupId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.Workspace"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -2604,6 +3184,146 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/invitations": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List all workspace invitations, optionally filtered by status",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "invitations"
+                ],
+                "summary": "List all invitations (admin)",
+                "operationId": "listAllInvitations",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Filter by status (PENDING_APPROVAL)",
+                        "name": "status",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.WorkspaceInvitation"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/invitations/{invitationId}/approve": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Admin approves a workspace invitation and registers the invitee as member",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "invitations"
+                ],
+                "summary": "Approve workspace invitation (admin)",
+                "operationId": "approveInvitation",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Invitation ID",
+                        "name": "invitationId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/invitations/{invitationId}/reject": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Admin rejects a workspace invitation",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "invitations"
+                ],
+                "summary": "Reject workspace invitation (admin)",
+                "operationId": "rejectInvitationByAdmin",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Invitation ID",
+                        "name": "invitationId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     }
                 }
@@ -3315,7 +4035,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Create a new menu",
+                "description": "Create a new menu. If roleIds is provided, the menu is mapped to those platform roles in a single transaction. platform_admin role is always automatically mapped.",
                 "consumes": [
                     "application/json"
                 ],
@@ -3334,7 +4054,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/model.Menu"
+                            "$ref": "#/definitions/model.CreateMenuRequest"
                         }
                     }
                 ],
@@ -3342,7 +4062,34 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/model.Menu"
+                            "$ref": "#/definitions/model.CreateMenuResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     }
                 }
@@ -3483,6 +4230,65 @@
                 ],
                 "summary": "List all menus",
                 "operationId": "listMenus",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.MenuTreeNode"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "error: Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "error: Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "error: 서버 내부 오류",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/menus/menus-tree/list": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List all menus as a tree structure. Admin permission required.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "menus"
+                ],
+                "summary": "List all menus Tree",
+                "operationId": "listMenusTree",
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -3821,65 +4627,6 @@
                 }
             }
         },
-        "/api/menus/tree/list": {
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List all menus as a tree structure. Admin permission required.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "menus"
-                ],
-                "summary": "List all menus Tree",
-                "operationId": "listMenusTree",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/model.MenuTreeNode"
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "error: Unauthorized",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "error: Forbidden",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "error: 서버 내부 오류",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/api/menus/user-menu-tree": {
             "get": {
                 "security": [
@@ -3928,7 +4675,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "전체 조직 목록을 조회합니다. tree=true이면 Tree 구조로 반환.",
+                "description": "전체 조직 목록을 조회합니다. tree=true이면 Tree 구조로 반환. name/code로 검색 가능 (검색 시 tree 파라미터 무시).",
                 "produces": [
                     "application/json"
                 ],
@@ -3942,6 +4689,18 @@
                         "type": "boolean",
                         "description": "Tree 구조 반환 여부 (기본: false)",
                         "name": "tree",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "조직명 검색 (부분 일치, ILIKE)",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "조직 코드 검색 (부분 일치, ILIKE)",
+                        "name": "code",
                         "in": "query"
                     }
                 ],
@@ -7845,6 +8604,99 @@
                 }
             }
         },
+        "/api/setup/projects/sync": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "지정된 nsId 목록의 project를 생성하거나 지정된 workspace에 할당합니다.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "summary": "선택한 namespace를 특정 workspace에 동기화",
+                "operationId": "applyProjectSync",
+                "parameters": [
+                    {
+                        "description": "Sync Apply Request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.ProjectSyncApplyRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.ProjectSyncApplyResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: 잘못된 요청",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "error: 서버 내부 오류",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/setup/projects/sync-diff": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "mc-infra-manager의 namespace 목록과 로컬 프로젝트를 비교하여 불일치 목록을 반환합니다. DB 변경 없음.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "summary": "mc-infra-manager와 프로젝트 동기화 차이 조회",
+                "operationId": "getProjectSyncDiff",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.ProjectSyncDiffResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "error: 서버 내부 오류",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/setup/sync-projects": {
             "post": {
                 "security": [
@@ -8001,6 +8853,63 @@
             }
         },
         "/api/users/id/{userId}/groups": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "사용자의 기존 그룹을 모두 제거하고 지정된 그룹으로 교체합니다.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "사용자 그룹 멤버십 전체 교체",
+                "operationId": "replaceUserGroups",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "사용자 ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "교체할 그룹 목록",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.AssignUserGroupsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
             "post": {
                 "security": [
                     {
@@ -8489,7 +9398,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Retrieve a list of all users.",
+                "description": "Retrieve a list of users. Optionally filter by Keycloak enabled status (true=active, false=pending approval).",
                 "consumes": [
                     "application/json"
                 ],
@@ -8501,6 +9410,16 @@
                 ],
                 "summary": "List all users",
                 "operationId": "listUsers",
+                "parameters": [
+                    {
+                        "description": "Optional filter",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/handler.UserListRequest"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -8511,8 +9430,220 @@
                             }
                         }
                     },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/users/me": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get the authenticated user's own profile information. No PlatformRole required.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Get my info",
+                "operationId": "getMyInfo",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.User"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/users/me/invitations": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List pending workspace invitations for the current user",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "List my invitations",
+                "operationId": "listMyInvitations",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.WorkspaceInvitation"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/users/me/invitations/{invitationId}/accept": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Accept a workspace invitation and join as member",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Accept workspace invitation",
+                "operationId": "acceptInvitation",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Invitation ID",
+                        "name": "invitationId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/users/me/invitations/{invitationId}/reject": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Reject a workspace invitation",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Reject workspace invitation",
+                "operationId": "rejectInvitation",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Invitation ID",
+                        "name": "invitationId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -8986,7 +10117,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "사용자가 소속된 조직 목록을 조회합니다.",
+                "description": "사용자가 소속된 조직 목록을 조회합니다. hierarchy=true이면 path/level 포함.",
                 "produces": [
                     "application/json"
                 ],
@@ -9002,6 +10133,12 @@
                         "name": "userId",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "계층 정보(path, level) 포함 여부 (기본: false)",
+                        "name": "hierarchy",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -9010,7 +10147,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/model.Organization"
+                                "$ref": "#/definitions/model.OrganizationTree"
                             }
                         }
                     },
@@ -9266,6 +10403,73 @@
                     },
                     "404": {
                         "description": "error: Workspace or Project not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/workspaces/credentials/validate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "워크스페이스 사용자의 CSP×AuthMethod 조합 인증 설정을 단계별로 검증하고 임시자격증명 발급까지 확인한다. 실패 여부와 무관하게 모든 단계를 응답에 포함한다.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "csp-validation"
+                ],
+                "summary": "CSP 인증 설정 단계별 검증",
+                "operationId": "mciamValidateCredentials",
+                "parameters": [
+                    {
+                        "description": "검증 요청",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CspValidationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.CspValidationResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: invalid request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "error: Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "error: User not found",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -9642,6 +10846,116 @@
                     },
                     "500": {
                         "description": "error: Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/workspaces/id/{wsId}/invitations": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List invitations for a specific workspace",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "List workspace invitations",
+                "operationId": "listWorkspaceInvitations",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Workspace ID",
+                        "name": "wsId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by status (PENDING/ACCEPTED/REJECTED)",
+                        "name": "status",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.WorkspaceInvitation"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Send an invitation to a platform user to join the workspace",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "Send workspace invitation",
+                "operationId": "sendWorkspaceInvitation",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Workspace ID",
+                        "name": "wsId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Invitation request",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.SendInvitationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/model.WorkspaceInvitation"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -10278,11 +11592,13 @@
             "type": "string",
             "enum": [
                 "OIDC",
-                "SAML"
+                "SAML",
+                "SECRET_KEY"
             ],
             "x-enum-varnames": [
                 "AuthMethodOIDC",
-                "AuthMethodSAML"
+                "AuthMethodSAML",
+                "AuthMethodSecretKey"
             ]
         },
         "constants.CSPType": {
@@ -10290,12 +11606,26 @@
             "enum": [
                 "aws",
                 "gcp",
-                "azure"
+                "azure",
+                "alibaba",
+                "tencent",
+                "ibm",
+                "ncp",
+                "nhn",
+                "kt",
+                "openstack"
             ],
             "x-enum-varnames": [
                 "CSPTypeAWS",
                 "CSPTypeGCP",
-                "CSPTypeAzure"
+                "CSPTypeAzure",
+                "CSPTypeAlibaba",
+                "CSPTypeTencent",
+                "CSPTypeIBM",
+                "CSPTypeNCP",
+                "CSPTypeNHN",
+                "CSPTypeKT",
+                "CSPTypeOpenStack"
             ]
         },
         "constants.IAMRoleType": {
@@ -10320,6 +11650,14 @@
                 "RoleTypeWorkspace",
                 "RoleTypeCSP"
             ]
+        },
+        "handler.UserListRequest": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
         },
         "idp.UserLogin": {
             "type": "object",
@@ -10466,6 +11804,21 @@
                 }
             }
         },
+        "model.AssignGroupUsersRequest": {
+            "type": "object",
+            "required": [
+                "user_ids"
+            ],
+            "properties": {
+                "user_ids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "integer"
+                    }
+                }
+            }
+        },
         "model.AssignGroupWorkspaceRequest": {
             "type": "object",
             "required": [
@@ -10593,6 +11946,34 @@
                 "AuthMethodSecretKey"
             ]
         },
+        "model.BulkHealthCheckRequest": {
+            "type": "object",
+            "properties": {
+                "csp_account_id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "model.BulkHealthCheckResponse": {
+            "type": "object",
+            "properties": {
+                "connected_count": {
+                    "type": "integer"
+                },
+                "failed_count": {
+                    "type": "integer"
+                },
+                "results": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.HealthCheckResult"
+                    }
+                },
+                "total_count": {
+                    "type": "integer"
+                }
+            }
+        },
         "model.ChangeMyPasswordRequest": {
             "type": "object",
             "required": [
@@ -10606,6 +11987,75 @@
                 "newPassword": {
                     "type": "string",
                     "minLength": 8
+                }
+            }
+        },
+        "model.CompanyRequest": {
+            "type": "object",
+            "required": [
+                "kc_client_id",
+                "kc_client_secret",
+                "name",
+                "realm_name"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "kc_client_id": {
+                    "type": "string"
+                },
+                "kc_client_secret": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "realm_name": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.CompanyResponse": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "kc_client_id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "realm_name": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.CompanyUpdateRequest": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
                 }
             }
         },
@@ -10627,7 +12077,14 @@
                     "enum": [
                         "aws",
                         "gcp",
-                        "azure"
+                        "azure",
+                        "alibaba",
+                        "tencent",
+                        "ibm",
+                        "ncp",
+                        "nhn",
+                        "kt",
+                        "openstack"
                     ]
                 },
                 "description": {
@@ -10717,6 +12174,14 @@
         "model.CreateCspRoleRequest": {
             "type": "object",
             "properties": {
+                "authMethod": {
+                    "description": "인증방식 (OIDC/SAML/SECRET_KEY), 미지정 시 OIDC 기본값",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/constants.AuthMethod"
+                        }
+                    ]
+                },
                 "cspRoleName": {
                     "description": "csp의 RoleName. 여러 role이 있기때문에 csp에 정의한 role로 구분하기 위해 사용",
                     "type": "string"
@@ -10782,6 +12247,56 @@
                 },
                 "roleId": {
                     "type": "string"
+                }
+            }
+        },
+        "model.CreateMenuRequest": {
+            "type": "object",
+            "required": [
+                "id"
+            ],
+            "properties": {
+                "displayName": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isAction": {
+                    "type": "boolean"
+                },
+                "menuNumber": {
+                    "type": "string"
+                },
+                "parentId": {
+                    "type": "string"
+                },
+                "priority": {
+                    "type": "string"
+                },
+                "resType": {
+                    "type": "string"
+                },
+                "roleIds": {
+                    "description": "생성과 동시에 매핑할 역할 ID 목록 (platform_admin은 항상 자동 매핑)",
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                }
+            }
+        },
+        "model.CreateMenuResponse": {
+            "type": "object",
+            "properties": {
+                "menu": {
+                    "$ref": "#/definitions/model.Menu"
+                },
+                "roleMappings": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.RoleMenuMapping"
+                    }
                 }
             }
         },
@@ -10863,6 +12378,17 @@
                 }
             }
         },
+        "model.CredentialSummary": {
+            "type": "object",
+            "properties": {
+                "accessKeyId": {
+                    "type": "string"
+                },
+                "expiration": {
+                    "type": "string"
+                }
+            }
+        },
         "model.CspAccount": {
             "type": "object",
             "properties": {
@@ -10907,6 +12433,52 @@
                 },
                 "name": {
                     "type": "string"
+                }
+            }
+        },
+        "model.CspAccountValidationResponse": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "integer"
+                },
+                "account_name": {
+                    "type": "string"
+                },
+                "csp_type": {
+                    "type": "string"
+                },
+                "results": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.CspAccountValidationResult"
+                    }
+                }
+            }
+        },
+        "model.CspAccountValidationResult": {
+            "type": "object",
+            "properties": {
+                "auth_method": {
+                    "type": "string"
+                },
+                "csp_role_id": {
+                    "type": "integer"
+                },
+                "csp_role_name": {
+                    "type": "string"
+                },
+                "csp_type": {
+                    "type": "string"
+                },
+                "detail": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "valid": {
+                    "type": "boolean"
                 }
             }
         },
@@ -10967,6 +12539,32 @@
                 },
                 "name": {
                     "type": "string"
+                }
+            }
+        },
+        "model.CspIdpSummary": {
+            "type": "object",
+            "properties": {
+                "active_count": {
+                    "type": "integer"
+                },
+                "csp_account_id": {
+                    "type": "integer"
+                },
+                "csp_account_name": {
+                    "type": "string"
+                },
+                "csp_type": {
+                    "type": "string"
+                },
+                "method_counts": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer"
+                    }
+                },
+                "total_count": {
+                    "type": "integer"
                 }
             }
         },
@@ -11107,6 +12705,59 @@
                 }
             }
         },
+        "model.CspValidationRequest": {
+            "type": "object",
+            "properties": {
+                "authMethod": {
+                    "description": "인증방식 (OIDC, SAML, SECRET_KEY)",
+                    "type": "string"
+                },
+                "cspType": {
+                    "description": "CSP 유형 (aws, gcp, ...)",
+                    "type": "string"
+                },
+                "workspaceId": {
+                    "description": "대상 워크스페이스 ID",
+                    "type": "string"
+                }
+            }
+        },
+        "model.CspValidationResponse": {
+            "type": "object",
+            "properties": {
+                "authMethod": {
+                    "type": "string"
+                },
+                "credentials": {
+                    "description": "valid=true일 때만",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.CredentialSummary"
+                        }
+                    ]
+                },
+                "cspType": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "failedStep": {
+                    "description": "0=전체성공, N=N번 단계 실패",
+                    "type": "integer"
+                },
+                "steps": {
+                    "description": "항상 전체 단계 포함",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.ValidationStep"
+                    }
+                },
+                "valid": {
+                    "type": "boolean"
+                }
+            }
+        },
         "model.FilterRoleMasterMappingRequest": {
             "type": "object",
             "properties": {
@@ -11193,6 +12844,33 @@
                     "type": "integer"
                 },
                 "workspace_name": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.HealthCheckResult": {
+            "type": "object",
+            "properties": {
+                "auth_method": {
+                    "type": "string"
+                },
+                "checked_at": {
+                    "type": "string"
+                },
+                "config_id": {
+                    "type": "integer"
+                },
+                "config_name": {
+                    "type": "string"
+                },
+                "csp_type": {
+                    "type": "string"
+                },
+                "error_message": {
+                    "type": "string"
+                },
+                "status": {
+                    "description": "CONNECTED, FAILED, TIMEOUT",
                     "type": "string"
                 }
             }
@@ -11307,6 +12985,21 @@
                     "type": "integer"
                 }
             }
+        },
+        "model.InvitationStatus": {
+            "type": "string",
+            "enum": [
+                "PENDING",
+                "PENDING_APPROVAL",
+                "ACCEPTED",
+                "REJECTED"
+            ],
+            "x-enum-varnames": [
+                "InvitationStatusPending",
+                "InvitationStatusPendingApproval",
+                "InvitationStatusAccepted",
+                "InvitationStatusRejected"
+            ]
         },
         "model.MciamPermission": {
             "type": "object",
@@ -11591,6 +13284,151 @@
                 }
             }
         },
+        "model.ProjectSyncApplyAssignedItem": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "nsId": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.ProjectSyncApplyCreatedItem": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "nsId": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.ProjectSyncApplyFailedItem": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string"
+                },
+                "nsId": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.ProjectSyncApplyRequest": {
+            "type": "object",
+            "required": [
+                "nsIds",
+                "workspaceId"
+            ],
+            "properties": {
+                "nsIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "workspaceId": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.ProjectSyncApplyResponse": {
+            "type": "object",
+            "properties": {
+                "assigned": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.ProjectSyncApplyAssignedItem"
+                    }
+                },
+                "created": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.ProjectSyncApplyCreatedItem"
+                    }
+                },
+                "failed": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.ProjectSyncApplyFailedItem"
+                    }
+                },
+                "skipped": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.ProjectSyncApplySkippedItem"
+                    }
+                }
+            }
+        },
+        "model.ProjectSyncApplySkippedItem": {
+            "type": "object",
+            "properties": {
+                "nsId": {
+                    "type": "string"
+                },
+                "reason": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.ProjectSyncDiffMissingItem": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "nsId": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.ProjectSyncDiffResponse": {
+            "type": "object",
+            "properties": {
+                "missingProjects": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.ProjectSyncDiffMissingItem"
+                    }
+                },
+                "unassignedProjects": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.ProjectSyncDiffUnassignedItem"
+                    }
+                }
+            }
+        },
+        "model.ProjectSyncDiffUnassignedItem": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "nsId": {
+                    "type": "string"
+                }
+            }
+        },
         "model.ResetPasswordRequest": {
             "type": "object",
             "required": [
@@ -11788,6 +13626,28 @@
                 }
             }
         },
+        "model.RoleMenuMapping": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "menu_id": {
+                    "description": "메뉴 ID",
+                    "type": "string"
+                },
+                "role_id": {
+                    "description": "역할 ID",
+                    "type": "integer"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
         "model.RoleSub": {
             "type": "object",
             "properties": {
@@ -11805,6 +13665,20 @@
                 },
                 "updated_at": {
                     "type": "string"
+                }
+            }
+        },
+        "model.SendInvitationRequest": {
+            "type": "object",
+            "required": [
+                "inviteeUserId"
+            ],
+            "properties": {
+                "inviteeUserId": {
+                    "type": "integer"
+                },
+                "roleId": {
+                    "type": "integer"
                 }
             }
         },
@@ -12095,6 +13969,44 @@
                 }
             }
         },
+        "model.ValidationStep": {
+            "type": "object",
+            "properties": {
+                "detail": {
+                    "description": "수행 내역 또는 오류 안내 (skipped면 \"\")",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "단계명",
+                    "type": "string"
+                },
+                "status": {
+                    "description": "ok | failed | skipped",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.ValidationStepStatus"
+                        }
+                    ]
+                },
+                "step": {
+                    "description": "순번 (1부터)",
+                    "type": "integer"
+                }
+            }
+        },
+        "model.ValidationStepStatus": {
+            "type": "string",
+            "enum": [
+                "ok",
+                "failed",
+                "skipped"
+            ],
+            "x-enum-varnames": [
+                "ValidationStepOk",
+                "ValidationStepFailed",
+                "ValidationStepSkipped"
+            ]
+        },
         "model.Workspace": {
             "type": "object",
             "properties": {
@@ -12118,6 +14030,35 @@
                 },
                 "updated_at": {
                     "type": "string"
+                }
+            }
+        },
+        "model.WorkspaceInvitation": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "inviteeUserId": {
+                    "type": "integer"
+                },
+                "inviterUserId": {
+                    "type": "integer"
+                },
+                "roleId": {
+                    "type": "integer"
+                },
+                "status": {
+                    "$ref": "#/definitions/model.InvitationStatus"
+                },
+                "updatedAt": {
+                    "type": "string"
+                },
+                "workspaceId": {
+                    "type": "integer"
                 }
             }
         },

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -4,20 +4,36 @@ definitions:
     enum:
     - OIDC
     - SAML
+    - SECRET_KEY
     type: string
     x-enum-varnames:
     - AuthMethodOIDC
     - AuthMethodSAML
+    - AuthMethodSecretKey
   constants.CSPType:
     enum:
     - aws
     - gcp
     - azure
+    - alibaba
+    - tencent
+    - ibm
+    - ncp
+    - nhn
+    - kt
+    - openstack
     type: string
     x-enum-varnames:
     - CSPTypeAWS
     - CSPTypeGCP
     - CSPTypeAzure
+    - CSPTypeAlibaba
+    - CSPTypeTencent
+    - CSPTypeIBM
+    - CSPTypeNCP
+    - CSPTypeNHN
+    - CSPTypeKT
+    - CSPTypeOpenStack
   constants.IAMRoleType:
     enum:
     - platform
@@ -36,6 +52,11 @@ definitions:
     - RoleTypePlatform
     - RoleTypeWorkspace
     - RoleTypeCSP
+  handler.UserListRequest:
+    properties:
+      enabled:
+        type: boolean
+    type: object
   idp.UserLogin:
     properties:
       id:
@@ -130,6 +151,16 @@ definitions:
     required:
     - role_id
     type: object
+  model.AssignGroupUsersRequest:
+    properties:
+      user_ids:
+        items:
+          type: integer
+        minItems: 1
+        type: array
+    required:
+    - user_ids
+    type: object
   model.AssignGroupWorkspaceRequest:
     properties:
       role_id:
@@ -219,6 +250,24 @@ definitions:
     - AuthMethodOIDC
     - AuthMethodSAML
     - AuthMethodSecretKey
+  model.BulkHealthCheckRequest:
+    properties:
+      csp_account_id:
+        type: integer
+    type: object
+  model.BulkHealthCheckResponse:
+    properties:
+      connected_count:
+        type: integer
+      failed_count:
+        type: integer
+      results:
+        items:
+          $ref: '#/definitions/model.HealthCheckResult'
+        type: array
+      total_count:
+        type: integer
+    type: object
   model.ChangeMyPasswordRequest:
     properties:
       currentPassword:
@@ -229,6 +278,52 @@ definitions:
     required:
     - currentPassword
     - newPassword
+    type: object
+  model.CompanyRequest:
+    properties:
+      description:
+        type: string
+      kc_client_id:
+        type: string
+      kc_client_secret:
+        type: string
+      name:
+        type: string
+      realm_name:
+        type: string
+    required:
+    - kc_client_id
+    - kc_client_secret
+    - name
+    - realm_name
+    type: object
+  model.CompanyResponse:
+    properties:
+      created_at:
+        type: string
+      description:
+        type: string
+      id:
+        type: integer
+      kc_client_id:
+        type: string
+      name:
+        type: string
+      realm_name:
+        type: string
+      status:
+        type: string
+      updated_at:
+        type: string
+    type: object
+  model.CompanyUpdateRequest:
+    properties:
+      description:
+        type: string
+      name:
+        type: string
+    required:
+    - name
     type: object
   model.CreateCspAccountRequest:
     properties:
@@ -241,6 +336,13 @@ definitions:
         - aws
         - gcp
         - azure
+        - alibaba
+        - tencent
+        - ibm
+        - ncp
+        - nhn
+        - kt
+        - openstack
         type: string
       description:
         type: string
@@ -302,6 +404,10 @@ definitions:
     type: object
   model.CreateCspRoleRequest:
     properties:
+      authMethod:
+        allOf:
+        - $ref: '#/definitions/constants.AuthMethod'
+        description: 인증방식 (OIDC/SAML/SECRET_KEY), 미지정 시 OIDC 기본값
       cspRoleName:
         description: csp의 RoleName. 여러 role이 있기때문에 csp에 정의한 role로 구분하기 위해 사용
         type: string
@@ -346,6 +452,39 @@ definitions:
     required:
     - menuIds
     - roleId
+    type: object
+  model.CreateMenuRequest:
+    properties:
+      displayName:
+        type: string
+      id:
+        type: string
+      isAction:
+        type: boolean
+      menuNumber:
+        type: string
+      parentId:
+        type: string
+      priority:
+        type: string
+      resType:
+        type: string
+      roleIds:
+        description: 생성과 동시에 매핑할 역할 ID 목록 (platform_admin은 항상 자동 매핑)
+        items:
+          type: integer
+        type: array
+    required:
+    - id
+    type: object
+  model.CreateMenuResponse:
+    properties:
+      menu:
+        $ref: '#/definitions/model.Menu'
+      roleMappings:
+        items:
+          $ref: '#/definitions/model.RoleMenuMapping'
+        type: array
     type: object
   model.CreateOrganizationRequest:
     properties:
@@ -401,6 +540,13 @@ definitions:
     required:
     - name
     type: object
+  model.CredentialSummary:
+    properties:
+      accessKeyId:
+        type: string
+      expiration:
+        type: string
+    type: object
   model.CspAccount:
     properties:
       account_info:
@@ -431,6 +577,36 @@ definitions:
         type: boolean
       name:
         type: string
+    type: object
+  model.CspAccountValidationResponse:
+    properties:
+      account_id:
+        type: integer
+      account_name:
+        type: string
+      csp_type:
+        type: string
+      results:
+        items:
+          $ref: '#/definitions/model.CspAccountValidationResult'
+        type: array
+    type: object
+  model.CspAccountValidationResult:
+    properties:
+      auth_method:
+        type: string
+      csp_role_id:
+        type: integer
+      csp_role_name:
+        type: string
+      csp_type:
+        type: string
+      detail:
+        type: string
+      error:
+        type: string
+      valid:
+        type: boolean
     type: object
   model.CspIdpConfig:
     properties:
@@ -469,6 +645,23 @@ definitions:
         type: boolean
       name:
         type: string
+    type: object
+  model.CspIdpSummary:
+    properties:
+      active_count:
+        type: integer
+      csp_account_id:
+        type: integer
+      csp_account_name:
+        type: string
+      csp_type:
+        type: string
+      method_counts:
+        additionalProperties:
+          type: integer
+        type: object
+      total_count:
+        type: integer
     type: object
   model.CspPolicy:
     properties:
@@ -560,6 +753,41 @@ definitions:
       updated_at:
         type: string
     type: object
+  model.CspValidationRequest:
+    properties:
+      authMethod:
+        description: 인증방식 (OIDC, SAML, SECRET_KEY)
+        type: string
+      cspType:
+        description: CSP 유형 (aws, gcp, ...)
+        type: string
+      workspaceId:
+        description: 대상 워크스페이스 ID
+        type: string
+    type: object
+  model.CspValidationResponse:
+    properties:
+      authMethod:
+        type: string
+      credentials:
+        allOf:
+        - $ref: '#/definitions/model.CredentialSummary'
+        description: valid=true일 때만
+      cspType:
+        type: string
+      error:
+        type: string
+      failedStep:
+        description: 0=전체성공, N=N번 단계 실패
+        type: integer
+      steps:
+        description: 항상 전체 단계 포함
+        items:
+          $ref: '#/definitions/model.ValidationStep'
+        type: array
+      valid:
+        type: boolean
+    type: object
   model.FilterRoleMasterMappingRequest:
     properties:
       authMethod:
@@ -617,6 +845,24 @@ definitions:
       workspace_id:
         type: integer
       workspace_name:
+        type: string
+    type: object
+  model.HealthCheckResult:
+    properties:
+      auth_method:
+        type: string
+      checked_at:
+        type: string
+      config_id:
+        type: integer
+      config_name:
+        type: string
+      csp_type:
+        type: string
+      error_message:
+        type: string
+      status:
+        description: CONNECTED, FAILED, TIMEOUT
         type: string
     type: object
   model.ImportApiFramework:
@@ -699,6 +945,18 @@ definitions:
         description: Total number of frameworks in request
         type: integer
     type: object
+  model.InvitationStatus:
+    enum:
+    - PENDING
+    - PENDING_APPROVAL
+    - ACCEPTED
+    - REJECTED
+    type: string
+    x-enum-varnames:
+    - InvitationStatusPending
+    - InvitationStatusPendingApproval
+    - InvitationStatusAccepted
+    - InvitationStatusRejected
   model.MciamPermission:
     properties:
       action:
@@ -891,6 +1149,100 @@ definitions:
           $ref: '#/definitions/model.Workspace'
         type: array
     type: object
+  model.ProjectSyncApplyAssignedItem:
+    properties:
+      id:
+        type: integer
+      name:
+        type: string
+      nsId:
+        type: string
+    type: object
+  model.ProjectSyncApplyCreatedItem:
+    properties:
+      id:
+        type: integer
+      name:
+        type: string
+      nsId:
+        type: string
+    type: object
+  model.ProjectSyncApplyFailedItem:
+    properties:
+      error:
+        type: string
+      nsId:
+        type: string
+    type: object
+  model.ProjectSyncApplyRequest:
+    properties:
+      nsIds:
+        items:
+          type: string
+        type: array
+      workspaceId:
+        type: string
+    required:
+    - nsIds
+    - workspaceId
+    type: object
+  model.ProjectSyncApplyResponse:
+    properties:
+      assigned:
+        items:
+          $ref: '#/definitions/model.ProjectSyncApplyAssignedItem'
+        type: array
+      created:
+        items:
+          $ref: '#/definitions/model.ProjectSyncApplyCreatedItem'
+        type: array
+      failed:
+        items:
+          $ref: '#/definitions/model.ProjectSyncApplyFailedItem'
+        type: array
+      skipped:
+        items:
+          $ref: '#/definitions/model.ProjectSyncApplySkippedItem'
+        type: array
+    type: object
+  model.ProjectSyncApplySkippedItem:
+    properties:
+      nsId:
+        type: string
+      reason:
+        type: string
+    type: object
+  model.ProjectSyncDiffMissingItem:
+    properties:
+      description:
+        type: string
+      name:
+        type: string
+      nsId:
+        type: string
+    type: object
+  model.ProjectSyncDiffResponse:
+    properties:
+      missingProjects:
+        items:
+          $ref: '#/definitions/model.ProjectSyncDiffMissingItem'
+        type: array
+      unassignedProjects:
+        items:
+          $ref: '#/definitions/model.ProjectSyncDiffUnassignedItem'
+        type: array
+    type: object
+  model.ProjectSyncDiffUnassignedItem:
+    properties:
+      description:
+        type: string
+      id:
+        type: integer
+      name:
+        type: string
+      nsId:
+        type: string
+    type: object
   model.ResetPasswordRequest:
     properties:
       newPassword:
@@ -1021,6 +1373,21 @@ definitions:
           $ref: '#/definitions/model.UserWorkspaceRole'
         type: array
     type: object
+  model.RoleMenuMapping:
+    properties:
+      created_at:
+        type: string
+      id:
+        type: integer
+      menu_id:
+        description: 메뉴 ID
+        type: string
+      role_id:
+        description: 역할 ID
+        type: integer
+      updated_at:
+        type: string
+    type: object
   model.RoleSub:
     properties:
       created_at:
@@ -1033,6 +1400,15 @@ definitions:
         $ref: '#/definitions/constants.IAMRoleType'
       updated_at:
         type: string
+    type: object
+  model.SendInvitationRequest:
+    properties:
+      inviteeUserId:
+        type: integer
+      roleId:
+        type: integer
+    required:
+    - inviteeUserId
     type: object
   model.SetupInitialAdminRequest:
     properties:
@@ -1229,6 +1605,32 @@ definitions:
       workspace_name:
         type: string
     type: object
+  model.ValidationStep:
+    properties:
+      detail:
+        description: 수행 내역 또는 오류 안내 (skipped면 "")
+        type: string
+      name:
+        description: 단계명
+        type: string
+      status:
+        allOf:
+        - $ref: '#/definitions/model.ValidationStepStatus'
+        description: ok | failed | skipped
+      step:
+        description: 순번 (1부터)
+        type: integer
+    type: object
+  model.ValidationStepStatus:
+    enum:
+    - ok
+    - failed
+    - skipped
+    type: string
+    x-enum-varnames:
+    - ValidationStepOk
+    - ValidationStepFailed
+    - ValidationStepSkipped
   model.Workspace:
     properties:
       created_at:
@@ -1245,6 +1647,25 @@ definitions:
         type: array
       updated_at:
         type: string
+    type: object
+  model.WorkspaceInvitation:
+    properties:
+      createdAt:
+        type: string
+      id:
+        type: integer
+      inviteeUserId:
+        type: integer
+      inviterUserId:
+        type: integer
+      roleId:
+        type: integer
+      status:
+        $ref: '#/definitions/model.InvitationStatus'
+      updatedAt:
+        type: string
+      workspaceId:
+        type: integer
     type: object
   model.WorkspaceProjectMappingRequest:
     properties:
@@ -1481,6 +1902,173 @@ paths:
       summary: Validate access token
       tags:
       - auth
+  /api/company:
+    delete:
+      description: 플랫폼 회사를 비활성화합니다. (platformAdmin 전용, 멱등 처리)
+      operationId: deactivateCompany
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.CompanyResponse'
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Deactivate company
+      tags:
+      - company
+    get:
+      description: 플랫폼 회사 정보를 조회합니다. (싱글톤)
+      operationId: getCompany
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.CompanyResponse'
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Get company
+      tags:
+      - company
+    post:
+      consumes:
+      - application/json
+      description: 플랫폼 회사 정보를 생성합니다. (싱글톤, platformAdmin 전용)
+      operationId: createCompany
+      parameters:
+      - description: Company Info
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/model.CompanyRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/model.CompanyResponse'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "409":
+          description: Conflict
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Create company
+      tags:
+      - company
+    put:
+      consumes:
+      - application/json
+      description: 플랫폼 회사 이름/설명을 수정합니다. (platformAdmin 전용)
+      operationId: updateCompany
+      parameters:
+      - description: Company Update Info
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/model.CompanyUpdateRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.CompanyResponse'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Update company
+      tags:
+      - company
+  /api/company/activate:
+    post:
+      description: 플랫폼 회사를 활성화합니다. (platformAdmin 전용, 멱등 처리)
+      operationId: activateCompany
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.CompanyResponse'
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Activate company
+      tags:
+      - company
   /api/csp-accounts:
     post:
       consumes:
@@ -1738,7 +2326,9 @@ paths:
     post:
       consumes:
       - application/json
-      description: Validate CSP account configuration
+      description: Validate CSP account by checking actual CSP infrastructure (IDP
+        provider existence, role trust policy, or credential validity) for each linked
+        CspRole
       operationId: validateCspAccount
       parameters:
       - description: Account ID
@@ -1752,9 +2342,7 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/model.CspAccountValidationResponse'
         "400":
           description: Bad Request
           schema:
@@ -1767,8 +2355,8 @@ paths:
             additionalProperties:
               type: string
             type: object
-        "500":
-          description: Internal Server Error
+        "503":
+          description: Service Unavailable
           schema:
             additionalProperties:
               type: string
@@ -1962,6 +2550,36 @@ paths:
       security:
       - BearerAuth: []
       summary: Create CSP IDP config
+      tags:
+      - csp-idp-configs
+  /api/csp-idp-configs/health-check:
+    post:
+      consumes:
+      - application/json
+      description: Check connection status of all active CSP IDP configurations concurrently
+      operationId: bulkHealthCheckCspIdpConfigs
+      parameters:
+      - description: Optional filter
+        in: body
+        name: request
+        schema:
+          $ref: '#/definitions/model.BulkHealthCheckRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.BulkHealthCheckResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Bulk health check for CSP IDP configs
       tags:
       - csp-idp-configs
   /api/csp-idp-configs/id/{configId}:
@@ -2254,6 +2872,32 @@ paths:
       security:
       - BearerAuth: []
       summary: List CSP IDP configs
+      tags:
+      - csp-idp-configs
+  /api/csp-idp-configs/summary:
+    get:
+      consumes:
+      - application/json
+      description: Get IDP configuration count summary grouped by CSP account
+      operationId: getCspIdpSummary
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.CspIdpSummary'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Get CSP IDP config summary
       tags:
       - csp-idp-configs
   /api/csp-policies:
@@ -2783,6 +3427,121 @@ paths:
       summary: 그룹 Platform Role 해제
       tags:
       - groups
+  /api/groups/id/{groupId}/platform-roles/available:
+    get:
+      description: 그룹에 아직 할당되지 않은 플랫폼 역할 목록을 조회합니다.
+      operationId: getAvailableGroupPlatformRoles
+      parameters:
+      - description: 그룹 ID
+        in: path
+        name: groupId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.RoleMaster'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 그룹에 할당 가능한 Platform Role 목록 조회
+      tags:
+      - groups
+  /api/groups/id/{groupId}/users:
+    post:
+      consumes:
+      - application/json
+      description: 그룹에 사용자 목록을 일괄 할당합니다. DB + Keycloak 그룹 동기화.
+      operationId: assignGroupUsers
+      parameters:
+      - description: 그룹 ID
+        in: path
+        name: groupId
+        required: true
+        type: integer
+      - description: 사용자 일괄 할당 요청
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/model.AssignGroupUsersRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 그룹에 사용자 일괄 할당 (Keycloak 동기화 포함)
+      tags:
+      - groups
+  /api/groups/id/{groupId}/users/{userId}:
+    delete:
+      description: 그룹에서 특정 사용자를 제거합니다. DB + Keycloak 그룹 동기화.
+      operationId: removeGroupUser
+      parameters:
+      - description: 그룹 ID
+        in: path
+        name: groupId
+        required: true
+        type: integer
+      - description: 사용자 ID
+        in: path
+        name: userId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 그룹에서 사용자 제거 (Keycloak 동기화 포함)
+      tags:
+      - groups
   /api/groups/id/{groupId}/workspaces:
     get:
       description: 그룹에 매핑된 워크스페이스 및 역할 목록을 조회합니다.
@@ -2841,6 +3600,12 @@ paths:
             type: object
         "400":
           description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
           schema:
             additionalProperties:
               type: string
@@ -2945,6 +3710,36 @@ paths:
       summary: 그룹 워크스페이스 역할 변경
       tags:
       - groups
+  /api/groups/id/{groupId}/workspaces/available:
+    get:
+      description: 그룹에 아직 매핑되지 않은 워크스페이스 목록을 조회합니다.
+      operationId: getAvailableGroupWorkspaces
+      parameters:
+      - description: 그룹 ID
+        in: path
+        name: groupId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.Workspace'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 그룹에 매핑 가능한 워크스페이스 목록 조회
+      tags:
+      - groups
   /api/initial-admin:
     post:
       consumes:
@@ -2969,6 +3764,96 @@ paths:
       summary: Setup initial platform admin
       tags:
       - admin
+  /api/invitations:
+    get:
+      consumes:
+      - application/json
+      description: List all workspace invitations, optionally filtered by status
+      operationId: listAllInvitations
+      parameters:
+      - description: Filter by status (PENDING_APPROVAL)
+        in: query
+        name: status
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.WorkspaceInvitation'
+            type: array
+      security:
+      - BearerAuth: []
+      summary: List all invitations (admin)
+      tags:
+      - invitations
+  /api/invitations/{invitationId}/approve:
+    put:
+      consumes:
+      - application/json
+      description: Admin approves a workspace invitation and registers the invitee
+        as member
+      operationId: approveInvitation
+      parameters:
+      - description: Invitation ID
+        in: path
+        name: invitationId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Approve workspace invitation (admin)
+      tags:
+      - invitations
+  /api/invitations/{invitationId}/reject:
+    put:
+      consumes:
+      - application/json
+      description: Admin rejects a workspace invitation
+      operationId: rejectInvitationByAdmin
+      parameters:
+      - description: Invitation ID
+        in: path
+        name: invitationId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Reject workspace invitation (admin)
+      tags:
+      - invitations
   /api/mcmp-api-permission-action-mappings:
     post:
       consumes:
@@ -3440,7 +4325,9 @@ paths:
     post:
       consumes:
       - application/json
-      description: Create a new menu
+      description: Create a new menu. If roleIds is provided, the menu is mapped to
+        those platform roles in a single transaction. platform_admin role is always
+        automatically mapped.
       operationId: createMenu
       parameters:
       - description: Menu Info
@@ -3448,14 +4335,32 @@ paths:
         name: menu
         required: true
         schema:
-          $ref: '#/definitions/model.Menu'
+          $ref: '#/definitions/model.CreateMenuRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/model.Menu'
+            $ref: '#/definitions/model.CreateMenuResponse'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "409":
+          description: Conflict
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
       security:
       - BearerAuth: []
       summary: Create new menu
@@ -3571,6 +4476,44 @@ paths:
       security:
       - BearerAuth: []
       summary: List all menus
+      tags:
+      - menus
+  /api/menus/menus-tree/list:
+    post:
+      consumes:
+      - application/json
+      description: List all menus as a tree structure. Admin permission required.
+      operationId: listMenusTree
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.MenuTreeNode'
+            type: array
+        "401":
+          description: 'error: Unauthorized'
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: 'error: Forbidden'
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: 'error: 서버 내부 오류'
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: List all menus Tree
       tags:
       - menus
   /api/menus/platform-roles:
@@ -3770,44 +4713,6 @@ paths:
       summary: Register/Update menus from YAML in request body
       tags:
       - menus
-  /api/menus/tree/list:
-    post:
-      consumes:
-      - application/json
-      description: List all menus as a tree structure. Admin permission required.
-      operationId: listMenusTree
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/model.MenuTreeNode'
-            type: array
-        "401":
-          description: 'error: Unauthorized'
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "403":
-          description: 'error: Forbidden'
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "500":
-          description: 'error: 서버 내부 오류'
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-      security:
-      - BearerAuth: []
-      summary: List all menus Tree
-      tags:
-      - menus
   /api/menus/user-menu-tree:
     get:
       consumes:
@@ -3836,13 +4741,22 @@ paths:
       - menus
   /api/organizations:
     get:
-      description: 전체 조직 목록을 조회합니다. tree=true이면 Tree 구조로 반환.
+      description: 전체 조직 목록을 조회합니다. tree=true이면 Tree 구조로 반환. name/code로 검색 가능 (검색
+        시 tree 파라미터 무시).
       operationId: listOrganizations
       parameters:
       - description: 'Tree 구조 반환 여부 (기본: false)'
         in: query
         name: tree
         type: boolean
+      - description: 조직명 검색 (부분 일치, ILIKE)
+        in: query
+        name: name
+        type: string
+      - description: 조직 코드 검색 (부분 일치, ILIKE)
+        in: query
+        name: code
+        type: string
       produces:
       - application/json
       responses:
@@ -6361,6 +7275,66 @@ paths:
       summary: Initialize menu permissions from CSV
       tags:
       - admin
+  /api/setup/projects/sync:
+    post:
+      consumes:
+      - application/json
+      description: 지정된 nsId 목록의 project를 생성하거나 지정된 workspace에 할당합니다.
+      operationId: applyProjectSync
+      parameters:
+      - description: Sync Apply Request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/model.ProjectSyncApplyRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.ProjectSyncApplyResponse'
+        "400":
+          description: 'error: 잘못된 요청'
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: 'error: 서버 내부 오류'
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 선택한 namespace를 특정 workspace에 동기화
+      tags:
+      - projects
+  /api/setup/projects/sync-diff:
+    get:
+      description: mc-infra-manager의 namespace 목록과 로컬 프로젝트를 비교하여 불일치 목록을 반환합니다. DB
+        변경 없음.
+      operationId: getProjectSyncDiff
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.ProjectSyncDiffResponse'
+        "500":
+          description: 'error: 서버 내부 오류'
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: mc-infra-manager와 프로젝트 동기화 차이 조회
+      tags:
+      - projects
   /api/setup/sync-projects:
     post:
       consumes:
@@ -6507,7 +7481,7 @@ paths:
       - users
   /api/users/{userId}/organizations:
     get:
-      description: 사용자가 소속된 조직 목록을 조회합니다.
+      description: 사용자가 소속된 조직 목록을 조회합니다. hierarchy=true이면 path/level 포함.
       operationId: getUserOrganizations
       parameters:
       - description: 사용자 ID
@@ -6515,6 +7489,10 @@ paths:
         name: userId
         required: true
         type: integer
+      - description: '계층 정보(path, level) 포함 여부 (기본: false)'
+        in: query
+        name: hierarchy
+        type: boolean
       produces:
       - application/json
       responses:
@@ -6522,7 +7500,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/model.Organization'
+              $ref: '#/definitions/model.OrganizationTree'
             type: array
         "400":
           description: Bad Request
@@ -6681,6 +7659,43 @@ paths:
       summary: 사용자를 그룹에 할당 (Keycloak 동기화 포함)
       tags:
       - groups
+    put:
+      consumes:
+      - application/json
+      description: 사용자의 기존 그룹을 모두 제거하고 지정된 그룹으로 교체합니다.
+      operationId: replaceUserGroups
+      parameters:
+      - description: 사용자 ID
+        in: path
+        name: userId
+        required: true
+        type: integer
+      - description: 교체할 그룹 목록
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/model.AssignUserGroupsRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 사용자 그룹 멤버십 전체 교체
+      tags:
+      - organizations
   /api/users/id/{userId}/groups/{groupId}:
     delete:
       description: 사용자를 특정 그룹에서 제거합니다. DB + Keycloak 그룹 동기화.
@@ -6959,8 +7974,15 @@ paths:
     post:
       consumes:
       - application/json
-      description: Retrieve a list of all users.
+      description: Retrieve a list of users. Optionally filter by Keycloak enabled
+        status (true=active, false=pending approval).
       operationId: listUsers
+      parameters:
+      - description: Optional filter
+        in: body
+        name: request
+        schema:
+          $ref: '#/definitions/handler.UserListRequest'
       produces:
       - application/json
       responses:
@@ -6970,6 +7992,12 @@ paths:
             items:
               $ref: '#/definitions/model.User'
             type: array
+        "403":
+          description: Forbidden
+          schema:
+            additionalProperties:
+              type: string
+            type: object
         "500":
           description: Internal Server Error
           schema:
@@ -6979,6 +8007,137 @@ paths:
       security:
       - BearerAuth: []
       summary: List all users
+      tags:
+      - users
+  /api/users/me:
+    get:
+      description: Get the authenticated user's own profile information. No PlatformRole
+        required.
+      operationId: getMyInfo
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.User'
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Get my info
+      tags:
+      - users
+  /api/users/me/invitations:
+    get:
+      consumes:
+      - application/json
+      description: List pending workspace invitations for the current user
+      operationId: listMyInvitations
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.WorkspaceInvitation'
+            type: array
+      security:
+      - BearerAuth: []
+      summary: List my invitations
+      tags:
+      - users
+  /api/users/me/invitations/{invitationId}/accept:
+    put:
+      consumes:
+      - application/json
+      description: Accept a workspace invitation and join as member
+      operationId: acceptInvitation
+      parameters:
+      - description: Invitation ID
+        in: path
+        name: invitationId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Forbidden
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Accept workspace invitation
+      tags:
+      - users
+  /api/users/me/invitations/{invitationId}/reject:
+    put:
+      consumes:
+      - application/json
+      description: Reject a workspace invitation
+      operationId: rejectInvitation
+      parameters:
+      - description: Invitation ID
+        in: path
+        name: invitationId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Forbidden
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Reject workspace invitation
       tags:
       - users
   /api/users/me/password:
@@ -7384,6 +8543,50 @@ paths:
       summary: Add project to workspace
       tags:
       - workspaces
+  /api/workspaces/credentials/validate:
+    post:
+      consumes:
+      - application/json
+      description: 워크스페이스 사용자의 CSP×AuthMethod 조합 인증 설정을 단계별로 검증하고 임시자격증명 발급까지 확인한다.
+        실패 여부와 무관하게 모든 단계를 응답에 포함한다.
+      operationId: mciamValidateCredentials
+      parameters:
+      - description: 검증 요청
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/model.CspValidationRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.CspValidationResponse'
+        "400":
+          description: 'error: invalid request'
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: 'error: Unauthorized'
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: 'error: User not found'
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: CSP 인증 설정 단계별 검증
+      tags:
+      - csp-validation
   /api/workspaces/id/{workspaceId}:
     delete:
       consumes:
@@ -7627,6 +8830,77 @@ paths:
               type: string
             type: object
       summary: List users and roles by workspace
+      tags:
+      - workspaces
+  /api/workspaces/id/{wsId}/invitations:
+    get:
+      consumes:
+      - application/json
+      description: List invitations for a specific workspace
+      operationId: listWorkspaceInvitations
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: wsId
+        required: true
+        type: integer
+      - description: Filter by status (PENDING/ACCEPTED/REJECTED)
+        in: query
+        name: status
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.WorkspaceInvitation'
+            type: array
+      security:
+      - BearerAuth: []
+      summary: List workspace invitations
+      tags:
+      - workspaces
+    post:
+      consumes:
+      - application/json
+      description: Send an invitation to a platform user to join the workspace
+      operationId: sendWorkspaceInvitation
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: wsId
+        required: true
+        type: integer
+      - description: Invitation request
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/model.SendInvitationRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/model.WorkspaceInvitation'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Send workspace invitation
       tags:
       - workspaces
   /api/workspaces/list:

--- a/src/handler/project_handler.go
+++ b/src/handler/project_handler.go
@@ -307,6 +307,66 @@ func (h *ProjectHandler) SyncProjects(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]string{"message": "Project synchronization successful"})
 }
 
+// GetProjectSyncDiff godoc
+// @Summary mc-infra-manager와 프로젝트 동기화 차이 조회
+// @Description mc-infra-manager의 namespace 목록과 로컬 프로젝트를 비교하여 불일치 목록을 반환합니다. DB 변경 없음.
+// @Tags projects
+// @Produce json
+// @Success 200 {object} model.ProjectSyncDiffResponse
+// @Failure 500 {object} map[string]string "error: 서버 내부 오류"
+// @Security BearerAuth
+// @Router /api/setup/projects/sync-diff [get]
+// @Id getProjectSyncDiff
+func (h *ProjectHandler) GetProjectSyncDiff(c echo.Context) error {
+	diff, err := h.projectService.GetProjectSyncDiff(c.Request().Context())
+	if err != nil {
+		log.Printf("GetProjectSyncDiff error: %v", err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("동기화 차이 조회 실패: %v", err)})
+	}
+	return c.JSON(http.StatusOK, diff)
+}
+
+// ApplyProjectSync godoc
+// @Summary 선택한 namespace를 특정 workspace에 동기화
+// @Description 지정된 nsId 목록의 project를 생성하거나 지정된 workspace에 할당합니다.
+// @Tags projects
+// @Accept json
+// @Produce json
+// @Param request body model.ProjectSyncApplyRequest true "Sync Apply Request"
+// @Success 200 {object} model.ProjectSyncApplyResponse
+// @Failure 400 {object} map[string]string "error: 잘못된 요청"
+// @Failure 500 {object} map[string]string "error: 서버 내부 오류"
+// @Security BearerAuth
+// @Router /api/setup/projects/sync [post]
+// @Id applyProjectSync
+func (h *ProjectHandler) ApplyProjectSync(c echo.Context) error {
+	var req model.ProjectSyncApplyRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "잘못된 요청 형식입니다"})
+	}
+	if req.WorkspaceID == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "workspaceId가 필요합니다"})
+	}
+	if len(req.NsIds) == 0 {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "nsIds가 필요합니다"})
+	}
+
+	workspaceIDInt, err := util.StringToUint(req.WorkspaceID)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "잘못된 workspaceId 형식입니다"})
+	}
+
+	result, err := h.projectService.ApplyProjectSyncToWorkspace(c.Request().Context(), workspaceIDInt, req.NsIds)
+	if err != nil {
+		log.Printf("ApplyProjectSync error: %v", err)
+		if err.Error() == "workspace not found" {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": "workspace not found"})
+		}
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("동기화 적용 실패: %v", err)})
+	}
+	return c.JSON(http.StatusOK, result)
+}
+
 // AddWorkspaceToProject godoc
 // @Summary 프로젝트에 워크스페이스 연결
 // @Description 프로젝트에 워크스페이스를 연결합니다.

--- a/src/main.go
+++ b/src/main.go
@@ -226,6 +226,8 @@ func main() {
 	{
 		setup.GET("/check-user-roles", adminHandler.CheckUserRoles)
 		setup.POST("/sync-projects", projectHandler.SyncProjects)
+		setup.GET("/projects/sync-diff", projectHandler.GetProjectSyncDiff)
+		setup.POST("/projects/sync", projectHandler.ApplyProjectSync)
 		setup.POST("/sync-mcmp-apis", mcmpApiHandler.SyncMcmpAPIs)
 		setup.POST("/initial-menus", menuHandler.RegisterMenusFromYAML, middleware.PlatformAdminMiddleware)
 		setup.POST("/initial-menus2", menuHandler.RegisterMenusFromBody, middleware.PlatformAdminMiddleware)

--- a/src/model/request.go
+++ b/src/model/request.go
@@ -285,3 +285,64 @@ type ChangeMyPasswordRequest struct {
 	CurrentPassword string `json:"currentPassword" validate:"required"`
 	NewPassword     string `json:"newPassword" validate:"required,min=8"`
 }
+
+// ProjectSyncApplyRequest POST /api/setup/projects/sync request body
+type ProjectSyncApplyRequest struct {
+	WorkspaceID string   `json:"workspaceId" validate:"required"`
+	NsIds       []string `json:"nsIds" validate:"required"`
+}
+
+// ProjectSyncDiffMissingItem namespace exists in infra but has no local project
+type ProjectSyncDiffMissingItem struct {
+	NsId        string `json:"nsId"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// ProjectSyncDiffUnassignedItem local project exists but is not assigned to any workspace
+type ProjectSyncDiffUnassignedItem struct {
+	ID          uint   `json:"id"`
+	NsId        string `json:"nsId"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// ProjectSyncDiffResponse GET /api/setup/projects/sync-diff response
+type ProjectSyncDiffResponse struct {
+	MissingProjects    []ProjectSyncDiffMissingItem    `json:"missingProjects"`
+	UnassignedProjects []ProjectSyncDiffUnassignedItem `json:"unassignedProjects"`
+}
+
+// ProjectSyncApplyCreatedItem newly created project during sync apply
+type ProjectSyncApplyCreatedItem struct {
+	ID   uint   `json:"id"`
+	NsId string `json:"nsId"`
+	Name string `json:"name"`
+}
+
+// ProjectSyncApplyAssignedItem existing project that was assigned to workspace
+type ProjectSyncApplyAssignedItem struct {
+	ID   uint   `json:"id"`
+	NsId string `json:"nsId"`
+	Name string `json:"name"`
+}
+
+// ProjectSyncApplySkippedItem namespace skipped during sync apply
+type ProjectSyncApplySkippedItem struct {
+	NsId   string `json:"nsId"`
+	Reason string `json:"reason"`
+}
+
+// ProjectSyncApplyFailedItem namespace where sync apply failed
+type ProjectSyncApplyFailedItem struct {
+	NsId  string `json:"nsId"`
+	Error string `json:"error"`
+}
+
+// ProjectSyncApplyResponse POST /api/setup/projects/sync response
+type ProjectSyncApplyResponse struct {
+	Created  []ProjectSyncApplyCreatedItem  `json:"created"`
+	Assigned []ProjectSyncApplyAssignedItem `json:"assigned"`
+	Skipped  []ProjectSyncApplySkippedItem  `json:"skipped"`
+	Failed   []ProjectSyncApplyFailedItem   `json:"failed"`
+}

--- a/src/service/project_service.go
+++ b/src/service/project_service.go
@@ -452,6 +452,189 @@ func (s *ProjectService) SyncProjectsWithInfraManager(ctx context.Context) error
 	return nil
 }
 
+// GetProjectSyncDiff compares local projects with mc-infra-manager namespaces.
+// Returns namespaces missing in local DB and local projects not assigned to any workspace.
+// Read-only: no DB changes.
+func (s *ProjectService) GetProjectSyncDiff(ctx context.Context) (*model.ProjectSyncDiffResponse, error) {
+	callReq := &model.McmpApiCallRequest{
+		ServiceName:   "mc-infra-manager",
+		ActionName:    "GetAllNs",
+		RequestParams: model.McmpApiRequestParams{},
+	}
+	statusCode, respBody, _, _, err := s.mcmpApiService.McmpApiCall(ctx, callReq)
+	if err != nil {
+		return nil, fmt.Errorf("mc-infra-manager GetAllNs failed: %w", err)
+	}
+	if statusCode < 200 || statusCode >= 300 {
+		return nil, fmt.Errorf("mc-infra-manager GetAllNs returned status %d", statusCode)
+	}
+
+	var infraResp struct {
+		Ns []struct {
+			ID          string `json:"id"`
+			Name        string `json:"name"`
+			Description string `json:"description"`
+		} `json:"ns"`
+	}
+	if err := json.Unmarshal(respBody, &infraResp); err != nil {
+		return nil, fmt.Errorf("failed to parse GetAllNs response: %w", err)
+	}
+
+	localProjects, err := s.projectRepo.FindProjects(&model.ProjectFilterRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list local projects: %w", err)
+	}
+	localByNsId := make(map[string]*model.Project, len(localProjects))
+	for _, p := range localProjects {
+		if p.NsId != "" {
+			localByNsId[p.NsId] = p
+		}
+	}
+
+	assignedMap, err := s.projectRepo.FindAllProjectWorkspaceAssignments()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get workspace assignments: %w", err)
+	}
+
+	result := &model.ProjectSyncDiffResponse{
+		MissingProjects:    []model.ProjectSyncDiffMissingItem{},
+		UnassignedProjects: []model.ProjectSyncDiffUnassignedItem{},
+	}
+
+	for _, ns := range infraResp.Ns {
+		if _, exists := localByNsId[ns.ID]; !exists {
+			result.MissingProjects = append(result.MissingProjects, model.ProjectSyncDiffMissingItem{
+				NsId:        ns.ID,
+				Name:        ns.Name,
+				Description: ns.Description,
+			})
+		}
+	}
+
+	for _, p := range localProjects {
+		if _, assigned := assignedMap[p.ID]; !assigned {
+			result.UnassignedProjects = append(result.UnassignedProjects, model.ProjectSyncDiffUnassignedItem{
+				ID:          p.ID,
+				NsId:        p.NsId,
+				Name:        p.Name,
+				Description: p.Description,
+			})
+		}
+	}
+
+	return result, nil
+}
+
+// ApplyProjectSyncToWorkspace creates missing projects and assigns unassigned ones to the specified workspace.
+// Each nsId is processed independently; partial failures are collected in the response.
+func (s *ProjectService) ApplyProjectSyncToWorkspace(ctx context.Context, workspaceID uint, nsIds []string) (*model.ProjectSyncApplyResponse, error) {
+	ws, err := s.workspaceRepo.FindWorkspaceByID(workspaceID)
+	if err != nil || ws == nil {
+		return nil, fmt.Errorf("workspace not found")
+	}
+
+	callReq := &model.McmpApiCallRequest{
+		ServiceName:   "mc-infra-manager",
+		ActionName:    "GetAllNs",
+		RequestParams: model.McmpApiRequestParams{},
+	}
+	statusCode, respBody, _, _, err := s.mcmpApiService.McmpApiCall(ctx, callReq)
+	if err != nil {
+		return nil, fmt.Errorf("mc-infra-manager GetAllNs failed: %w", err)
+	}
+	if statusCode < 200 || statusCode >= 300 {
+		return nil, fmt.Errorf("mc-infra-manager GetAllNs returned status %d", statusCode)
+	}
+
+	var infraResp struct {
+		Ns []struct {
+			ID          string `json:"id"`
+			Name        string `json:"name"`
+			Description string `json:"description"`
+		} `json:"ns"`
+	}
+	if err := json.Unmarshal(respBody, &infraResp); err != nil {
+		return nil, fmt.Errorf("failed to parse GetAllNs response: %w", err)
+	}
+	infraByNsId := make(map[string]struct {
+		Name        string
+		Description string
+	}, len(infraResp.Ns))
+	for _, ns := range infraResp.Ns {
+		infraByNsId[ns.ID] = struct {
+			Name        string
+			Description string
+		}{ns.Name, ns.Description}
+	}
+
+	localProjects, err := s.projectRepo.FindProjects(&model.ProjectFilterRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list local projects: %w", err)
+	}
+	localByNsId := make(map[string]*model.Project, len(localProjects))
+	for _, p := range localProjects {
+		if p.NsId != "" {
+			localByNsId[p.NsId] = p
+		}
+	}
+
+	assignedMap, err := s.projectRepo.FindAllProjectWorkspaceAssignments()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get workspace assignments: %w", err)
+	}
+
+	resp := &model.ProjectSyncApplyResponse{
+		Created:  []model.ProjectSyncApplyCreatedItem{},
+		Assigned: []model.ProjectSyncApplyAssignedItem{},
+		Skipped:  []model.ProjectSyncApplySkippedItem{},
+		Failed:   []model.ProjectSyncApplyFailedItem{},
+	}
+
+	for _, nsId := range nsIds {
+		infraNs, inInfra := infraByNsId[nsId]
+		if !inInfra {
+			resp.Skipped = append(resp.Skipped, model.ProjectSyncApplySkippedItem{NsId: nsId, Reason: "not found in infra"})
+			continue
+		}
+
+		localProject, exists := localByNsId[nsId]
+		if !exists {
+			// Create project locally (without calling mc-infra-manager PostNs — namespace already exists)
+			newProject := &model.Project{
+				NsId:        nsId,
+				Name:        infraNs.Name,
+				Description: infraNs.Description,
+			}
+			if err := s.projectRepo.CreateProject(newProject); err != nil {
+				log.Printf("ApplyProjectSync: failed to create project for nsId %s: %v", nsId, err)
+				resp.Failed = append(resp.Failed, model.ProjectSyncApplyFailedItem{NsId: nsId, Error: err.Error()})
+				continue
+			}
+			if err := s.projectRepo.AddProjectWorkspaceAssociation(newProject.ID, workspaceID); err != nil {
+				log.Printf("ApplyProjectSync: failed to assign new project %d to workspace %d: %v", newProject.ID, workspaceID, err)
+				resp.Failed = append(resp.Failed, model.ProjectSyncApplyFailedItem{NsId: nsId, Error: err.Error()})
+				continue
+			}
+			resp.Created = append(resp.Created, model.ProjectSyncApplyCreatedItem{ID: newProject.ID, NsId: nsId, Name: newProject.Name})
+			continue
+		}
+
+		if _, assigned := assignedMap[localProject.ID]; assigned {
+			resp.Skipped = append(resp.Skipped, model.ProjectSyncApplySkippedItem{NsId: nsId, Reason: "already assigned"})
+			continue
+		}
+
+		if err := s.projectRepo.AddProjectWorkspaceAssociation(localProject.ID, workspaceID); err != nil {
+			log.Printf("ApplyProjectSync: failed to assign project %d to workspace %d: %v", localProject.ID, workspaceID, err)
+			resp.Failed = append(resp.Failed, model.ProjectSyncApplyFailedItem{NsId: nsId, Error: err.Error()})
+			continue
+		}
+		resp.Assigned = append(resp.Assigned, model.ProjectSyncApplyAssignedItem{ID: localProject.ID, NsId: nsId, Name: localProject.Name})
+	}
+
+	return resp, nil
+}
+
 // CreateProject 새로운 프로젝트를 생성하고 기본 워크스페이스에 할당합니다.
 func (s *ProjectService) CreateProject(project *model.Project) error {
 	// 프로젝트 생성


### PR DESCRIPTION
## Summary

- `GET /api/setup/projects/sync-diff`: mc-infra-manager namespace와 로컬 project를 비교해 **불일치 목록**을 반환 (read-only)
  - `missingProjects`: infra에는 있으나 로컬 project가 없는 namespace
  - `unassignedProjects`: 로컬 project는 있으나 어느 workspace에도 미할당
- `POST /api/setup/projects/sync`: 선택한 nsId 목록을 **지정 workspace에 선택적 적용**
  - 각 nsId 독립 처리(best-effort), `created / assigned / skipped / failed` 분류 반환
- 기존 `POST /api/setup/sync-projects` (일괄 자동 sync) 변경 없음 — 회귀 없음

## Test plan

- [x] T1: `GET /sync-diff` — e2e namespace 27건 missingProjects 반환 확인
- [x] T2: `POST /sync` nsId 1개 + workspaceId=2 → `created` 1건
- [x] T3: 재조회 → missingProjects 27→26건 감소
- [x] T4: 이미 할당된 nsId 재시도 → `skipped: already assigned`
- [x] T5: 존재하지 않는 nsId → `skipped: not found in infra`
- [x] T6: 존재하지 않는 workspaceId → `400 workspace not found`
- [x] T7: nsIds 빈 배열 → `400`
- [x] T8: workspaceId 누락 → `400`
- [x] T9: 기존 `POST /setup/sync-projects` 회귀 → `200 OK` 정상