### PR TITLE
fix: sync mc-admin-cli changes to setup scripts and nginx configs

### DIFF
--- a/asset/setup/1_setup_auto.sh
+++ b/asset/setup/1_setup_auto.sh
@@ -57,7 +57,16 @@ auto_setup() {
         return 1
     fi
     echo "✓ API resources initialized successfully"
-    
+
+    # 5-1. 프레임워크 서비스 URL 등록 (sync-projects 전 서비스 레지스트리 선행 등록)
+    echo "Step 5-1: Registering framework service URLs..."
+    register_framework_services
+    if [ $? -ne 0 ]; then
+        echo "ERROR: Framework service registration failed"
+        return 1
+    fi
+    echo "✓ Framework services registered successfully"
+
     # 6. 프로젝트 동기화
     echo "Step 6: Syncing projects..."
     sync_projects
@@ -259,6 +268,61 @@ init_api_resources() {
     fi
     
     echo "API resources initialized"
+    return 0
+}
+
+register_framework_services() {
+    echo "Registering framework service URLs to mcmp_api_services..."
+
+    register_service() {
+        local name="$1"
+        local version="$2"
+        local base_url="$3"
+        local auth_type="${4:-none}"
+        local auth_user="${5:-}"
+        local auth_pass="${6:-}"
+
+        json_data=$(jq -n \
+            --arg name "$name" \
+            --arg version "$version" \
+            --arg baseUrl "$base_url" \
+            --arg authType "$auth_type" \
+            --arg authUser "$auth_user" \
+            --arg authPass "$auth_pass" \
+            --argjson isActive true \
+            '{name: $name, version: $version, baseUrl: $baseUrl, authType: $authType, authUser: $authUser, authPass: $authPass, isActive: $isActive}')
+
+        response=$(curl -s -w "HTTPSTATUS:%{http_code}" -X POST \
+            --header "Authorization: Bearer $MC_IAM_MANAGER_PLATFORMADMIN_ACCESSTOKEN" \
+            --header 'Content-Type: application/json' \
+            --data "$json_data" \
+            "$MC_IAM_MANAGER_HOST/api/mcmp-apis")
+
+        http_code=$(echo $response | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
+        response_body=$(echo $response | sed -e 's/HTTPSTATUS\:.*//g')
+
+        if [ "$http_code" = "201" ]; then
+            echo "  ✓ Registered: $name ($base_url)"
+        elif [ "$http_code" = "409" ]; then
+            echo "  ✓ Already registered: $name (skipped)"
+        else
+            echo "  ✗ Failed to register $name (HTTP $http_code): $response_body"
+            return 1
+        fi
+        return 0
+    }
+
+    INFRA_MANAGER_VERSION=$(grep -A1 "^  mc-infra-manager:" ./api.yaml 2>/dev/null | grep "version:" | awk '{print $2}' | tr -d '"')
+    INFRA_MANAGER_VERSION="${INFRA_MANAGER_VERSION:-0.12.6}"
+
+    register_service "mc-infra-manager" "$INFRA_MANAGER_VERSION" \
+        "http://mc-infra-manager:${MC_INFRA_MANAGER_PORT:-1323}/tumblebug" \
+        "basic" "$MC_INFRA_MANAGER_API_USERNAME" "$MC_INFRA_MANAGER_API_PASSWORD"
+    if [ $? -ne 0 ]; then
+        return 1
+    fi
+
+    echo "Framework service registration completed"
     return 0
 }
 

--- a/asset/setup/presetup/nginx/nginx.template.conf
+++ b/asset/setup/presetup/nginx/nginx.template.conf
@@ -43,7 +43,7 @@ http {
 
         # Health check endpoint (HTTP에서 접근 가능)
         location /health {
-            proxy_pass http://mciam-manager:${MC_IAM_MANAGER_PORT}/readyz;
+            proxy_pass http://mc-iam-manager:${MC_IAM_MANAGER_PORT}/readyz;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -88,7 +88,7 @@ http {
 
         # Health check endpoint (HTTPS에서도 접근 가능)
         location /health {
-            proxy_pass http://mciam-manager:${MC_IAM_MANAGER_PORT}/readyz;
+            proxy_pass http://mc-iam-manager:${MC_IAM_MANAGER_PORT}/readyz;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -103,7 +103,7 @@ http {
         }
 
         location / {
-            proxy_pass http://mciam-manager:${MC_IAM_MANAGER_PORT};
+            proxy_pass http://mc-iam-manager:${MC_IAM_MANAGER_PORT};
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -118,7 +118,7 @@ http {
         }
 
         location /auth/ {
-            proxy_pass http://mciam-keycloak:${MC_IAM_MANAGER_KEYCLOAK_PORT}/auth/;
+            proxy_pass http://mc-iam-manager-kc:${MC_IAM_MANAGER_KEYCLOAK_PORT}/auth/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/conf/mc-iam-manager/1_setup_auto.sh
+++ b/conf/mc-iam-manager/1_setup_auto.sh
@@ -51,7 +51,16 @@ auto_setup() {
         return 1
     fi
     echo "✓ API resources initialized successfully"
-    
+
+    # 5-1. 프레임워크 서비스 URL 등록 (sync-projects 전 서비스 레지스트리 선행 등록)
+    echo "Step 5-1: Registering framework service URLs..."
+    register_framework_services
+    if [ $? -ne 0 ]; then
+        echo "ERROR: Framework service registration failed"
+        return 1
+    fi
+    echo "✓ Framework services registered successfully"
+
     # 6. 프로젝트 동기화
     echo "Step 6: Syncing projects..."
     sync_projects
@@ -306,6 +315,61 @@ init_api_resources() {
     fi
     
     echo "API resources initialized"
+    return 0
+}
+
+register_framework_services() {
+    echo "Registering framework service URLs to mcmp_api_services..."
+
+    register_service() {
+        local name="$1"
+        local version="$2"
+        local base_url="$3"
+        local auth_type="${4:-none}"
+        local auth_user="${5:-}"
+        local auth_pass="${6:-}"
+
+        json_data=$(jq -n \
+            --arg name "$name" \
+            --arg version "$version" \
+            --arg baseUrl "$base_url" \
+            --arg authType "$auth_type" \
+            --arg authUser "$auth_user" \
+            --arg authPass "$auth_pass" \
+            --argjson isActive true \
+            '{name: $name, version: $version, baseUrl: $baseUrl, authType: $authType, authUser: $authUser, authPass: $authPass, isActive: $isActive}')
+
+        response=$(curl -s -w "HTTPSTATUS:%{http_code}" -X POST \
+            --header "Authorization: Bearer $MC_IAM_MANAGER_PLATFORMADMIN_ACCESSTOKEN" \
+            --header 'Content-Type: application/json' \
+            --data "$json_data" \
+            "$MC_IAM_MANAGER_HOST/api/mcmp-apis")
+
+        http_code=$(echo $response | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
+        response_body=$(echo $response | sed -e 's/HTTPSTATUS\:.*//g')
+
+        if [ "$http_code" = "201" ]; then
+            echo "  ✓ Registered: $name ($base_url)"
+        elif [ "$http_code" = "409" ]; then
+            echo "  ✓ Already registered: $name (skipped)"
+        else
+            echo "  ✗ Failed to register $name (HTTP $http_code): $response_body"
+            return 1
+        fi
+        return 0
+    }
+
+    INFRA_MANAGER_VERSION=$(grep -A1 "^  mc-infra-manager:" ./api.yaml 2>/dev/null | grep "version:" | awk '{print $2}' | tr -d '"')
+    INFRA_MANAGER_VERSION="${INFRA_MANAGER_VERSION:-0.12.6}"
+
+    register_service "mc-infra-manager" "$INFRA_MANAGER_VERSION" \
+        "http://mc-infra-manager:${MC_INFRA_MANAGER_PORT:-1323}/tumblebug" \
+        "basic" "$MC_INFRA_MANAGER_API_USERNAME" "$MC_INFRA_MANAGER_API_PASSWORD"
+    if [ $? -ne 0 ]; then
+        return 1
+    fi
+
+    echo "Framework service registration completed"
     return 0
 }
 

--- a/conf/mc-iam-manager/nginx.template.conf
+++ b/conf/mc-iam-manager/nginx.template.conf
@@ -90,7 +90,7 @@ http {
 
         # Health check endpoint (HTTPS에서도 접근 가능)
         location /health {
-            proxy_pass http://mciam-manager:${MC_IAM_MANAGER_PORT}/readyz;
+            proxy_pass http://mc-iam-manager:${MC_IAM_MANAGER_PORT}/readyz;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary

- **ADMIN-BUG-003** `register_framework_services()` 함수 및 Step 5-1 호출 추가 (`conf`, `asset` 양쪽)
  - `sync-mcmp-apis`는 serviceActions(권한)만 등록하고 `mcmp_api_services` 레지스트리는 미처리
  - sync-projects 실행 전 framework service URL을 별도 등록하는 단계가 mc-admin-cli에서 추가되었으나 mc-iam-manager에 미반영된 상태였음
- nginx upstream 컨테이너명 구버전 잔존 수정 (`conf`, `asset` 양쪽)
  - `mciam-manager` → `mc-iam-manager`
  - `mciam-keycloak` → `mc-iam-manager-kc`
  - 수정 전 docker-compose 네트워크에서 DNS resolution 실패 위험

## Changed Files

| 파일 | 변경 내용 |
|------|----------|
| `conf/mc-iam-manager/1_setup_auto.sh` | Step 5-1 호출 + `register_framework_services()` 함수 추가 |
| `asset/setup/1_setup_auto.sh` | 동일 |
| `conf/mc-iam-manager/nginx.template.conf` | `mciam-manager` → `mc-iam-manager` (1건) |
| `asset/setup/presetup/nginx/nginx.template.conf` | `mciam-manager` → `mc-iam-manager` (3건), `mciam-keycloak` → `mc-iam-manager-kc` (1건) |

## Test plan

- [ ] `bash -n conf/mc-iam-manager/1_setup_auto.sh` — syntax OK
- [ ] `bash -n asset/setup/1_setup_auto.sh` — syntax OK
- [ ] `grep "mciam-" conf/mc-iam-manager/nginx.template.conf asset/setup/presetup/nginx/nginx.template.conf` — 결과 없음
- [ ] mc-iam-manager 재기동 후 `1_setup_auto.sh` 실행 시 Step 5-1 출력 및 `GET /api/mcmp-apis` 응답에 `mc-infra-manager` 항목 확인