### PR TITLE
feat(mcmp-api): add POST /api/mcmp-apis for single FrameworkService creation

### DIFF
--- a/src/handler/mcmpapi_handler.go
+++ b/src/handler/mcmpapi_handler.go
@@ -347,6 +347,47 @@ func (h *McmpApiHandler) TestCallGetAllNs(c echo.Context) error {
 	return nil
 }
 
+// CreateFrameworkService godoc
+// @Summary Create MCMP API Service Definition
+// @Description Creates a new MCMP API service (framework) record. Returns 409 if a service with the same name already exists.
+// @Tags McmpAPI
+// @Accept json
+// @Produce json
+// @Param body body model.CreateMcmpApiServiceRequest true "Service definition"
+// @Success 201 {object} mcmpapi.McmpApiService
+// @Failure 400 {object} map[string]string "error: invalid request body or validation failure"
+// @Failure 409 {object} map[string]string "error: framework service already exists"
+// @Failure 500 {object} map[string]string "error: internal server error"
+// @Router /api/mcmp-apis [post]
+// @Id CreateFrameworkService
+// @Security BearerAuth
+func (h *McmpApiHandler) CreateFrameworkService(c echo.Context) error {
+	var req model.CreateMcmpApiServiceRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid body: " + err.Error()})
+	}
+	if err := c.Validate(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+	}
+
+	svc := &mcmpapi.McmpApiService{
+		Name:     req.Name,
+		Version:  req.Version,
+		BaseURL:  req.BaseURL,
+		AuthType: req.AuthType,
+		AuthUser: req.AuthUser,
+		AuthPass: req.AuthPass,
+		IsActive: req.IsActive,
+	}
+	if err := h.service.CreateFrameworkService(svc); err != nil {
+		if errors.Is(err, service.ErrFrameworkServiceAlreadyExists) {
+			return c.JSON(http.StatusConflict, map[string]string{"error": err.Error()})
+		}
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	return c.JSON(http.StatusCreated, svc)
+}
+
 // UpdateService godoc
 // @Summary Update MCMP API Service Definition
 // @Description Updates specific fields (e.g., BaseURL, Auth info) of an MCMP API service definition identified by its name. Cannot update name or version.

--- a/src/main.go
+++ b/src/main.go
@@ -443,6 +443,7 @@ func main() {
 		mcmpApis.PUT("/name/:serviceName/versions/:version/activate", mcmpApiHandler.SetActiveVersion, middleware.PlatformRoleMiddleware(middleware.Manage))
 		mcmpApis.POST("/call", mcmpApiHandler.McmpApiCall, middleware.PlatformRoleMiddleware(middleware.Manage))
 		mcmpApis.GET("/test/mc-infra-manager/getallns", mcmpApiHandler.TestCallGetAllNs, middleware.PlatformRoleMiddleware(middleware.Manage))
+		mcmpApis.POST("", mcmpApiHandler.CreateFrameworkService, middleware.PlatformRoleMiddleware(middleware.Manage))
 		mcmpApis.PUT("/name/:serviceName", mcmpApiHandler.UpdateFrameworkService, middleware.PlatformRoleMiddleware(middleware.Manage))
 		mcmpApis.POST("/import", mcmpApiHandler.ImportAPIs, middleware.PlatformRoleMiddleware(middleware.Manage))
 	}

--- a/src/model/request.go
+++ b/src/model/request.go
@@ -266,6 +266,17 @@ type ImportApiResponse struct {
 	FrameworkResults []ImportApiFrameworkResult `json:"frameworkResults"` // Detailed results for each framework
 }
 
+// CreateMcmpApiServiceRequest represents the request body for POST /api/mcmp-apis
+type CreateMcmpApiServiceRequest struct {
+	Name     string `json:"name"     validate:"required,max=100"`
+	Version  string `json:"version"  validate:"required,max=50"`
+	BaseURL  string `json:"baseUrl"  validate:"required,url"`
+	AuthType string `json:"authType,omitempty" validate:"omitempty,oneof=none basic bearer"`
+	AuthUser string `json:"authUser,omitempty"`
+	AuthPass string `json:"authPass,omitempty"`
+	IsActive bool   `json:"isActive,omitempty"`
+}
+
 // SignupRequest represents the signup form data
 type SignupRequest struct {
 	Email        string `json:"email" validate:"required,email"`

--- a/src/service/mcmpapi_service.go
+++ b/src/service/mcmpapi_service.go
@@ -27,6 +27,8 @@ import (
 // Local path to service-actions.yaml file (relative to working directory)
 const localServiceActionsPath = "asset/mcmpapi/service-actions.yaml"
 
+var ErrFrameworkServiceAlreadyExists = errors.New("framework service already exists")
+
 // McmpApiService defines the interface for mcmp API operations
 type McmpApiService interface {
 	GetDB() *gorm.DB
@@ -36,6 +38,7 @@ type McmpApiService interface {
 	SetActiveVersion(serviceName, version string) error
 	GetAllAPIDefinitions(serviceNameFilter, actionNameFilter string) (*mcmpapi.McmpApiDefinitions, error)
 	UpdateService(serviceName string, updates map[string]interface{}) error
+	CreateFrameworkService(svc *mcmpapi.McmpApiService) error
 	McmpApiCall(ctx context.Context, req *model.McmpApiCallRequest) (int, []byte, string, string, error)
 	SyncMcmpAPIsFromYAML() error
 	ImportAPIs(req *model.ImportApiRequest) (*model.ImportApiResponse, error)
@@ -304,6 +307,29 @@ func (s *mcmpApiService) UpdateService(serviceName string, updates map[string]in
 	// }
 
 	return s.repo.UpdateService(serviceName, updates)
+}
+
+// CreateFrameworkService creates a single McmpApiService record within its own transaction.
+func (s *mcmpApiService) CreateFrameworkService(svc *mcmpapi.McmpApiService) error {
+	if err := s.ensureTables(); err != nil {
+		return err
+	}
+	tx := s.db.Begin()
+	defer func() {
+		if r := recover(); r != nil {
+			tx.Rollback()
+		}
+	}()
+
+	if err := s.repo.CreateService(tx, svc); err != nil {
+		tx.Rollback()
+		if errors.Is(err, gorm.ErrDuplicatedKey) ||
+			strings.Contains(strings.ToLower(err.Error()), "duplicate") {
+			return ErrFrameworkServiceAlreadyExists
+		}
+		return err
+	}
+	return tx.Commit().Error
 }
 
 // McmpApiCall executes a call to an external MCMP API based on stored definitions and provided parameters. (Renamed)


### PR DESCRIPTION
## Summary

- `POST /api/mcmp-apis` 엔드포인트 신규 추가 (단일 `McmpApiService` 생성)
- 기존에는 신규 FrameworkService 추가 시 배열 기반 `POST /import`만 가능했으나, 단일 리소스 생성 전용 엔드포인트를 추가
- 기존 내부 함수 `repo.CreateService(tx, *McmpApiService)` 재사용, Repository 변경 없음
- 동일 `name` 중복 등록 시 409 Conflict 반환

## Changed Files

| File | 내용 |
|---|---|
| `src/model/request.go` | `CreateMcmpApiServiceRequest` DTO 추가 |
| `src/service/mcmpapi_service.go` | `ErrFrameworkServiceAlreadyExists` sentinel + 인터페이스 + `CreateFrameworkService` 구현 |
| `src/handler/mcmpapi_handler.go` | `CreateFrameworkService` 핸들러 추가 (Swagger `@Id` 포함) |
| `src/main.go` | `mcmpApis.POST("", ...)` 라우트 등록 (Manage 권한) |

## API Spec

```
POST /api/mcmp-apis
Authorization: Bearer <token>
Content-Type: application/json

{
  "name": "mc-cost-optimizer-fe",
  "version": "v1",
  "baseUrl": "http://52.79.163.111:7780",
  "authType": "none",
  "isActive": true
}
```

| Status | 조건 |
|---|---|
| 201 Created | 정상 생성 |
| 400 Bad Request | 필수 필드 누락 또는 유효성 실패 |
| 409 Conflict | 동일 name 이미 존재 |
| 403 Forbidden | Manage 권한 없는 토큰 |

## Test plan

- [x] `POST /api/mcmp-apis` 정상 요청 → 201 + 생성된 객체 반환 확인
- [x] 동일 name 재전송 → 409 Conflict 확인
- [ ] `name` 필드 누락 요청 → 400 Bad Request 확인
- [ ] Manage 권한 없는 토큰 → 403 확인