### PR TITLE
fix(ug): bypass gocloak omitempty bug for enabled=false user filter

### DIFF
--- a/src/handler/user_handler.go
+++ b/src/handler/user_handler.go
@@ -95,6 +95,12 @@ func (h *UserHandler) ListUsers(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
 	}
 
+	if req.Enabled != nil {
+		fmt.Printf("[INFO] ListUsers: request={enabled: %v}\n", *req.Enabled)
+	} else {
+		fmt.Printf("[INFO] ListUsers: request={enabled: nil (전체 조회)}\n")
+	}
+
 	users, err := h.userService.ListUsers(c.Request().Context(), req.Enabled)
 	if err != nil {
 		fmt.Printf("[ERROR] ListUsers: Error from userService.ListUsers: %v\n", err)

--- a/src/service/keycloak_service.go
+++ b/src/service/keycloak_service.go
@@ -161,24 +161,39 @@ func (s *keycloakService) GetUserByUsername(ctx context.Context, username string
 }
 
 // GetUsers retrieves users from Keycloak, optionally filtered by enabled status.
+// gocloak.GetUsersParams.Enabled uses json:"omitempty" which drops false values,
+// so we pass enabled as a manual query param to avoid the omitempty bug.
 func (s *keycloakService) GetUsers(ctx context.Context, enabled *bool) ([]*gocloak.User, error) {
-	// Directly use config.KC
 	if config.KC == nil || config.KC.Client == nil {
 		return nil, fmt.Errorf("keycloak configuration not initialized")
 	}
-	token, err := config.KC.LoginAdmin(ctx) // Use admin token
+	token, err := config.KC.LoginAdmin(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get admin token: %w", err)
 	}
-	getUsersParams := gocloak.GetUsersParams{}
-	if enabled != nil {
-		getUsersParams.Enabled = enabled
+
+	if enabled == nil {
+		kcUsers, err := config.KC.Client.GetUsers(ctx, token.AccessToken, config.KC.Realm, gocloak.GetUsersParams{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get users from keycloak: %w", err)
+		}
+		return kcUsers, nil
 	}
-	kcUsers, err := config.KC.Client.GetUsers(ctx, token.AccessToken, config.KC.Realm, getUsersParams)
+
+	// enabled 값이 false일 때 omitempty로 쿼리 파라미터가 누락되는 gocloak 버그 우회:
+	// Keycloak Admin REST API를 직접 호출하여 ?enabled=false 명시 전송
+	var result []*gocloak.User
+	url := fmt.Sprintf("%s/admin/realms/%s/users?enabled=%v", config.KC.Host, config.KC.Realm, *enabled)
+	resp, err := config.KC.Client.GetRequestWithBearerAuth(ctx, token.AccessToken).
+		SetResult(&result).
+		Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get users from keycloak: %w", err)
 	}
-	return kcUsers, nil
+	if resp.IsError() {
+		return nil, fmt.Errorf("keycloak returned error %d for GetUsers", resp.StatusCode())
+	}
+	return result, nil
 }
 
 // CreateUser creates a user in Keycloak.


### PR DESCRIPTION
## Summary

PR#79(UG 사용자 그룹 관리) 머지 이후 추가된 2개 커밋

- **fix**: gocloak v13 `GetUsersParams.Enabled` 필드의 `omitempty` 태그로 인해 `enabled=false` 쿼리 파라미터가 누락되는 버그 우회
  - `gocloak.GetUsersParams{Enabled: &false}` 사용 시 Keycloak에 `?enabled=false`가 전송되지 않음
  - Keycloak Admin REST API 직접 호출(`?enabled=false` 명시)로 우회 처리
- **feat**: `ListUsers` 핸들러에 request 파라미터 디버그 로그 추가 (필요 없으면 제거 가능)

## Test plan

- [ ] `GET /api/users?enabled=false` 요청 시 비활성 사용자만 반환되는지 확인
- [ ] `GET /api/users?enabled=true` 요청 시 활성 사용자만 반환되는지 확인
- [ ] `GET /api/users` (enabled 파라미터 없음) 시 전체 사용자 반환되는지 확인
- [ ] (선택) `fmt.Printf` 디버그 로그 제거 필요 여부 검토