### PR TITLE
sync src/docs swagger and regenerate service-actions.yaml

### DIFF
--- a/asset/mcmpapi/service-actions.yaml
+++ b/asset/mcmpapi/service-actions.yaml
@@ -3,7 +3,7 @@ serviceActions:
         _meta:
             version: 0.5.0
             repository: https://github.com/m-cmp/mc-application-manager
-            generatedAt: "2026-05-12T07:17:42Z"
+            generatedAt: "2026-06-01T02:11:43Z"
         checkConnectionUsingPOST:
             method: post
             resourcePath: /oss/connection-check
@@ -272,7 +272,7 @@ serviceActions:
         _meta:
             version: 0.5.0
             repository: https://github.com/m-cmp/mc-cost-optimizer
-            generatedAt: "2026-05-12T07:17:42Z"
+            generatedAt: "2026-06-01T02:11:43Z"
         getAbrnormalRcmd:
             method: post
             resourcePath: /api/costopti/be/opti/abnormalRcmd
@@ -331,9 +331,13 @@ serviceActions:
             description: ""
     mc-iam-manager:
         _meta:
-            version: 0.3.0
+            version: 0.5.2
             repository: https://github.com/m-cmp/mc-iam-manager
-            generatedAt: "2026-05-12T07:17:42Z"
+            generatedAt: "2026-06-01T02:11:43Z"
+        CreateFrameworkService:
+            method: post
+            resourcePath: /api/mcmp-apis
+            description: Creates a new MCMP API service (framework) record. Returns 409 if a service with the same name already exists.
         ResetUserPassword:
             method: put
             resourcePath: /api/users/id/{userId}/password
@@ -1242,7 +1246,7 @@ serviceActions:
         _meta:
             version: main
             repository: https://github.com/cloud-barista/cb-spider
-            generatedAt: "2026-05-12T07:17:42Z"
+            generatedAt: "2026-06-01T02:11:43Z"
         add-favorite-imagespec:
             method: post
             resourcePath: /vm/imagespecfavorite
@@ -1327,6 +1331,10 @@ serviceActions:
             method: get
             resourcePath: /countnlb
             description: Get the total number of Network Load Balancers (NLBs) across all connections.
+        count-all-rdbms:
+            method: get
+            resourcePath: /countrdbms
+            description: Get the total number of RDBMS instances across all connections.
         count-all-securitygroup:
             method: get
             resourcePath: /countsecuritygroup
@@ -1367,6 +1375,10 @@ serviceActions:
             method: get
             resourcePath: /countnlb/{ConnectionName}
             description: Get the total number of Network Load Balancers (NLBs) for a specific connection.
+        count-rdbms-by-connection:
+            method: get
+            resourcePath: /countrdbms/{ConnectionName}
+            description: Get the total number of RDBMS instances for a specific connection.
         count-s3-by-connection:
             method: get
             resourcePath: /counts3/{ConnectionName}
@@ -1415,6 +1427,10 @@ serviceActions:
             method: post
             resourcePath: /nlb
             description: "Create a new Network Load Balancer (NLB) with specified configurations. \U0001F577️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Network-Load-Balancer-and-Driver-API)]"
+        create-rdbms:
+            method: post
+            resourcePath: /rdbms
+            description: Create a new Relational Database (RDBMS) with the specified configuration.
         create-s3-bucket:
             method: put
             resourcePath: /s3/{BucketName}
@@ -1477,6 +1493,10 @@ serviceActions:
             method: delete
             resourcePath: /cspnlb/{Id}
             description: Delete a specified CSP Network Load Balancer (NLB).
+        delete-csp-rdbms:
+            method: delete
+            resourcePath: /csprdbms/{Id}
+            description: Delete a specified CSP RDBMS.
         delete-csp-securitygroup:
             method: delete
             resourcePath: /cspsecuritygroup/{Id}
@@ -1505,6 +1525,10 @@ serviceActions:
             method: delete
             resourcePath: /nlb/{Name}
             description: Delete a specified Network Load Balancer (NLB).
+        delete-rdbms:
+            method: delete
+            resourcePath: /rdbms/{Name}
+            description: Delete a specified RDBMS instance.
         delete-recent-imagespec:
             method: delete
             resourcePath: /vm/imagespecrecent
@@ -1646,6 +1670,18 @@ serviceActions:
             method: get
             resourcePath: /quotainfo
             description: "Retrieve all quota limits and current usage for a given service type. No filtering is applied; all CSP-original quota items for the service type are returned. \U0001F577️ Supported CSPs: AWS, Azure, GCP, Alibaba."
+        get-rdbms:
+            method: get
+            resourcePath: /rdbms/{Name}
+            description: Retrieve details of a specific RDBMS instance.
+        get-rdbms-metainfo:
+            method: get
+            resourcePath: /rdbmsmetainfo
+            description: Retrieve CSP-specific RDBMS capability information (supported engines, features, storage options).
+        get-rdbms-owner-vpc:
+            method: get
+            resourcePath: /getrdbmsowner
+            description: Retrieve the Owner VPC of a given RDBMS CSP ID.
         get-region:
             method: get
             resourcePath: /region/{RegionName}
@@ -1847,6 +1883,14 @@ serviceActions:
             method: get
             resourcePath: /allnlbinfo
             description: Retrieve a comprehensive list of all Network Load Balancers (NLBs) associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
+        list-all-rdbms:
+            method: get
+            resourcePath: /allrdbms
+            description: Retrieve a comprehensive list of all RDBMS instances associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
+        list-all-rdbms-info:
+            method: get
+            resourcePath: /allrdbmsinfo
+            description: Retrieve a list of all RDBMS information associated with all connections.
         list-all-securitygroup:
             method: get
             resourcePath: /allsecuritygroup
@@ -1939,6 +1983,10 @@ serviceActions:
             method: get
             resourcePath: /quotaservicetype
             description: "Retrieve the list of service type names for which quota information is available. Use a returned service type as input to the GetQuotaInfo API. \U0001F577️ Supported CSPs: AWS, Azure, GCP, Alibaba."
+        list-rdbms:
+            method: get
+            resourcePath: /rdbms
+            description: Retrieve a list of RDBMS instances associated with a specific connection.
         list-recent-imagespec:
             method: get
             resourcePath: /vm/imagespecrecent
@@ -2079,6 +2127,10 @@ serviceActions:
             method: post
             resourcePath: /regnlb
             description: Register a new Network Load Balancer (NLB) with the specified name and CSP ID.
+        register-rdbms:
+            method: post
+            resourcePath: /regrdbms
+            description: Register a new RDBMS with the specified name and CSP ID.
         register-region:
             method: post
             resourcePath: /region
@@ -2169,6 +2221,10 @@ serviceActions:
             method: delete
             resourcePath: /regnlb/{Name}
             description: Unregister a Network Load Balancer (NLB) with the specified name.
+        unregister-rdbms:
+            method: delete
+            resourcePath: /regrdbms/{Name}
+            description: Unregister an RDBMS with the specified name.
         unregister-region:
             method: delete
             resourcePath: /region/{RegionName}
@@ -2205,7 +2261,7 @@ serviceActions:
         _meta:
             version: main
             repository: https://github.com/cloud-barista/cb-tumblebug
-            generatedAt: "2026-05-12T07:17:42Z"
+            generatedAt: "2026-06-01T02:11:43Z"
         AddNLBNodes:
             method: post
             resourcePath: /ns/{nsId}/infra/{infraId}/nlb/{nlbId}/node
@@ -4760,7 +4816,7 @@ serviceActions:
         _meta:
             version: 0.5.0
             repository: https://github.com/m-cmp/mc-workflow-manager
-            generatedAt: "2026-05-12T07:17:42Z"
+            generatedAt: "2026-06-01T02:11:43Z"
         checkConnectionUsingGET:
             method: get
             resourcePath: /readyz

--- a/conf/mc-iam-manager/service-actions.yaml
+++ b/conf/mc-iam-manager/service-actions.yaml
@@ -3,7 +3,7 @@ serviceActions:
         _meta:
             version: 0.5.0
             repository: https://github.com/m-cmp/mc-application-manager
-            generatedAt: "2026-03-03T01:56:15Z"
+            generatedAt: "2026-06-01T02:11:43Z"
         checkConnectionUsingPOST:
             method: post
             resourcePath: /oss/connection-check
@@ -272,7 +272,7 @@ serviceActions:
         _meta:
             version: 0.5.0
             repository: https://github.com/m-cmp/mc-cost-optimizer
-            generatedAt: "2026-03-03T01:56:15Z"
+            generatedAt: "2026-06-01T02:11:43Z"
         getAbrnormalRcmd:
             method: post
             resourcePath: /api/costopti/be/opti/abnormalRcmd
@@ -331,9 +331,13 @@ serviceActions:
             description: ""
     mc-iam-manager:
         _meta:
-            version: 0.3.0
+            version: 0.5.2
             repository: https://github.com/m-cmp/mc-iam-manager
-            generatedAt: "2026-03-11T06:09:51Z"
+            generatedAt: "2026-06-01T02:11:43Z"
+        CreateFrameworkService:
+            method: post
+            resourcePath: /api/mcmp-apis
+            description: Creates a new MCMP API service (framework) record. Returns 409 if a service with the same name already exists.
         ResetUserPassword:
             method: put
             resourcePath: /api/users/id/{userId}/password
@@ -346,6 +350,14 @@ serviceActions:
             method: put
             resourcePath: /api/mcmp-apis/name/{serviceName}
             description: Updates specific fields (e.g., BaseURL, Auth info) of an MCMP API service definition identified by its name. Cannot update name or version.
+        acceptInvitation:
+            method: put
+            resourcePath: /api/users/me/invitations/{invitationId}/accept
+            description: Accept a workspace invitation and join as member
+        activateCompany:
+            method: post
+            resourcePath: /api/company/activate
+            description: 플랫폼 회사를 활성화합니다. (platformAdmin 전용, 멱등 처리)
         activateCspAccount:
             method: post
             resourcePath: /api/csp-accounts/id/{accountId}/activate
@@ -354,6 +366,10 @@ serviceActions:
             method: post
             resourcePath: /api/csp-idp-configs/id/{configId}/activate
             description: Activate a CSP IDP configuration
+        activateUser:
+            method: put
+            resourcePath: /api/users/id/{userId}/activate
+            description: Reactivate a deactivated user account (INACTIVE → ACTIVE).
         addCspRoleMappings:
             method: post
             resourcePath: /api/roles/csp-roles
@@ -370,10 +386,22 @@ serviceActions:
             method: post
             resourcePath: /api/projects/assign/workspaces
             description: 프로젝트에 워크스페이스를 연결합니다.
+        applyProjectSync:
+            method: post
+            resourcePath: /api/setup/projects/sync
+            description: 지정된 nsId 목록의 project를 생성하거나 지정된 workspace에 할당합니다.
+        approveInvitation:
+            method: put
+            resourcePath: /api/invitations/{invitationId}/approve
+            description: Admin approves a workspace invitation and registers the invitee as member
         assignGroupPlatformRole:
             method: post
             resourcePath: /api/groups/id/{groupId}/platform-roles
             description: 그룹에 플랫폼 역할을 할당합니다. DB + Keycloak 이중 관리.
+        assignGroupUsers:
+            method: post
+            resourcePath: /api/groups/id/{groupId}/users
+            description: 그룹에 사용자 목록을 일괄 할당합니다. DB + Keycloak 그룹 동기화.
         assignGroupWorkspace:
             method: post
             resourcePath: /api/groups/id/{groupId}/workspaces
@@ -406,6 +434,10 @@ serviceActions:
             method: post
             resourcePath: /api/csp-policies/attach
             description: Attach a CSP policy to a CSP role
+        bulkHealthCheckCspIdpConfigs:
+            method: post
+            resourcePath: /api/csp-idp-configs/health-check
+            description: Check connection status of all active CSP IDP configurations concurrently
         changeMyPassword:
             method: put
             resourcePath: /api/users/me/password
@@ -414,10 +446,18 @@ serviceActions:
             method: get
             resourcePath: /api/setup/check-user-roles
             description: Check all roles assigned to a user. 특정 유저가 가진 role 목록을 조회합니다.
+        createCompany:
+            method: post
+            resourcePath: /api/company
+            description: 플랫폼 회사 정보를 생성합니다. (싱글톤, platformAdmin 전용)
         createCspAccount:
             method: post
             resourcePath: /api/csp-accounts
             description: Create a new CSP account
+        createCspIAMRole:
+            method: post
+            resourcePath: /api/csp/iam/roles
+            description: CSP에 IAM 역할을 직접 생성합니다
         createCspIdpConfig:
             method: post
             resourcePath: /api/csp-idp-configs
@@ -445,7 +485,7 @@ serviceActions:
         createMenu:
             method: post
             resourcePath: /api/menus
-            description: Create a new menu
+            description: Create a new menu. If roleIds is provided, the menu is mapped to those platform roles in a single transaction. platform_admin role is always automatically mapped.
         createMenusRolesMapping:
             method: post
             resourcePath: /api/menus/platform-roles
@@ -482,6 +522,10 @@ serviceActions:
             method: post
             resourcePath: /api/roles/workspace-roles
             description: Create a new workspace role
+        deactivateCompany:
+            method: delete
+            resourcePath: /api/company
+            description: 플랫폼 회사를 비활성화합니다. (platformAdmin 전용, 멱등 처리)
         deactivateCspAccount:
             method: post
             resourcePath: /api/csp-accounts/id/{accountId}/deactivate
@@ -490,10 +534,18 @@ serviceActions:
             method: post
             resourcePath: /api/csp-idp-configs/id/{configId}/deactivate
             description: Deactivate a CSP IDP configuration
+        deactivateUser:
+            method: put
+            resourcePath: /api/users/id/{userId}/deactivate
+            description: Deactivate a user account (ACTIVE → INACTIVE). Keycloak login is disabled.
         deleteCspAccount:
             method: delete
             resourcePath: /api/csp-accounts/id/{accountId}
             description: Delete a CSP account by ID
+        deleteCspIAMRole:
+            method: delete
+            resourcePath: /api/csp/iam/roles/{roleName}
+            description: CSP에서 IAM 역할을 삭제합니다
         deleteCspIdpConfig:
             method: delete
             resourcePath: /api/csp-idp-configs/id/{configId}
@@ -525,7 +577,7 @@ serviceActions:
         deleteOrganization:
             method: delete
             resourcePath: /api/organizations/id/{organizationId}
-            description: 조직을 삭제합니다. 하위 조직 또는 소속 사용자가 있으면 삭제 불가.
+            description: 조직을 삭제합니다. cascade=true이면 하위 조직 및 사용자 매핑도 모두 삭제됩니다. 기본(cascade=false)이고 하위 조직이 있으면 400을 반환합니다.
         deletePlatformRole:
             method: delete
             resourcePath: /api/roles/platform-roles/id/{roleId}
@@ -544,7 +596,7 @@ serviceActions:
             description: Delete a role by its name.
         deleteUser:
             method: delete
-            resourcePath: /api/users/{id}
+            resourcePath: /api/users/id/{userId}
             description: Delete a user by their ID.
         deleteWorkspace:
             method: delete
@@ -558,18 +610,38 @@ serviceActions:
             method: post
             resourcePath: /api/csp-policies/detach
             description: Detach a CSP policy from a CSP role
+        getAvailableGroupPlatformRoles:
+            method: get
+            resourcePath: /api/groups/id/{groupId}/platform-roles/available
+            description: 그룹에 아직 할당되지 않은 플랫폼 역할 목록을 조회합니다.
+        getAvailableGroupWorkspaces:
+            method: get
+            resourcePath: /api/groups/id/{groupId}/workspaces/available
+            description: 그룹에 아직 매핑되지 않은 워크스페이스 목록을 조회합니다.
         getCloudResourceTypeByID:
             method: get
             resourcePath: /api/resource-types/cloud-resources/framework/:frameworkId/id/:resourceTypeId
             description: 특정 리소스 타입을 ID로 조회합니다
+        getCompany:
+            method: get
+            resourcePath: /api/company
+            description: 플랫폼 회사 정보를 조회합니다. (싱글톤)
         getCspAccountByID:
             method: get
             resourcePath: /api/csp-accounts/id/{accountId}
             description: Retrieve CSP account details by ID
+        getCspIAMRole:
+            method: get
+            resourcePath: /api/csp/iam/roles/{roleName}
+            description: CSP에서 특정 IAM 역할 정보를 조회합니다
         getCspIdpConfigByID:
             method: get
             resourcePath: /api/csp-idp-configs/id/{configId}
             description: Retrieve CSP IDP configuration details by ID
+        getCspIdpSummary:
+            method: get
+            resourcePath: /api/csp-idp-configs/summary
+            description: Get IDP configuration count summary grouped by CSP account
         getCspPolicyByID:
             method: get
             resourcePath: /api/csp-policies/id/{policyId}
@@ -602,6 +674,18 @@ serviceActions:
             method: post
             resourcePath: /api/menus/id/{menuId}
             description: Get menu details by ID
+        getMyInfo:
+            method: get
+            resourcePath: /api/users/me
+            description: Get the authenticated user's own profile information. No PlatformRole required.
+        getMyPlatformRoles:
+            method: get
+            resourcePath: /api/users/me/platform-roles
+            description: 현재 로그인한 사용자에게 실제로 적용되는 플랫폼 역할 목록을 조회합니다. 직접 할당된 역할과 그룹 상속 역할을 통합하여 반환합니다.
+        getMyWorkspaceRoles:
+            method: get
+            resourcePath: /api/users/me/workspace-roles
+            description: 현재 로그인한 사용자에게 실제로 적용되는 워크스페이스별 역할 목록을 조회합니다. 직접 할당된 역할과 그룹 상속 역할을 통합하여 반환합니다.
         getOrganizationByCode:
             method: get
             resourcePath: /api/organizations/code/{code}
@@ -610,6 +694,18 @@ serviceActions:
             method: get
             resourcePath: /api/organizations/id/{organizationId}
             description: 조직 ID로 조직 정보를 조회합니다.
+        getOrganizationDeletable:
+            method: get
+            resourcePath: /api/organizations/id/{organizationId}/deletable
+            description: 특정 조직의 삭제 가능 여부와 사유를 반환합니다.
+        getOrganizationSubtree:
+            method: get
+            resourcePath: /api/organizations/id/{organizationId}/subtree
+            description: 지정 조직을 루트로 하는 하위 트리를 반환합니다.
+        getOrganizationTree:
+            method: get
+            resourcePath: /api/organizations/tree
+            description: 전체 조직을 계층 트리 구조로 반환합니다. 최대 10단계 깊이를 지원하며 각 노드에 children 배열을 포함합니다.
         getOrganizationUsers:
             method: get
             resourcePath: /api/organizations/id/{organizationId}/users
@@ -638,6 +734,10 @@ serviceActions:
             method: get
             resourcePath: /api/projects/name/{projectName}
             description: Get project details by name
+        getProjectSyncDiff:
+            method: get
+            resourcePath: /api/setup/projects/sync-diff
+            description: mc-infra-manager의 namespace 목록과 로컬 프로젝트를 비교하여 불일치 목록을 반환합니다. DB 변경 없음.
         getProjectWorkspaces:
             method: get
             resourcePath: /api/projects/id/{projectId}/workspaces
@@ -662,6 +762,10 @@ serviceActions:
             method: get
             resourcePath: /api/csp-policies/role/{roleId}
             description: Get list of policies attached to a CSP role
+        getUserAccessSummary:
+            method: get
+            resourcePath: /api/users/id/{userId}/access-summary
+            description: 사용자의 직접 할당 플랫폼 역할, 소속 그룹 목록, 그룹 기반 역할을 통합 조회합니다.
         getUserByID:
             method: get
             resourcePath: /api/users/id/{userId}
@@ -674,6 +778,10 @@ serviceActions:
             method: get
             resourcePath: /api/users/name/{username}
             description: Get user details by username
+        getUserEffectivePlatformRoles:
+            method: get
+            resourcePath: /api/users/id/{userId}/effective-platform-roles
+            description: 사용자에게 직접 할당된 역할과 소속 그룹을 통해 상속된 역할을 중복 제거하여 반환합니다.
         getUserMenuTree:
             method: get
             resourcePath: /api/menus/user-menu-tree
@@ -681,7 +789,7 @@ serviceActions:
         getUserOrganizations:
             method: get
             resourcePath: /api/users/{userId}/organizations
-            description: 사용자가 소속된 조직 목록을 조회합니다.
+            description: 사용자가 소속된 조직 목록을 조회합니다. hierarchy=true이면 path/level 포함.
         getUserWorkspaceAndWorkspaceRolesByUserID:
             method: get
             resourcePath: /api/users/id/{userId}/workspaces/roles/list
@@ -726,6 +834,10 @@ serviceActions:
             method: get
             resourcePath: /api/setup/initial-role-menu-permission
             description: CSV 파일을 읽어서 메뉴 권한을 초기화합니다
+        listAllInvitations:
+            method: get
+            resourcePath: /api/invitations
+            description: List all workspace invitations, optionally filtered by status
         listAllWorkspaceUsersAndRoles:
             method: post
             resourcePath: /api/workspaces/users-roles/list
@@ -733,7 +845,7 @@ serviceActions:
         listCSPRoles:
             method: post
             resourcePath: /api/roles/csp/list
-            description: Get a list of all csp roles
+            description: Get a list of all csp roles stored in the database
         listCloudResourceTypes:
             method: post
             resourcePath: /api/resource-types/cloud-resources/list
@@ -768,12 +880,16 @@ serviceActions:
             description: List all menus as a tree structure. Admin permission required.
         listMenusTree:
             method: post
-            resourcePath: /api/menus/tree/list
+            resourcePath: /api/menus/menus-tree/list
             description: List all menus as a tree structure. Admin permission required.
+        listMyInvitations:
+            method: get
+            resourcePath: /api/users/me/invitations
+            description: List pending workspace invitations for the current user
         listOrganizations:
             method: get
             resourcePath: /api/organizations
-            description: 전체 조직 목록을 조회합니다. tree=true이면 Tree 구조로 반환.
+            description: 전체 조직 목록을 조회합니다. tree=true이면 Tree 구조로 반환. name/code로 검색 가능 (검색 시 tree 파라미터 무시).
         listPermissionsByActionID:
             method: get
             resourcePath: /api/mcmp-api-permission-action-mappings/actions/{actionId}/permissions
@@ -829,7 +945,7 @@ serviceActions:
         listUsers:
             method: post
             resourcePath: /api/users/list
-            description: Retrieve a list of all users.
+            description: Retrieve a list of users. Optionally filter by Keycloak enabled status (true=active, false=pending approval).
         listUsersAndRolesByWorkspace:
             method: post
             resourcePath: /api/workspaces/id/{workspaceId}/users/list
@@ -850,6 +966,10 @@ serviceActions:
             method: post
             resourcePath: /api/mcmp-api-permission-action-mappings/actions/list
             description: Returns all workspace actions mapped to a specific permission
+        listWorkspaceInvitations:
+            method: get
+            resourcePath: /api/workspaces/id/{wsId}/invitations
+            description: List invitations for a specific workspace
         listWorkspaceProjects:
             method: post
             resourcePath: /api/workspaces/projects/list
@@ -914,6 +1034,10 @@ serviceActions:
             method: put
             resourcePath: /api/csp-credentials/{id}
             description: CSP 인증 정보를 업데이트합니다
+        mciamValidateCredentials:
+            method: post
+            resourcePath: /api/workspaces/credentials/validate
+            description: 워크스페이스 사용자의 CSP×AuthMethod 조합 인증 설정을 단계별로 검증하고 임시자격증명 발급까지 확인한다. 실패 여부와 무관하게 모든 단계를 응답에 포함한다.
         mciamValidateToken:
             method: post
             resourcePath: /api/auth/validate
@@ -926,6 +1050,14 @@ serviceActions:
             method: post
             resourcePath: /api/mcmp-apis/mcmpApiCall
             description: Executes a defined MCMP API action with parameters structured in McmpApiCallRequest.
+        moveOrganization:
+            method: put
+            resourcePath: /api/organizations/id/{organizationId}/move
+            description: 조직을 트리 내 다른 위치(다른 부모 조직)로 이동합니다. 하위 조직도 함께 이동하며 조직 코드가 자동 재생성됩니다.
+        processWithdrawal:
+            method: put
+            resourcePath: /api/users/id/{userId}/withdraw
+            description: 'Admin processes a withdrawal request: removes all role/org mappings and disables in Keycloak.'
         registerMenusFromBody:
             method: post
             resourcePath: /api/menus/setup/initial-menus2
@@ -934,6 +1066,14 @@ serviceActions:
             method: post
             resourcePath: /api/menus/setup/initial-menus
             description: Register or update menus from a local YAML file specified by the filePath query parameter, or from the MC_WEB_CONSOLE_MENUYAML URL in .env if not provided. If loaded from URL, the file is saved to asset/menu/menu.yaml.
+        rejectInvitation:
+            method: put
+            resourcePath: /api/users/me/invitations/{invitationId}/reject
+            description: Reject a workspace invitation
+        rejectInvitationByAdmin:
+            method: put
+            resourcePath: /api/invitations/{invitationId}/reject
+            description: Admin rejects a workspace invitation
         removeCspRoleMappings:
             method: delete
             resourcePath: /api/roles/unassign/csp-roles
@@ -942,6 +1082,10 @@ serviceActions:
             method: delete
             resourcePath: /api/groups/id/{groupId}/platform-roles/{roleId}
             description: 그룹에 할당된 플랫폼 역할을 해제합니다. DB + Keycloak 동시 제거.
+        removeGroupUser:
+            method: delete
+            resourcePath: /api/groups/id/{groupId}/users/{userId}
+            description: 그룹에서 특정 사용자를 제거합니다. DB + Keycloak 그룹 동기화.
         removeGroupWorkspaceRole:
             method: delete
             resourcePath: /api/groups/id/{groupId}/workspaces/{workspaceId}
@@ -982,6 +1126,18 @@ serviceActions:
             method: delete
             resourcePath: /api/roles/unassign/workspace-role
             description: Remove a workspace role from a user
+        replaceUserGroups:
+            method: put
+            resourcePath: /api/users/id/{userId}/groups
+            description: 사용자의 기존 그룹을 모두 제거하고 지정된 그룹으로 교체합니다.
+        requestWithdrawal:
+            method: post
+            resourcePath: /api/users/me/withdrawal
+            description: Current user requests account withdrawal (ACTIVE → WITHDRAWAL_REQUESTED).
+        sendWorkspaceInvitation:
+            method: post
+            resourcePath: /api/workspaces/id/{wsId}/invitations
+            description: Send an invitation to a platform user to join the workspace
         setActiveVersion:
             method: put
             resourcePath: /api/mcmp-apis/name/{serviceName}/versions/{version}/activate
@@ -1006,14 +1162,6 @@ serviceActions:
             method: post
             resourcePath: /api/setup/sync-projects
             description: mc-infra-manager의 네임스페이스 목록을 조회하여 로컬 DB에 없는 프로젝트를 추가합니다.
-        getProjectSyncDiff:
-            method: get
-            resourcePath: /api/setup/projects/sync-diff
-            description: mc-infra-manager의 namespace 목록과 로컬 프로젝트를 비교하여 불일치 목록을 반환합니다. DB 변경 없음.
-        applyProjectSync:
-            method: post
-            resourcePath: /api/setup/projects/sync
-            description: 지정된 nsId 목록의 project를 생성하거나 지정된 workspace에 할당합니다.
         testCallGetAllNs:
             method: get
             resourcePath: /api/mcmp-apis/test/mc-infra-manager/getallns
@@ -1022,10 +1170,18 @@ serviceActions:
             method: post
             resourcePath: /api/csp-idp-configs/id/{configId}/test
             description: Test connection to CSP using IDP configuration
+        updateCompany:
+            method: put
+            resourcePath: /api/company
+            description: 플랫폼 회사 이름/설명을 수정합니다. (platformAdmin 전용)
         updateCspAccount:
             method: put
             resourcePath: /api/csp-accounts/id/{accountId}
             description: Update CSP account details
+        updateCspIAMRole:
+            method: put
+            resourcePath: /api/csp/iam/roles/{roleName}
+            description: CSP의 IAM 역할 정보를 수정합니다
         updateCspIdpConfig:
             method: put
             resourcePath: /api/csp-idp-configs/id/{configId}
@@ -1072,7 +1228,7 @@ serviceActions:
             description: Update the details of an existing role.
         updateUser:
             method: put
-            resourcePath: /api/users/{id}
+            resourcePath: /api/users/id/{userId}
             description: Update the details of an existing user.
         updateUserStatus:
             method: post
@@ -1085,12 +1241,3582 @@ serviceActions:
         validateCspAccount:
             method: post
             resourcePath: /api/csp-accounts/id/{accountId}/validate
-            description: Validate CSP account configuration
+            description: Validate CSP account by checking actual CSP infrastructure (IDP provider existence, role trust policy, or credential validity) for each linked CspRole
+    mc-infra-connector:
+        _meta:
+            version: main
+            repository: https://github.com/cloud-barista/cb-spider
+            generatedAt: "2026-06-01T02:11:43Z"
+        add-favorite-imagespec:
+            method: post
+            resourcePath: /vm/imagespecfavorite
+            description: Add an Image and Spec combination to favorites
+        add-nlb-vm:
+            method: post
+            resourcePath: /nlb/{Name}/vms
+            description: Add a new set of VMs to an existing Network Load Balancer (NLB).
+        add-nodegroup:
+            method: post
+            resourcePath: /cluster/{Name}/nodegroup
+            description: Add a new Node Group to an existing Cluster.
+        add-rule:
+            method: post
+            resourcePath: /securitygroup/{SGName}/rules
+            description: Add new rules to a Security Group.
+        add-subnet:
+            method: post
+            resourcePath: /vpc/{VPCName}/subnet
+            description: Add a new Subnet to an existing VPC.
+        add-tag:
+            method: post
+            resourcePath: /tag
+            description: |-
+                Add a tag to a specified resource.
+                ※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER
+        any-call:
+            method: post
+            resourcePath: /anycall
+            description: "Execute a custom function (FID) with key-value parameters through AnyCall. \U0001F577️ [[Development Guide](https://github.com/cloud-barista/cb-spider/wiki/AnyCall-API-Extension-Guide)]"
+        attach-disk:
+            method: put
+            resourcePath: /disk/{Name}/attach
+            description: Attach an existing Disk to a VM.
+        bulk-import-favorite-imagespec:
+            method: post
+            resourcePath: /vm/imagespecfavorite/bulk
+            description: Import multiple VM favorite records from JSON, skipping duplicates
+        bulk-import-recent-imagespec:
+            method: post
+            resourcePath: /vm/imagespecrecent/bulk
+            description: Import multiple VM recent records from JSON, skipping duplicates
+        change-nodegroup-scaling:
+            method: put
+            resourcePath: /cluster/{Name}/nodegroup/{NodeGroupName}/autoscalesize
+            description: Change the scaling settings for a Node Group in a Cluster.
+        check-tcp-port:
+            method: get
+            resourcePath: /check/tcp
+            description: Verifies whether a given TCP port is open on the specified host.
+        check-udp-port:
+            method: get
+            resourcePath: /check/udp
+            description: |-
+                Verifies whether a given UDP port is open on the specified host.
+                ※ Note: As UDP is connectionless, this check mainly performs a lookup and may not confirm if the server is working.
+        control-vm:
+            method: put
+            resourcePath: /controlvm/{Name}
+            description: Control the state of a Virtual Machine (VM) such as suspend, resume, or reboot.
+        count-all-cluster:
+            method: get
+            resourcePath: /countcluster
+            description: Get the total number of Clusters across all connections.
+        count-all-connection:
+            method: get
+            resourcePath: /countconnectionconfig
+            description: Get the total number of connections.
+        count-all-disk:
+            method: get
+            resourcePath: /countdisk
+            description: Get the total number of Disks across all connections.
+        count-all-keypair:
+            method: get
+            resourcePath: /countkeypair
+            description: Get the total number of KeyPairs across all connections.
+        count-all-myimage:
+            method: get
+            resourcePath: /countmyimage
+            description: Get the total number of MyImages across all connections.
+        count-all-nlb:
+            method: get
+            resourcePath: /countnlb
+            description: Get the total number of Network Load Balancers (NLBs) across all connections.
+        count-all-rdbms:
+            method: get
+            resourcePath: /countrdbms
+            description: Get the total number of RDBMS instances across all connections.
+        count-all-securitygroup:
+            method: get
+            resourcePath: /countsecuritygroup
+            description: Get the total number of Security Groups across all connections.
+        count-all-subnet:
+            method: get
+            resourcePath: /countsubnet
+            description: Get the total number of Subnets across all connections.
+        count-all-vm:
+            method: get
+            resourcePath: /countvm
+            description: Get the total number of Virtual Machines (VMs) across all connections.
+        count-all-vpc:
+            method: get
+            resourcePath: /countvpc
+            description: Get the total number of VPCs across all connections.
+        count-cluster-by-connection:
+            method: get
+            resourcePath: /countcluster/{ConnectionName}
+            description: Get the total number of Clusters for a specific connection.
+        count-connection-by-provider:
+            method: get
+            resourcePath: /countconnectionconfig/{ProviderName}
+            description: Get the total number of connections for a specific provider.
+        count-disk-by-connection:
+            method: get
+            resourcePath: /countdisk/{ConnectionName}
+            description: Get the total number of Disks for a specific connection.
+        count-keypair-by-connection:
+            method: get
+            resourcePath: /countkeypair/{ConnectionName}
+            description: Get the total number of KeyPairs for a specific connection.
+        count-myimage-by-connection:
+            method: get
+            resourcePath: /countmyimage/{ConnectionName}
+            description: Get the total number of MyImages for a specific connection.
+        count-nlb-by-connection:
+            method: get
+            resourcePath: /countnlb/{ConnectionName}
+            description: Get the total number of Network Load Balancers (NLBs) for a specific connection.
+        count-rdbms-by-connection:
+            method: get
+            resourcePath: /countrdbms/{ConnectionName}
+            description: Get the total number of RDBMS instances for a specific connection.
+        count-s3-by-connection:
+            method: get
+            resourcePath: /counts3/{ConnectionName}
+            description: Get the total number of S3 buckets for a specific connection.
+        count-securitygroup-by-connection:
+            method: get
+            resourcePath: /countsecuritygroup/{ConnectionName}
+            description: Get the total number of Security Groups for a specific connection.
+        count-subnet-by-connection:
+            method: get
+            resourcePath: /countsubnet/{ConnectionName}
+            description: Get the total number of Subnets for a specific connection.
+        count-vm-by-connection:
+            method: get
+            resourcePath: /countvm/{ConnectionName}
+            description: Get the total number of Virtual Machines (VMs) for a specific connection.
+        count-vpc-by-connection:
+            method: get
+            resourcePath: /countvpc/{ConnectionName}
+            description: Get the total number of VPCs for a specific connection.
+        create-cluster:
+            method: post
+            resourcePath: /cluster
+            description: "Create a new Cluster with specified configurations. \U0001F577️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Provider-Managed-Kubernetes-and-Driver-API)] <br> * NodeGroupList is optional, depends on CSP type: <br> &nbsp;- Type-I (e.g., Tencent, Alibaba): requires separate Node Group addition after Cluster creation. <br> &nbsp;- Type-II (e.g., Azure, NHN): mandates at least one Node Group during initial Cluster creation."
+        create-connection-config:
+            method: post
+            resourcePath: /connectionconfig
+            description: "Create a new Connection Config. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#4-cloud-connection-configuration-%EC%A0%95%EB%B3%B4-%EB%93%B1%EB%A1%9D-%EB%B0%8F-%EA%B4%80%EB%A6%AC)]"
+        create-disk:
+            method: post
+            resourcePath: /disk
+            description: "Create a new Disk with the specified configuration. \U0001F577️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Disk-and-Driver-API)], [[Snapshot-MyImage,Disk Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Snapshot,-MyImage-and-Disk-Overview)]"
+        create-filesystem:
+            method: post
+            resourcePath: /filesystem
+            description: Create a new FileSystem with the specified configuration.
+        create-keypair:
+            method: post
+            resourcePath: /keypair
+            description: "Create a new KeyPair with the specified configurations. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#5-vm-keypair-%EC%83%9D%EC%84%B1-%EB%B0%8F-%EC%A0%9C%EC%96%B4)]"
+        create-myimage:
+            method: post
+            resourcePath: /myimage
+            description: "Create a new MyImage snapshot from a specified VM. \U0001F577️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/MyImage-and-Driver-API)], [[Snapshot-MyImage,Disk Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Snapshot,-MyImage-and-Disk-Overview)]"
+        create-nlb:
+            method: post
+            resourcePath: /nlb
+            description: "Create a new Network Load Balancer (NLB) with specified configurations. \U0001F577️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Network-Load-Balancer-and-Driver-API)]"
+        create-rdbms:
+            method: post
+            resourcePath: /rdbms
+            description: Create a new Relational Database (RDBMS) with the specified configuration.
+        create-s3-bucket:
+            method: put
+            resourcePath: /s3/{BucketName}
+            description: |-
+                Creates a new S3 bucket or sets bucket configuration based on query parameters.
+
+                **Operations:**
+                - No query params: Create a new bucket
+                - ?versioning: Set versioning configuration (Enable/Suspend)
+                - ?cors: Set CORS configuration
+
+                **IMPORTANT: Choose only ONE body configuration based on query parameter:**
+                - If using ?versioning: Use VersioningConfiguration body
+                - If using ?cors: Use CORSConfiguration body
+                - If no query params: No body required (bucket creation)
+
+                **Versioning Status Values:**
+                - Enabled: Enable versioning for the bucket
+                - Suspended: Suspend versioning for the bucket
+
+                **CORS Configuration Example:**
+                - AllowedOrigin: ["*"] or ["https://example.com"]
+                - AllowedMethod: ["GET", "PUT", "POST", "DELETE", "HEAD"]
+                - AllowedHeader: ["*"] or ["Content-Type", "Authorization"]
+                - ExposeHeader: ["ETag", "x-amz-request-id"]
+                - MaxAgeSeconds: 3600 (cache preflight response for 1 hour)
+        create-securitygroup:
+            method: post
+            resourcePath: /securitygroup
+            description: "Create a new Security Group with specified rules and tags. \U0001F577️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Security-Group-Rules-and-Driver-API)], \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#4-securitygroup-%EC%83%9D%EC%84%B1-%EB%B0%8F-%EC%A0%9C%EC%96%B4)]"
+        create-vpc:
+            method: post
+            resourcePath: /vpc
+            description: "Create a new Virtual Private Cloud (VPC) with specified subnet configurations. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#3-vpcsubnet-%EC%83%9D%EC%84%B1-%EB%B0%8F-%EC%A0%9C%EC%96%B4)]"
+        delete-cluster:
+            method: delete
+            resourcePath: /cluster/{Name}
+            description: Delete a specified Cluster.
+        delete-connection-config:
+            method: delete
+            resourcePath: /connectionconfig/{ConfigName}
+            description: Delete a specific Connection Config.
+        delete-csp-cluster:
+            method: delete
+            resourcePath: /cspcluster/{Id}
+            description: Delete a specified CSP Cluster.
+        delete-csp-disk:
+            method: delete
+            resourcePath: /cspdisk/{Id}
+            description: Delete a specified CSP Disk.
+        delete-csp-keypair:
+            method: delete
+            resourcePath: /cspkeypair/{Id}
+            description: Delete a specified CSP KeyPair.
+        delete-csp-myimage:
+            method: delete
+            resourcePath: /cspmyimage/{Id}
+            description: Delete a specified CSP MyImage.
+        delete-csp-nlb:
+            method: delete
+            resourcePath: /cspnlb/{Id}
+            description: Delete a specified CSP Network Load Balancer (NLB).
+        delete-csp-rdbms:
+            method: delete
+            resourcePath: /csprdbms/{Id}
+            description: Delete a specified CSP RDBMS.
+        delete-csp-securitygroup:
+            method: delete
+            resourcePath: /cspsecuritygroup/{Id}
+            description: Delete a specified CSP Security Group.
+        delete-csp-vpc:
+            method: delete
+            resourcePath: /cspvpc/{Id}
+            description: Delete a specified CSP Virtual Private Cloud (VPC).
+        delete-disk:
+            method: delete
+            resourcePath: /disk/{Name}
+            description: Delete a specified Disk.
+        delete-favorite-imagespec:
+            method: delete
+            resourcePath: /vm/imagespecfavorite
+            description: Remove an Image and Spec combination from favorites
+        delete-keypair:
+            method: delete
+            resourcePath: /keypair/{Name}
+            description: Delete a specified KeyPair.
+        delete-myimage:
+            method: delete
+            resourcePath: /myimage/{Name}
+            description: Delete a specified MyImage.
+        delete-nlb:
+            method: delete
+            resourcePath: /nlb/{Name}
+            description: Delete a specified Network Load Balancer (NLB).
+        delete-rdbms:
+            method: delete
+            resourcePath: /rdbms/{Name}
+            description: Delete a specified RDBMS instance.
+        delete-recent-imagespec:
+            method: delete
+            resourcePath: /vm/imagespecrecent
+            description: Remove an Image and Spec combination from recent records
+        delete-s3-bucket:
+            method: delete
+            resourcePath: /s3/{BucketName}
+            description: |-
+                Deletes an S3 bucket or specific bucket configuration based on query parameters.
+
+                **Operations:**
+                - No query params: Delete bucket (must be empty)
+                - ?cors: Delete CORS configuration
+                - ?empty: Force empty bucket (removes all objects)
+                - ?force: Force delete bucket with all contents
+        delete-s3-object:
+            method: delete
+            resourcePath: /s3/{BucketName}/{ObjectKey}
+            description: |-
+                Deletes an object or aborts a multipart upload based on query parameters.
+
+                **Operations:**
+                - No query params: Delete object (current version)
+                - ?versionId={id}: Delete specific version
+                - ?uploadId={id}: Abort multipart upload
+        delete-securitygroup:
+            method: delete
+            resourcePath: /securitygroup/{Name}
+            description: Delete a specified Security Group.
+        delete-vpc:
+            method: delete
+            resourcePath: /vpc/{Name}
+            description: Delete a specified Virtual Private Cloud (VPC).
+        destroy-all-resource:
+            method: delete
+            resourcePath: /destroy
+            description: Deletes all resources associated with a specific cloud connection. This action is irreversible.
+        detach-disk:
+            method: put
+            resourcePath: /disk/{Name}/detach
+            description: Detach an existing Disk from a VM.
+        download-s3-object:
+            method: get
+            resourcePath: /s3/{BucketName}/{ObjectKey}
+            description: |-
+                Downloads an object from S3 or lists parts of a multipart upload. **Response type varies by query parameter:**
+
+                | Query Parameter | Response | Description |
+                |---|---|---|
+                | *(none)* | `application/octet-stream` (binary) | Download object content |
+                | `?versionId={id}` | `application/octet-stream` (binary) | Download specific object version |
+                | `?uploadId={id}&list-type=parts` | `ListPartsResultJSON` | List parts of in-progress multipart upload |
+
+                **Note**: The example value below shows the `?uploadId&list-type=parts` (list parts JSON) response.
+                For binary downloads, the response body is the raw file content.
+
+                **List Parts Example (verify uploaded parts):**
+                - uploadId: Use UploadId from initiate response
+                - list-type: Must be "parts"
+                - Response shows all uploaded parts with PartNumber, ETag, Size
+                - Optional: part-number-marker (pagination), max-parts (limit)
+        fetch-resource-usage:
+            method: get
+            resourcePath: /sysstats/usage
+            description: |-
+                Retrieve resource usage information such as CPU, memory, disk I/O, and network I/O.
+                Use query parameter 'mode=text' to get the output in text format instead of JSON.
+        fetch-system-info:
+            method: get
+            resourcePath: /sysstats/system
+            description: |-
+                Retrieve system information such as hostname, platform, CPU, memory, and disk.
+                Use query parameter 'mode=text' to get the output in text format instead of JSON.
+        get-cloudos-metainfo:
+            method: get
+            resourcePath: /cloudos/metainfo/{CloudOSName}
+            description: Retrieve metadata information for a specific Cloud OS.
+        get-cluster:
+            method: get
+            resourcePath: /cluster/{Name}
+            description: Retrieve details of a specific Cluster.
+        get-cluster-owner-vpc:
+            method: post
+            resourcePath: /getclusterowner
+            description: Retrieve the owner VPC of a specified Cluster.
+        get-cluster-token:
+            method: get
+            resourcePath: /cluster/{Name}/token
+            description: Get a temporary token for accessing EKS cluster (for kubectl exec auth)
+        get-connection-config:
+            method: get
+            resourcePath: /connectionconfig/{ConfigName}
+            description: Retrieve details of a specific Connection Config.
+        get-credential:
+            method: get
+            resourcePath: /credential/{CredentialName}
+            description: Retrieve details of a specific Credential.
+        get-csp-vm:
+            method: get
+            resourcePath: /cspvm/{Id}
+            description: Retrieve details of a specific CSP Virtual Machine (VM).
+        get-disk:
+            method: get
+            resourcePath: /disk/{Name}
+            description: Retrieve details of a specific Disk.
+        get-driver:
+            method: get
+            resourcePath: /driver/{DriverName}
+            description: Retrieve details of a specific Cloud Driver.
+        get-driver-capability:
+            method: get
+            resourcePath: /driver/capability
+            description: Retrieve capability information of the cloud driver.
+        get-image:
+            method: get
+            resourcePath: /vmimage/{Name}
+            description: "Retrieve details of a specific Public Image. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/How-to-get-Image-List-with-REST-API)]"
+        get-keypair:
+            method: get
+            resourcePath: /keypair/{Name}
+            description: Retrieve details of a specific KeyPair.
+        get-myimage:
+            method: get
+            resourcePath: /myimage/{Name}
+            description: Retrieve details of a specific MyImage.
+        get-nlb:
+            method: get
+            resourcePath: /nlb/{Name}
+            description: Retrieve details of a specific Network Load Balancer (NLB).
+        get-nlb-owner-vpc:
+            method: post
+            resourcePath: /getnlbowner
+            description: Retrieve the owner VPC of a specified Network Load Balancer (NLB).
+        get-org-vm-spec:
+            method: get
+            resourcePath: /vmorgspec/{Name}
+            description: Retrieve details of a specific Original VM Spec.
+        get-quota-info:
+            method: get
+            resourcePath: /quotainfo
+            description: "Retrieve all quota limits and current usage for a given service type. No filtering is applied; all CSP-original quota items for the service type are returned. \U0001F577️ Supported CSPs: AWS, Azure, GCP, Alibaba."
+        get-rdbms:
+            method: get
+            resourcePath: /rdbms/{Name}
+            description: Retrieve details of a specific RDBMS instance.
+        get-rdbms-metainfo:
+            method: get
+            resourcePath: /rdbmsmetainfo
+            description: Retrieve CSP-specific RDBMS capability information (supported engines, features, storage options).
+        get-rdbms-owner-vpc:
+            method: get
+            resourcePath: /getrdbmsowner
+            description: Retrieve the Owner VPC of a given RDBMS CSP ID.
+        get-region:
+            method: get
+            resourcePath: /region/{RegionName}
+            description: Retrieve details of a specific Region.
+        get-region-zone:
+            method: get
+            resourcePath: /regionzone/{Name}
+            description: "Retrieve details of a specific Region Zone. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/REST-API-Region-Zone-Information-Guide)]"
+        get-region-zone-preconfig:
+            method: get
+            resourcePath: /preconfig/regionzone/{Name}
+            description: "Retrieve details of a specific pre-configured Region Zone based on driver and credential names. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/REST-API-Region-Zone-Information-Guide)]"
+        get-s3-bucket-get:
+            method: get
+            resourcePath: /s3/{BucketName}
+            description: |-
+                List objects in bucket or get bucket configuration. **Response type varies by query parameter:**
+
+                | Query Parameter | Response Schema | Description |
+                |---|---|---|
+                | *(none)* | `ListBucketResultJSON` | List objects in bucket (default) |
+                | `?location` | `{"LocationConstraint": "ap-northeast-2"}` | Bucket region/location |
+                | `?versioning` | `VersioningConfiguration` | Versioning status: Enabled / Suspended / "" |
+                | `?cors` | `CORSConfiguration` | CORS configuration rules |
+                | `?versions` | `ListVersionsResultJSON` | Object version history |
+                | `?uploads` | `ListMultipartUploadsResultJSON` | In-progress multipart uploads |
+
+                **Note**: The example value below shows the default (no query params) `ListBucketResultJSON` response.
+        get-s3-bucket-head:
+            method: head
+            resourcePath: /s3/{BucketName}
+            description: Check if a bucket exists using HEAD request. Returns 200 if exists, 404 if not found.
+        get-s3-bucket-usage:
+            method: get
+            resourcePath: /s3/{BucketName}/usage
+            description: |-
+                Returns the total size (in bytes) of all objects stored in an S3 bucket.
+
+                **Response Fields:**
+                - CurrentSize: Size of current (latest) objects in bytes
+                - DeletedVersionsSize: Size of non-current versions in bytes
+                - TotalSize: Total bucket size (CurrentSize + DeletedVersionsSize)
+        get-s3-object-info:
+            method: head
+            resourcePath: /s3/{BucketName}/{ObjectKey}
+            description: |-
+                Returns metadata about an object without returning the object itself.
+
+                **Important**: This is a HEAD request that only returns headers (metadata), not the file content.
+                The response includes Content-Type, Content-Length, Last-Modified, ETag, and version information.
+                Do NOT use "Download file" button in Swagger UI - it will create an empty/invalid file.
+                Use GET /s3/{BucketName}/{ObjectKey} to download the actual file.
+        get-s3-presigned-upload-url:
+            method: get
+            resourcePath: /s3/presigned/upload/{BucketName}/{ObjectKey}
+            description: Generates a presigned URL that can be used to upload an object to S3 without requiring AWS credentials. This is a CB-Spider special feature.
+        get-s3-presigned-url:
+            method: get
+            resourcePath: /s3/presigned/download/{BucketName}/{ObjectKey}
+            description: Generates a presigned URL that can be used to download an object from S3 without requiring AWS credentials. This is a CB-Spider special feature.
+        get-securitygroup:
+            method: get
+            resourcePath: /securitygroup/{Name}
+            description: Retrieve details of a specific Security Group.
+        get-sg-owner-vpc:
+            method: post
+            resourcePath: /getsecuritygroupowner
+            description: Retrieve the owner VPC of a specified Security Group.
+        get-subnet:
+            method: get
+            resourcePath: /vpc/{VPCName}/subnet/{SubnetName}
+            description: Retrieve a specific Subnet from a VPC.
+        get-tag:
+            method: get
+            resourcePath: /tag/{Key}
+            description: |-
+                Retrieve a specific tag for a specified resource.
+                ※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER
+        get-vm:
+            method: get
+            resourcePath: /vm/{Name}
+            description: Retrieve details of a specific Virtual Machine (VM).
+        get-vm-spec:
+            method: get
+            resourcePath: /vmspec/{Name}
+            description: "Retrieve details of a specific VM spec. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#2-vm-spec-%EC%A0%95%EB%B3%B4-%EC%A0%9C%EA%B3%B5)]"
+        get-vm-status:
+            method: get
+            resourcePath: /vmstatus/{Name}
+            description: Retrieve the status of a specific Virtual Machine (VM).
+        get-vm-using-rs:
+            method: post
+            resourcePath: /getvmusingresources
+            description: Retrieve details of a VM using resource ID.
+        get-vmgroup-healthinfo:
+            method: get
+            resourcePath: /nlb/{Name}/health
+            description: Retrieve the health information of the VM group in a specified Network Load Balancer (NLB).
+        get-vmprice-info:
+            method: get
+            resourcePath: /priceinfo/vm/{RegionName}
+            description: "Retrieve VM Price Information for a specific connection and region. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Price-Info-Guide)]"
+        get-vpc:
+            method: get
+            resourcePath: /vpc/{Name}
+            description: Retrieve details of a specific Virtual Private Cloud (VPC).
+        handle-s3-object-post:
+            method: post
+            resourcePath: /s3/{BucketName}/{ObjectKey}
+            description: |-
+                Object-level POST operations. **Response type varies by query parameter:**
+
+                | Query Parameter | Response Schema | Description |
+                |---|---|---|
+                | `?uploads` | `InitiateMultipartUploadResultJSON` | Initiate multipart upload (returns UploadId) |
+                | `?uploadId={id}` | `CompleteMultipartUploadResultJSON` | Complete multipart upload |
+
+                **Note**: The example value below shows the `?uploads` (initiate) response.
+
+                **Multipart Upload Testing Guide (Swagger UI):**
+
+                **Step 1: Initiate Multipart Upload**
+                - Use POST /s3/{BucketName}/{ObjectKey}?uploads
+                - Set ConnectionName, BucketName, ObjectKey (e.g., "testfile.bin")
+                - Response will contain UploadId (save this!)
+
+                **Step 2: Upload Parts**
+                - Use PUT /s3/{BucketName}/{ObjectKey}?uploadId={saved_uploadId}&partNumber=1
+                - In request body, upload file part (binary data)
+                - Response header contains ETag (save this!)
+                - Repeat for part 2, 3, etc. with partNumber=2, 3...
+
+                **Step 3: List Parts (Optional)**
+                - Use GET /s3/{BucketName}/{ObjectKey}?uploadId={saved_uploadId}&list-type=parts
+                - Verify all uploaded parts
+
+                **Step 4: Complete Upload**
+                - Use POST /s3/{BucketName}/{ObjectKey}?uploadId={saved_uploadId}
+                - IMPORTANT: Enter uploadId in query parameter field (not in the parameter table below)
+                - Body (required): Provide parts list with PartNumber and ETag for each uploaded part
+                - Note: ETag values must include double quotes, e.g., "abc123" (with surrounding double quotes)
+        health-check-health:
+            method: get
+            resourcePath: /health
+            description: "Checks the health of CB-Spider service and its dependencies via /health endpoint. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]"
+        health-check-healthcheck:
+            method: get
+            resourcePath: /healthcheck
+            description: "Checks the health of CB-Spider service and its dependencies via /healthcheck endpoint. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]"
+        health-check-ping:
+            method: get
+            resourcePath: /ping
+            description: "Checks the health of CB-Spider service and its dependencies via /ping endpoint. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]"
+        health-check-readyz:
+            method: get
+            resourcePath: /readyz
+            description: "Checks the health of CB-Spider service and its dependencies via /readyz endpoint. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]"
+        increase-disk-size:
+            method: put
+            resourcePath: /disk/{Name}/size
+            description: Increase the size of an existing disk.
+        list-all-cluster:
+            method: get
+            resourcePath: /allcluster
+            description: Retrieve a comprehensive list of all Clusters associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
+        list-all-cluster-info:
+            method: get
+            resourcePath: /allclusterinfo
+            description: Retrieve a list of all Cluster information associated with a specific connection.
+        list-all-disk:
+            method: get
+            resourcePath: /alldisk
+            description: Retrieve a comprehensive list of all Disks associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
+        list-all-disk-info:
+            method: get
+            resourcePath: /alldiskinfo
+            description: Retrieve a list of all Disk information associated with all connections.
+        list-all-keypair:
+            method: get
+            resourcePath: /allkeypair
+            description: Retrieve a comprehensive list of all KeyPairs associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
+        list-all-keypair-info:
+            method: get
+            resourcePath: /allkeypairinfo
+            description: Retrieve a list of KeyPair information associated with all connections.
+        list-all-myimage:
+            method: get
+            resourcePath: /allmyimage
+            description: Retrieve a comprehensive list of all MyImages associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
+        list-all-myimage-info:
+            method: get
+            resourcePath: /allmyimageinfo
+            description: Retrieve a comprehensive list of all MyImage information associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
+        list-all-nlb:
+            method: get
+            resourcePath: /allnlb
+            description: Retrieve a comprehensive list of all Network Load Balancers (NLBs) associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
+        list-all-nlb-info:
+            method: get
+            resourcePath: /allnlbinfo
+            description: Retrieve a comprehensive list of all Network Load Balancers (NLBs) associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
+        list-all-rdbms:
+            method: get
+            resourcePath: /allrdbms
+            description: Retrieve a comprehensive list of all RDBMS instances associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
+        list-all-rdbms-info:
+            method: get
+            resourcePath: /allrdbmsinfo
+            description: Retrieve a list of all RDBMS information associated with all connections.
+        list-all-securitygroup:
+            method: get
+            resourcePath: /allsecuritygroup
+            description: Retrieve a comprehensive list of all Security Groups associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
+        list-all-securitygroup-info:
+            method: get
+            resourcePath: /allsecuritygroupinfo
+            description: Retrieve a list of Security Group information associated with all connections.
+        list-all-vm:
+            method: get
+            resourcePath: /allvm
+            description: Retrieve a comprehensive list of all Virtual Machines (VMs) associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
+        list-all-vm-info:
+            method: get
+            resourcePath: /allvminfo
+            description: Retrieve a list of detailed information on all Virtual Machines (VMs) associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
+        list-all-vpc:
+            method: get
+            resourcePath: /allvpc
+            description: Retrieve a comprehensive list of all Virtual Private Clouds (VPCs) associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
+        list-all-vpc-info:
+            method: get
+            resourcePath: /allvpcinfo
+            description: Retrieve a comprehensive list of all Virtual Private Clouds (VPCs) associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
+        list-cloudos:
+            method: get
+            resourcePath: /cloudos
+            description: Retrieve a list of supported Cloud OS.
+        list-cluster:
+            method: get
+            resourcePath: /cluster
+            description: Retrieve a list of Clusters associated with a specific connection.
+        list-connection-config:
+            method: get
+            resourcePath: /connectionconfig
+            description: Retrieve a list of registered Connection Configs.
+        list-credential:
+            method: get
+            resourcePath: /credential
+            description: Retrieve a list of registered Credentials.
+        list-disk:
+            method: get
+            resourcePath: /disk
+            description: Retrieve a list of Disks associated with a specific connection.
+        list-driver:
+            method: get
+            resourcePath: /driver
+            description: Retrieve a list of registered Cloud Drivers.
+        list-favorite-imagespec:
+            method: get
+            resourcePath: /vm/imagespecfavorite
+            description: Get list of favorite Image and Spec combinations
+        list-image:
+            method: get
+            resourcePath: /vmimage
+            description: "Retrieve a list of Public Images associated with a specific connection. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/How-to-get-Image-List-with-REST-API)]"
+        list-keypair:
+            method: get
+            resourcePath: /keypair
+            description: Retrieve a list of KeyPairs associated with a specific connection.
+        list-myimage:
+            method: get
+            resourcePath: /myimage
+            description: Retrieve a list of MyImages associated with a specific connection.
+        list-nlb:
+            method: get
+            resourcePath: /nlb
+            description: Retrieve a list of Network Load Balancers (NLBs) associated with a specific connection.
+        list-org-region:
+            method: get
+            resourcePath: /orgregion
+            description: Retrieve a list of Original Regions associated with a specific connection. <br> The response structure may vary depending on the request ConnectionName.
+        list-org-vm-spec:
+            method: get
+            resourcePath: /vmorgspec
+            description: Retrieve a list of Original VM Specs associated with a specific connection. <br> The response structure may vary depending on the request ConnectionName.
+        list-org-zone:
+            method: get
+            resourcePath: /orgzone
+            description: Retrieve a list of Original Zones associated with a specific connection. <br> The response structure may vary depending on the request ConnectionName.
+        list-preconfigured-original-org-region:
+            method: get
+            resourcePath: /preconfig/orgregion
+            description: Retrieve a list of pre-configured Original Regions based on driver and credential names. <br> The response structure may vary depending on the request DriverName and CredentialName.
+        list-product-family:
+            method: get
+            resourcePath: /productfamily/{RegionName}
+            description: "Retrieve a list of Product Families associated with a specific connection and region. \U0001F577️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Price-Info-and-Cloud-Driver-API)], \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/RestAPI-Multi%E2%80%90Cloud-Price-Information-Guide)]"
+        list-quota-service-type:
+            method: get
+            resourcePath: /quotaservicetype
+            description: "Retrieve the list of service type names for which quota information is available. Use a returned service type as input to the GetQuotaInfo API. \U0001F577️ Supported CSPs: AWS, Azure, GCP, Alibaba."
+        list-rdbms:
+            method: get
+            resourcePath: /rdbms
+            description: Retrieve a list of RDBMS instances associated with a specific connection.
+        list-recent-imagespec:
+            method: get
+            resourcePath: /vm/imagespecrecent
+            description: Get list of recently used Image and Spec combinations for VM creation with statistics
+        list-region:
+            method: get
+            resourcePath: /region
+            description: Retrieve a list of registered Regions.
+        list-region-zone:
+            method: get
+            resourcePath: /regionzone
+            description: "Retrieve a list of Region Zones associated with a specific connection. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/REST-API-Region-Zone-Information-Guide)]"
+        list-region-zone-preconfig:
+            method: get
+            resourcePath: /preconfig/regionzone
+            description: "Retrieve a list of pre-configured Region Zones based on driver and credential names. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/REST-API-Region-Zone-Information-Guide)]"
+        list-s3-buckets:
+            method: get
+            resourcePath: /s3
+            description: Returns a list of all buckets owned by the authenticated sender of the request. To list buckets, you must have the ConnectionName parameter.
+        list-securitygroup:
+            method: get
+            resourcePath: /securitygroup
+            description: Retrieve a list of Security Groups associated with a specific connection.
+        list-tag:
+            method: get
+            resourcePath: /tag
+            description: |-
+                Retrieve a list of tags for a specified resource.
+                ※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER
+        list-vm:
+            method: get
+            resourcePath: /vm
+            description: Retrieve a list of Virtual Machines (VMs) associated with a specific connection.
+        list-vm-spec:
+            method: get
+            resourcePath: /vmspec
+            description: "Retrieve a list of VM specs associated with a specific connection. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#2-vm-spec-%EC%A0%95%EB%B3%B4-%EC%A0%9C%EA%B3%B5)]"
+        list-vm-status:
+            method: get
+            resourcePath: /vmstatus
+            description: Retrieve a list of statuses for Virtual Machines (VMs) associated with a specific connection.
+        list-vpc:
+            method: get
+            resourcePath: /vpc
+            description: Retrieve a list of Virtual Private Clouds (VPCs) associated with a specific connection.
+        list-vpc-securitygroup:
+            method: get
+            resourcePath: /securitygroup/vpc/{VPCName}
+            description: Retrieve a list of Security Groups associated with a specific VPC in a given cloud connection.
+        proxy-mcinsight-vmimage:
+            method: get
+            resourcePath: /mcinsight/vm-image
+            description: Proxy endpoint to retrieve VM Image list from MC-Insight API with filters
+        proxy-mcinsight-vmimage-filters:
+            method: get
+            resourcePath: /mcinsight/vm-image/filters
+            description: Proxy endpoint to retrieve VM Image filters from MC-Insight API
+        proxy-mcinsight-vmprice:
+            method: get
+            resourcePath: /mcinsight/price-info
+            description: Proxy endpoint to retrieve VM Price information from MC-Insight API with filters
+        proxy-mcinsight-vmprice-filters:
+            method: get
+            resourcePath: /mcinsight/price-info/filters
+            description: Proxy endpoint to retrieve VM Price filters from MC-Insight API
+        proxy-mcinsight-vmspec:
+            method: get
+            resourcePath: /mcinsight/vm-spec
+            description: Proxy endpoint to retrieve VM Spec list from MC-Insight API with filters
+        proxy-mcinsight-vmspec-filters:
+            method: get
+            resourcePath: /mcinsight/vm-spec/filters
+            description: Proxy endpoint to retrieve VM Spec filters from MC-Insight API
+        put-s3-object-from-file:
+            method: put
+            resourcePath: /s3/{BucketName}/{ObjectKey}
+            description: |-
+                Uploads a file to S3 bucket or uploads a part for multipart upload based on query parameters.
+
+                **Operations:**
+                - No query params: Upload object (standard upload)
+                - ?uploadId={id}&partNumber={num}: Upload a part for multipart upload
+
+                **Part Upload Example (Step 2 of multipart upload):**
+                - uploadId: Use UploadId from initiate response (Step 1)
+                - partNumber: 1, 2, 3... (consecutive integers, minimum 1)
+                - Body: Binary file data (in Swagger UI, use "Choose File" button)
+                - Response: Check ETag header - save it for completion (Step 4)
+                - Repeat for each part with different partNumber
+        put-s3-object-from-form:
+            method: post
+            resourcePath: /s3/{BucketName}
+            description: |-
+                Uploads a file using HTML form (multipart/form-data) or deletes multiple objects based on query parameters.
+
+                **Operations:**
+                - No query params: Upload object via form (requires 'key' and 'file' fields, Content-Type: multipart/form-data)
+                - ?delete: Delete multiple objects (requires JSON body, Content-Type: application/json)
+
+                **JSON Body Example for Delete Multiple Objects:**
+                ```json
+                {
+                "Delete": {
+                "Objects": [
+                {"Key": "file1.txt"},
+                {"Key": "file2.txt"},
+                {"Key": "folder/file3.txt"}
+                ]
+                }
+                }
+                ```
+        register-cluster:
+            method: post
+            resourcePath: /regcluster
+            description: Register a new Cluster with the specified VPC and CSP ID.
+        register-credential:
+            method: post
+            resourcePath: /credential
+            description: "Register a new Credential. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#2-cloud-credential-%EC%A0%95%EB%B3%B4-%EB%93%B1%EB%A1%9D-%EB%B0%8F-%EA%B4%80%EB%A6%AC)]"
+        register-disk:
+            method: post
+            resourcePath: /regdisk
+            description: Register a new Disk with the specified name, zone, and CSP ID.
+        register-driver:
+            method: post
+            resourcePath: /driver
+            description: "Register a new Cloud Driver. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#1-cloud-driver-%EC%A0%95%EB%B3%B4-%EB%93%B1%EB%A1%9D-%EB%B0%8F-%EA%B4%80%EB%A6%AC)]"
+        register-keypair:
+            method: post
+            resourcePath: /regkeypair
+            description: Register a new KeyPair with the specified name and CSP ID.
+        register-myimage:
+            method: post
+            resourcePath: /regmyimage
+            description: Register a new MyImage with the specified name and CSP ID.
+        register-nlb:
+            method: post
+            resourcePath: /regnlb
+            description: Register a new Network Load Balancer (NLB) with the specified name and CSP ID.
+        register-rdbms:
+            method: post
+            resourcePath: /regrdbms
+            description: Register a new RDBMS with the specified name and CSP ID.
+        register-region:
+            method: post
+            resourcePath: /region
+            description: "Register a new Region. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#3-cloud-regionzone-%EC%A0%95%EB%B3%B4-%EB%93%B1%EB%A1%9D-%EB%B0%8F-%EA%B4%80%EB%A6%AC)]"
+        register-securitygroup:
+            method: post
+            resourcePath: /regsecuritygroup
+            description: Register a new Security Group with the specified name and CSP ID.
+        register-subnet:
+            method: post
+            resourcePath: /regsubnet
+            description: Register a new Subnet within a specified VPC.
+        register-vm:
+            method: post
+            resourcePath: /regvm
+            description: Register a new Virtual Machine (VM) with the specified name and CSP ID.
+        register-vpc:
+            method: post
+            resourcePath: /regvpc
+            description: Register a new Virtual Private Cloud (VPC) with the specified name and CSP ID.
+        remove-csp-subnet:
+            method: delete
+            resourcePath: /vpc/{VPCName}/cspsubnet/{Id}
+            description: Remove an existing CSP Subnet from a VPC.
+        remove-nlb-vm:
+            method: delete
+            resourcePath: /nlb/{Name}/vms
+            description: Remove a set of VMs from an existing Network Load Balancer (NLB).
+        remove-nodegroup:
+            method: delete
+            resourcePath: /cluster/{Name}/nodegroup/{NodeGroupName}
+            description: Remove an existing Node Group from a Cluster.
+        remove-rule:
+            method: delete
+            resourcePath: /securitygroup/{SGName}/rules
+            description: Remove existing rules from a Security Group.
+        remove-subnet:
+            method: delete
+            resourcePath: /vpc/{VPCName}/subnet/{SubnetName}
+            description: Remove an existing Subnet from a VPC.
+        remove-tag:
+            method: delete
+            resourcePath: /tag/{Key}
+            description: |-
+                Remove a specific tag from a specified resource.
+                ※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER
+        set-nodegroup-autoscaling:
+            method: put
+            resourcePath: /cluster/{Name}/nodegroup/{NodeGroupName}/onautoscaling
+            description: Enable or disable auto scaling for a Node Group in a Cluster.
+        start-vm:
+            method: post
+            resourcePath: /vm
+            description: "Start a new Virtual Machine (VM) with specified configurations. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#2-%EB%A9%80%ED%8B%B0%ED%81%B4%EB%9D%BC%EC%9A%B0%EB%93%9C-vm-%EC%9D%B8%ED%94%84%EB%9D%BC-%EC%9E%90%EC%9B%90-%EC%A0%9C%EC%96%B4multi-cloud-vm-infra-resource-control)], [[Snapshot-MyImage,Disk Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Snapshot,-MyImage-and-Disk-Overview)]"
+        terminate-csp-vm:
+            method: delete
+            resourcePath: /cspvm/{Id}
+            description: Terminate a specified CSP Virtual Machine (VM).
+        terminate-vm:
+            method: delete
+            resourcePath: /vm/{Name}
+            description: Terminate a specified Virtual Machine (VM).
+        unregister-cluster:
+            method: delete
+            resourcePath: /regcluster/{Name}
+            description: Unregister a Cluster with the specified name.
+        unregister-credential:
+            method: delete
+            resourcePath: /credential/{CredentialName}
+            description: Unregister a specific Credential.
+        unregister-disk:
+            method: delete
+            resourcePath: /regdisk/{Name}
+            description: Unregister a Disk with the specified name.
+        unregister-driver:
+            method: delete
+            resourcePath: /driver/{DriverName}
+            description: Unregister a specific Cloud Driver.
+        unregister-keypair:
+            method: delete
+            resourcePath: /regkeypair/{Name}
+            description: Unregister a KeyPair with the specified name.
+        unregister-myimage:
+            method: delete
+            resourcePath: /regmyimage/{Name}
+            description: Unregister a MyImage with the specified name.
+        unregister-nlb:
+            method: delete
+            resourcePath: /regnlb/{Name}
+            description: Unregister a Network Load Balancer (NLB) with the specified name.
+        unregister-rdbms:
+            method: delete
+            resourcePath: /regrdbms/{Name}
+            description: Unregister an RDBMS with the specified name.
+        unregister-region:
+            method: delete
+            resourcePath: /region/{RegionName}
+            description: Unregister a specific Region.
+        unregister-securitygroup:
+            method: delete
+            resourcePath: /regsecuritygroup/{Name}
+            description: Unregister a Security Group with the specified name.
+        unregister-subnet:
+            method: delete
+            resourcePath: /regsubnet/{Name}
+            description: Unregister a Subnet from a specified VPC.
+        unregister-vm:
+            method: delete
+            resourcePath: /regvm/{Name}
+            description: Unregister a Virtual Machine (VM) with the specified name.
+        unregister-vpc:
+            method: delete
+            resourcePath: /regvpc/{Name}
+            description: Unregister a VPC with the specified name.
+        upgrade-cluster:
+            method: put
+            resourcePath: /cluster/{Name}/upgrade
+            description: Upgrade a Cluster to a specified version.
+        upload-driver:
+            method: post
+            resourcePath: /driver/upload
+            description: Upload a Cloud Driver library file.
+        version-info:
+            method: get
+            resourcePath: /version
+            description: Retrieves the version information of CB-Spider.
+    mc-infra-manager:
+        _meta:
+            version: main
+            repository: https://github.com/cloud-barista/cb-tumblebug
+            generatedAt: "2026-06-01T02:11:43Z"
+        AddNLBNodes:
+            method: post
+            resourcePath: /ns/{nsId}/infra/{infraId}/nlb/{nlbId}/node
+            description: Add nodes to NLB
+        AnalyzeProvisioningRisk:
+            method: get
+            resourcePath: /provisioning/risk/{specId}
+            description: |-
+                Evaluate the likelihood of provisioning failure based on historical data for a specific node specification and image combination.
+                This endpoint provides intelligent risk assessment to help prevent deployment failures:
+
+                **Risk Analysis Factors:**
+                - Historical failure rate for the node specification
+                - Image-specific compatibility with the spec
+                - Recent failure patterns and trends
+                - Cross-reference of spec+image combination success rates
+
+                **Risk Levels:**
+                - `high`: Very likely to fail (>80% failure rate or image-specific failures)
+                - `medium`: Moderate risk (50-80% failure rate or mixed results)
+                - `low`: Low risk (<50% failure rate or no previous failures)
+                - `unknown`: Insufficient data for analysis
+
+                **Recommended Actions by Risk Level:**
+                - **High Risk**: Consider alternative specs or images, verify CSP quotas and permissions
+                - **Medium Risk**: Proceed with caution, have backup plans ready
+                - **Low Risk**: Safe to proceed with normal deployment
+
+                **Integration Points:**
+                - Automatically called during Infra review process
+                - Can be used in CI/CD pipelines for deployment validation
+                - Helpful for capacity planning and resource selection
+        AnalyzeProvisioningRiskDetailed:
+            method: get
+            resourcePath: /tumblebug/provisioning/risk/detailed
+            description: |-
+                Provides comprehensive risk analysis with separate assessments for node specification and image risks, plus actionable recommendations.
+                This endpoint offers enhanced risk analysis by separating spec-level and image-level risk factors:
+
+                **Risk Analysis Breakdown:**
+                - **Spec Risk**: Analyzes whether the node specification itself has compatibility or resource issues
+                - **Image Risk**: Evaluates the track record of the specific image with this spec
+                - **Overall Risk**: Combines both factors to determine the primary risk source
+                - **Recommendations**: Provides actionable guidance based on risk analysis
+
+                **Spec Risk Factors:**
+                - Number of different images that failed with this spec (indicates spec-level issues)
+                - Overall failure rate across all images
+                - Success/failure ratio with various images
+
+                **Image Risk Factors:**
+                - Previous success/failure history of this specific image with this spec
+                - Whether this is a new, untested combination
+
+                **Recommendation Types:**
+                - Change node specification (when spec is the primary risk factor)
+                - Try different image (when image is the primary risk factor)
+                - Monitor deployment closely (for new combinations or medium risk)
+                - Proceed with confidence (for low-risk combinations)
+        BulkDeleteGlobalDnsRecord:
+            method: delete
+            resourcePath: /resources/globalDns/records
+            description: |-
+                Delete multiple DNS records from Route53 in a single request.
+                Records are grouped by domain and submitted as a single ChangeBatch per domain for efficiency.
+        CancelExecutionTask:
+            method: post
+            resourcePath: /ns/{nsId}/cmd/infra/{infraId}/task/{taskId}/cancel
+            description: Cancel a running execution task by task ID. This will send a cancellation signal to the task and update the node command status.
+        CheckHTTPVersion:
+            method: get
+            resourcePath: /httpVersion
+            description: Checks and logs the HTTP version of the incoming request to the server console.
+        CheckK8sNodeGroupsOnK8sCreation:
+            method: get
+            resourcePath: /checkK8sNodeGroupsOnK8sCreation
+            description: Check whether nodegroups are required during the K8sCluster creation
+        CheckK8sNodeImageDesignation:
+            method: get
+            resourcePath: /checkK8sNodeImageDesignation
+            description: Check whether node image designation is possible to create a K8sCluster
+        CheckObjectStorage:
+            method: head
+            resourcePath: /ns/{nsId}/resources/objectStorage/{osId}
+            description: Check existence of an object storage (bucket)
+        CheckResource:
+            method: get
+            resourcePath: /ns/{nsId}/checkResource/{resourceType}/{resourceId}
+            description: Check resources' existence
+        ClearAllNodeCommandStatus:
+            method: delete
+            resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}/commandStatusAll
+            description: Delete all command status records for a node
+        ComplementSshKeyRemoteCommand:
+            method: put
+            resourcePath: /ns/{nsId}/resources/sshKey/{sshKeyId}/complement
+            description: Update username and privateKey to enable remote command execution on registered nodes
+        CreateObjectStorage:
+            method: put
+            resourcePath: /ns/{nsId}/resources/objectStorage
+            description: Create an object storage (bucket)
+        CreateObjectStorageLagacy:
+            method: put
+            resourcePath: /resources/objectStorage/{objectStorageName}
+            description: |-
+                (To be deprecated) Create an object storage (bucket)
+
+                **Important Notes:**
+                - The `objectStorageName` must be globally unique across all existing buckets in the S3 compatible storage.
+                - The bucket namespace is shared by all users of the system.
+        CreateOrUpdateLabel:
+            method: put
+            resourcePath: /label/{labelType}/{uid}
+            description: Create or update a label for a resource identified by its uid
+        CreateSharedResource:
+            method: post
+            resourcePath: /ns/{nsId}/sharedResource
+            description: Create shared resources for MC-Infra
+        DelAllCustomImage:
+            method: delete
+            resourcePath: /ns/{nsId}/resources/customImage
+            description: Delete all customImages
+        DelAllDataDisk:
+            method: delete
+            resourcePath: /ns/{nsId}/resources/dataDisk
+            description: Delete all Data Disks
+        DelAllImage:
+            method: delete
+            resourcePath: /ns/{nsId}/resources/image
+            description: Delete all images
+        DelAllInfra:
+            method: delete
+            resourcePath: /ns/{nsId}/infra
+            description: Delete all Infras
+        DelAllInfraPolicy:
+            method: delete
+            resourcePath: /ns/{nsId}/policy/infra
+            description: Delete all Infra policies
+        DelAllNLB:
+            method: delete
+            resourcePath: /ns/{nsId}/infra/{infraId}/nlb
+            description: Delete all NLBs
+        DelAllNs:
+            method: delete
+            resourcePath: /ns
+            description: Delete all namespaces
+        DelAllSecurityGroup:
+            method: delete
+            resourcePath: /ns/{nsId}/resources/securityGroup
+            description: Delete all Security Groups
+        DelAllSharedResources:
+            method: delete
+            resourcePath: /ns/{nsId}/sharedResources
+            description: Delete all Default Resource Objects in the given namespace
+        DelAllSshKey:
+            method: delete
+            resourcePath: /ns/{nsId}/resources/sshKey
+            description: Delete all SSH Keys
+        DelAllVNet:
+            method: delete
+            resourcePath: /ns/{nsId}/resources/vNet
+            description: Delete all VNets
+        DelCustomImage:
+            method: delete
+            resourcePath: /ns/{nsId}/resources/customImage/{customImageId}
+            description: Delete customImage
+        DelDataDisk:
+            method: delete
+            resourcePath: /ns/{nsId}/resources/dataDisk/{dataDiskId}
+            description: Delete Data Disk
+        DelFirewallRules:
+            method: delete
+            resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}/rules
+            description: |-
+                Delete specific FirewallRules: Remove specified rules from the Security Group while keeping other existing rules.
+                This API will remove only the specified rules from the Security Group, leaving all other rules intact.
+
+                Usage:
+                Use this API to remove specific firewall rules from a Security Group. Only the rules matching the provided criteria will be deleted.
+                - Rules that exactly match the provided Direction, Protocol, Port, and CIDR will be removed.
+                - All other existing rules will remain unchanged.
+
+                Notes:
+                - "Ports" field supports single port ("22"), port range ("80-100"), and multiple ports/ranges ("22,80-100,443").
+                - "Protocol" can be TCP, UDP, ICMP, ALL, etc. (as supported by the cloud provider).
+                - "Direction" must be either "inbound" or "outbound".
+                - "CIDR" is the allowed IP range.
+        DelImage:
+            method: delete
+            resourcePath: /ns/{nsId}/resources/image/{imageId}
+            description: Delete image
+        DelInfra:
+            method: delete
+            resourcePath: /ns/{nsId}/infra/{infraId}
+            description: Delete Infra
+        DelInfraNode:
+            method: delete
+            resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}
+            description: Delete node in specified Infra
+        DelInfraPolicy:
+            method: delete
+            resourcePath: /ns/{nsId}/policy/infra/{infraId}
+            description: Delete Infra Policy
+        DelNLB:
+            method: delete
+            resourcePath: /ns/{nsId}/infra/{infraId}/nlb/{nlbId}
+            description: Delete NLB
+        DelNs:
+            method: delete
+            resourcePath: /ns/{nsId}
+            description: Delete namespace
+        DelSecurityGroup:
+            method: delete
+            resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}
+            description: Delete Security Group
+        DelSpec:
+            method: delete
+            resourcePath: /ns/{nsId}/resources/spec/{specId}
+            description: Delete spec
+        DelSshKey:
+            method: delete
+            resourcePath: /ns/{nsId}/resources/sshKey/{sshKeyId}
+            description: Delete SSH Key
+        DelSubnet:
+            method: delete
+            resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}
+            description: |-
+                Delete Subnet
+                ---
+                **action options:**
+
+                **reconcile** – Synchronize Tumblebug metadata with the actual CSP state.
+                Checks whether the Subnet resource still exists on CSP (via Spider).
+                If the CSP resource is gone, removes the orphaned Tumblebug metadata.
+                If the CSP resource still exists, keeps the metadata intact.
+                Use this to clean up stale metadata after system errors or partial failures.
+                (e.g., `DELETE /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}?action=reconcile`)
+
+                **force** – Force-delete the Subnet on CSP (passes `?force=true` to Spider).
+                Use this when normal deletion fails due to CSP-side constraints (e.g., resource in use).
+                (e.g., `DELETE /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}?action=force`)
+        DelVNet:
+            method: delete
+            resourcePath: /ns/{nsId}/resources/vNet/{vNetId}
+            description: |-
+                Delete VNet
+                ---
+                **action options:**
+
+                **withsubnets** – Delete the VNet together with all its subnets in a single call.
+
+                **reconcile** – Synchronize Tumblebug metadata with the actual CSP state.
+                Checks whether the VNet/Subnet resource still exists on CSP (via Spider).
+                If the CSP resource is gone, removes the orphaned Tumblebug metadata.
+                If the CSP resource still exists, keeps the metadata intact.
+                Use this to clean up stale metadata after system errors or partial failures.
+                (e.g., `DELETE /ns/{nsId}/resources/vNet/{vNetId}?action=reconcile`)
+
+                **force** – Force-delete the VNet and its subnets on CSP (passes `?force=true` to Spider).
+                Use this when normal deletion fails due to CSP-side constraints (e.g., resource in use).
+                (e.g., `DELETE /ns/{nsId}/resources/vNet/{vNetId}?action=force`)
+        DeleteAllInfraDynamicTemplate:
+            method: delete
+            resourcePath: /ns/{nsId}/template/infra
+            description: Delete all Infra Dynamic Templates in a namespace.
+        DeleteAllK8sCluster:
+            method: delete
+            resourcePath: /ns/{nsId}/k8sCluster
+            description: Delete all K8sClusters
+        DeleteAllRequests:
+            method: delete
+            resourcePath: /requests
+            description: Delete details of all requests
+        DeleteAllSecurityGroupTemplate:
+            method: delete
+            resourcePath: /ns/{nsId}/template/securityGroup
+            description: Delete all SecurityGroup Templates in a namespace.
+        DeleteAllVNetTemplate:
+            method: delete
+            resourcePath: /ns/{nsId}/template/vNet
+            description: Delete all vNet Templates in a namespace.
+        DeleteDataObject:
+            method: delete
+            resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/object/{objectKey}
+            description: Delete an object from an object storage (bucket)
+        DeleteDataObjectLagacy:
+            method: delete
+            resourcePath: /resources/objectStorage/{objectStorageName}/{objectKey}
+            description: (To be deprecated) Delete an object from a bucket
+        DeleteDeregisterSubnet:
+            method: delete
+            resourcePath: /ns/{nsId}/deregisterResource/vNet/{vNetId}/subnet/{subnetId}
+            description: Deregister Subnet, which was created in CSP
+        DeleteDeregisterVNet:
+            method: delete
+            resourcePath: /ns/{nsId}/deregisterResource/vNet/{vNetId}
+            description: Deregister the VNet, which was created in CSP
+        DeleteGlobalDnsRecord:
+            method: delete
+            resourcePath: /resources/globalDns/record
+            description: |-
+                Delete DNS record(s) from Route53. If setIdentifier is provided, deletes only that specific record.
+                If setIdentifier is empty, deletes all records matching the name and type.
+        DeleteInfraDynamicTemplate:
+            method: delete
+            resourcePath: /ns/{nsId}/template/infra/{templateId}
+            description: Delete a specific Infra Dynamic Template.
+        DeleteK8sCluster:
+            method: delete
+            resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}
+            description: Delete K8sCluster
+        DeleteK8sNodeGroup:
+            method: delete
+            resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}
+            description: Remove a K8sNodeGroup
+        DeleteMultipleDataObjectsLagacy:
+            method: post
+            resourcePath: /resources/objectStorage/{objectStorageName}
+            description: |-
+                (To be deprecated) `Delete` multiple objects from a bucket
+
+                **Important Notes:**
+                - The request body must contain the list of objects to delete in XML format
+                - The `delete` query parameter must be set to `true`
+
+                **Request Body Example:**
+                ```xml
+                <?xml version="1.0" encoding="UTF-8"?>
+                <Delete xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <Object>
+                <Key>test-object1.txt</Key>
+                </Object>
+                <Object>
+                <Key>test-object2.txt</Key>
+                </Object>
+                </Delete>
+                ```
+
+                **Actual XML Response Example:**
+                ```xml
+                <?xml version="1.0" encoding="UTF-8"?>
+                <DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <Deleted>
+                <Key>test-object1.txt</Key>
+                </Deleted>
+                <Deleted>
+                <Key>test-object2.txt</Key>
+                </Deleted>
+                </DeleteResult>
+                ```
+        DeleteNodeCommandStatus:
+            method: delete
+            resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}/commandStatus/{index}
+            description: Delete a specific command status record by index for a node
+        DeleteNodeCommandStatusByCriteria:
+            method: delete
+            resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}/commandStatus
+            description: Delete multiple command status records for a node based on filtering criteria
+        DeleteNodeSshHostKey:
+            method: delete
+            resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}/sshHostKey
+            description: Reset the stored SSH host key for a specific node. This should be used when the node's host key has legitimately changed (e.g., after node recreation) and you trust the new key. The next SSH connection will store the new host key (TOFU).
+        DeleteObject:
+            method: delete
+            resourcePath: /object
+            description: Delete an object
+        DeleteObjectStorageCORS:
+            method: delete
+            resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/cors
+            description: Delete all CORS rules of an object storage (bucket)
+        DeleteObjectStorageCORSLagacy:
+            method: delete
+            resourcePath: /resources/objectStorage/{objectStorageName}/cors
+            description: (To be deprecated) Delete CORS configuration of an object storage (bucket)
+        DeleteObjectStorageLagacy:
+            method: delete
+            resourcePath: /resources/objectStorage/{objectStorageName}
+            description: (To be deprecated) Delete an object storage (bucket)
+        DeleteObjects:
+            method: delete
+            resourcePath: /objects
+            description: Delete child objects along with the given object
+        DeleteProvisioningLog:
+            method: delete
+            resourcePath: /provisioning/log/{specId}
+            description: |-
+                Remove all provisioning history data for a specific node specification.
+                This operation permanently deletes historical failure and success records:
+
+                **Warning**: This action is irreversible and will remove:
+                - All failure and success statistics
+                - Historical error messages and troubleshooting data
+                - Risk analysis baseline for future deployments
+                - Failure pattern analysis data
+
+                **When to Use:**
+                - **Data Cleanup**: Remove outdated or irrelevant provisioning history
+                - **Fresh Start**: Clear history after infrastructure changes that resolve previous issues
+                - **Privacy Compliance**: Remove logs containing sensitive error information
+                - **Storage Management**: Clean up logs to manage kvstore space
+
+                **Impact on System:**
+                - Future risk analysis for this spec will have no historical baseline
+                - Infra review process will not show historical warnings for this spec
+                - Provisioning reliability metrics will be reset to zero
+        DeleteRequest:
+            method: delete
+            resourcePath: /request/{reqId}
+            description: Delete details of a specific request
+        DeleteScheduleRegisterCspResources:
+            method: delete
+            resourcePath: /registerCspResources/schedule/{jobId}
+            description: |-
+                Stop and permanently delete a scheduled CSP resource registration job
+
+                **Warning:** This operation is irreversible!
+                - Job will be stopped immediately
+                - All job data and execution history will be deleted
+                - Cannot be recovered after deletion
+
+                **Alternatives:**
+                - To temporarily stop: Use `/pause` endpoint instead
+                - To keep history: Set `enabled: false` via PUT endpoint
+        DeleteScheduleRegisterCspResourcesAll:
+            method: delete
+            resourcePath: /registerCspResources/schedule
+            description: |-
+                ⚠️ **DANGER: This operation deletes ALL scheduled jobs in the system!**
+
+                **⚠️ CRITICAL WARNINGS:**
+                - This will PERMANENTLY DELETE **ALL** scheduled jobs across all namespaces
+                - All job execution history will be lost
+                - This operation is IRREVERSIBLE and cannot be undone
+                - Use with EXTREME CAUTION in production environments
+
+                **Use Cases:**
+                - Cleaning up test/development environments
+                - Emergency shutdown of all scheduled operations
+                - System maintenance or reset
+
+                **Safer Alternatives:**
+                - Delete individual jobs: Use `DELETE /registerCspResources/schedule/{jobId}`
+                - Temporarily stop all jobs: Pause each job individually via `/pause` endpoint
+                - Disable without deleting: Update each job with `enabled: false`
+
+                **Response Information:**
+                - Returns the count of deleted jobs
+                - Returns 200 even if no jobs were found (count will be 0)
+        DeleteSecurityGroupTemplate:
+            method: delete
+            resourcePath: /ns/{nsId}/template/securityGroup/{templateId}
+            description: Delete a specific SecurityGroup Template.
+        DeleteSiteToSiteVpn:
+            method: delete
+            resourcePath: /ns/{nsId}/infra/{infraId}/vpn/{vpnId}
+            description: |-
+                Delete a site-to-site VPN
+
+                - Note: A one-time retry is performed to handle transient failures caused by CSP-internal timing issues between dependent resources.
+
+                **Query option:**
+
+                | option | Description |
+                |--------|-------------|
+                | (none) | Standard delete via Terrarium. |
+                | `reconcile` | Do not call the Terrarium delete API. Instead, check whether the Terrarium resource actually exists. If it is missing, remove orphaned Tumblebug metadata. If it exists but the metadata is stuck in a terminal-failure state (e.g., `Failed(DeletionFailed)`), restore the status to `Available`. Returns a reconcile result object instead of a normal delete response. |
+        DeleteSqlDb:
+            method: delete
+            resourcePath: /ns/{nsId}/resources/sqlDb/{sqlDbId}
+            description: Delete a SQL datatbase
+        DeleteVNetTemplate:
+            method: delete
+            resourcePath: /ns/{nsId}/template/vNet/{templateId}
+            description: Delete a specific vNet Template.
+        DeleteVersionedObject:
+            method: delete
+            resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/versions/{objectKey}
+            description: |
+                Delete a specific version of an object in an object storage (bucket)
+
+                **Note: **
+                - If no version is specified, we will define how it behaves and update it when necessary.
+        DeleteVersionedObjectLagacy:
+            method: delete
+            resourcePath: /resources/objectStorage/{objectStorageName}/versions/{objectKey}
+            description: (To be deprecated) Delete a specific version of an object in an object storage (bucket)
+        DeregisterCustomImage:
+            method: delete
+            resourcePath: /ns/{nsId}/deregisterResource/customImage/{customImageId}
+            description: Deregister customImage from Spider and TB without deleting the actual CSP resource
+        DeregisterDataDisk:
+            method: delete
+            resourcePath: /ns/{nsId}/deregisterResource/dataDisk/{dataDiskId}
+            description: Deregister Data Disk from Spider and TB without deleting the actual CSP resource
+        DeregisterInfraNode:
+            method: delete
+            resourcePath: /ns/{nsId}/deregisterResource/infra/{infraId}/node/{nodeId}
+            description: Deregister node from Spider and TB without deleting the actual CSP resource
+        DeregisterSecurityGroup:
+            method: delete
+            resourcePath: /ns/{nsId}/deregisterResource/securityGroup/{securityGroupId}
+            description: Deregister Security Group from Spider and TB without deleting the actual CSP resource
+        DeregisterSshKey:
+            method: delete
+            resourcePath: /ns/{nsId}/deregisterResource/sshKey/{sshKeyId}
+            description: Deregister SSH Key from Spider and TB without deleting the actual CSP resource
+        ExistObjectStorageLagacy:
+            method: head
+            resourcePath: /resources/objectStorage/{objectStorageName}
+            description: (To be deprecated) Check existence of an object storage (bucket)
+        FetchImages:
+            method: post
+            resourcePath: /fetchImages
+            description: |-
+                Fetch images waiting for completion.
+
+                **Provider Selection Options:**
+                - `targetProviders`: Specify exact providers to fetch (e.g., ["aws", "gcp"]). When set, only these providers are processed and `excludedProviders` is ignored.
+                - `excludedProviders`: Specify providers to skip (e.g., ["azure"]). Only used when `targetProviders` is not set.
+                - `regionAgnosticProviders`: Providers where images are shared across regions (e.g., ["gcp"]). Only one region will be fetched per provider.
+
+                **Note:** `regionAgnosticProviders` should only contain providers that are also in `targetProviders` (or not excluded).
+        FetchImagesAsync:
+            method: post
+            resourcePath: /fetchImagesAsync
+            description: |-
+                Fetch images in the background without waiting for completion.
+
+                **Provider Selection Options:**
+                - `targetProviders`: Specify exact providers to fetch (e.g., ["aws", "gcp"]). When set, only these providers are processed and `excludedProviders` is ignored.
+                - `excludedProviders`: Specify providers to skip (e.g., ["azure"]). Only used when `targetProviders` is not set.
+                - `regionAgnosticProviders`: Providers where images are shared across regions (e.g., ["gcp"]). Only one region will be fetched per provider.
+
+                **Note:** `regionAgnosticProviders` should only contain providers that are also in `targetProviders` (or not excluded).
+        FetchPrice:
+            method: post
+            resourcePath: /fetchPrice
+            description: Fetch price from all CSP connections and update the price information for associated specs in the system.
+        FetchSpecs:
+            method: post
+            resourcePath: /fetchSpecs
+            description: |-
+                Fetch specs from CSPs and register them in the system.
+
+                **Provider Selection Options:**
+                - `targetProviders`: Specify exact providers to fetch (e.g., ["aws", "gcp"]). When set, only these providers are processed and `excludedProviders` is ignored.
+                - `excludedProviders`: Specify providers to skip (e.g., ["azure"]). Only used when `targetProviders` is not set.
+                - `regionAgnosticProviders`: Providers where specs are shared across regions (e.g., ["gcp"]). Only one region will be fetched per provider.
+
+                **Note:** `regionAgnosticProviders` should only contain providers that are also in `targetProviders` (or not excluded).
+        FilterSpecsByRange:
+            method: post
+            resourcePath: /ns/{nsId}/resources/filterSpecsByRange
+            description: Filter specs by range. Use limit field to control the maximum number of results. If limit is 0 or not specified, returns all matching results.
+        ForwardAnyReqToAny:
+            method: post
+            resourcePath: /forward/{path}
+            description: Forward any (GET) request to CB-Spider
+        GeneratePresignedDownloadURLLagacy:
+            method: get
+            resourcePath: /resources/objectStorage/presigned/download/{objectStorageName}/{objectKey}
+            description: |-
+                (To be deprecated) Generate a presigned URL for downloading an object from a bucket
+
+                **Important Notes:**
+                - The actual response will be XML format with root element `PresignedURLResult`
+                - The `expires` query parameter specifies the expiration time in seconds for the presigned URL (default: 3600 seconds)
+                - The generated presigned URL can be used to download the object directly without further authentication
+
+                **Actual XML Response Example:**
+                ```xml
+                <?xml version="1.0" encoding="UTF-8"?>
+                <PresignedURLResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <PresignedURL>https://globally-unique-bucket-hctdx3.s3.dualstack.ap-southeast-2.amazonaws.com/test-file.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA***EXAMPLE%2F20250904%2Fap-southeast-2%2Fs3%2Faws4_request&X-Amz-Date=20250904T061448Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=***-signature</PresignedURL>
+                <Expires>3600</Expires>
+                <Method>GET</Method>
+                </PresignedURLResult>
+                ```
+        GeneratePresignedURL:
+            method: post
+            resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/object/{objectKey}/presignedUrl
+            description: |-
+                Generate a presigned URL for uploading  or downloading an object to an object storage (bucket)
+
+                **Important Notes:**
+                - The generated presigned URL can be used to upload the object directly without further authentication
+                - The expiration time is specified in seconds (default: 3600 seconds)
+
+                **Example Usage: Upload**
+                ```bash
+                # Using the presigned URL to upload a file
+                curl -i -H "Content-Type: text/plain" -X PUT "<PRESIGNED_URL>" --data-binary "@local-file.txt"
+                ```
+
+                **Example Usage: download**
+                ```bash
+                # Using the presigned URL to download a file
+                curl -X GET "<PRESIGNED_URL>" -o downloaded-file.txt
+                ```
+        GeneratePresignedUploadURLLagacy:
+            method: get
+            resourcePath: /resources/objectStorage/presigned/upload/{objectStorageName}/{objectKey}
+            description: |-
+                (To be deprecated) Generate a presigned URL for uploading an object to a bucket
+
+                **Important Notes:**
+                - The actual response will be XML format with root element `PresignedURLResult`
+                - The `expires` query parameter specifies the expiration time in seconds for the presigned URL (default: 3600 seconds)
+                - The generated presigned URL can be used to upload the object directly without further authentication
+
+                **Actual XML Response Example:**
+                ```xml
+                <?xml version="1.0" encoding="UTF-8"?>
+                <PresignedURLResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <PresignedURL>https://globally-unique-bucket-hctdx3.s3.dualstack.ap-southeast-2.amazonaws.com/test-file.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA***EXAMPLE%2F20250904%2Fap-southeast-2%2Fs3%2Faws4_request&X-Amz-Date=20250904T061448Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=***-signature</PresignedURL>
+                <Expires>3600</Expires>
+                <Method>PUT</Method>
+                </PresignedURLResult>
+                ```
+        GetAllBenchmark:
+            method: post
+            resourcePath: /ns/{nsId}/benchmarkAll/infra/{infraId}
+            description: Run Infra benchmark for all performance metrics and return results
+        GetAllConfig:
+            method: get
+            resourcePath: /config
+            description: List all configs
+        GetAllCustomImage:
+            method: get
+            resourcePath: /ns/{nsId}/resources/customImage
+            description: List all customImages or customImages' ID
+        GetAllDataDisk:
+            method: get
+            resourcePath: /ns/{nsId}/resources/dataDisk
+            description: List all Data Disks or Data Disks' ID
+        GetAllImage:
+            method: get
+            resourcePath: /ns/{nsId}/resources/image
+            description: List all images or images' ID
+        GetAllInfra:
+            method: get
+            resourcePath: /ns/{nsId}/infra
+            description: List all Infras or Infras' ID
+        GetAllInfraDynamicTemplate:
+            method: get
+            resourcePath: /ns/{nsId}/template/infra
+            description: |-
+                List all Infra Dynamic Templates in a namespace.
+                Optionally filter by keyword matching against template name or description (case-insensitive).
+        GetAllInfraPolicy:
+            method: get
+            resourcePath: /ns/{nsId}/policy/infra
+            description: List all Infra policies
+        GetAllK8sCluster:
+            method: get
+            resourcePath: /ns/{nsId}/k8sCluster
+            description: List all K8sClusters or K8sClusters' ID
+        GetAllNLB:
+            method: get
+            resourcePath: /ns/{nsId}/infra/{infraId}/nlb
+            description: List all NLBs or NLBs' ID
+        GetAllNs:
+            method: get
+            resourcePath: /ns
+            description: List all namespaces or namespaces' ID
+        GetAllRequests:
+            method: get
+            resourcePath: /requests
+            description: Get details of all requests with optional filters.
+        GetAllSecurityGroup:
+            method: get
+            resourcePath: /ns/{nsId}/resources/securityGroup
+            description: List all Security Groups or Security Groups' ID
+        GetAllSecurityGroupTemplate:
+            method: get
+            resourcePath: /ns/{nsId}/template/securityGroup
+            description: |-
+                List all SecurityGroup Templates in a namespace.
+                Optionally filter by keyword matching against template name or description (case-insensitive).
+        GetAllSiteToSiteVpn:
+            method: get
+            resourcePath: /ns/{nsId}/infra/{infraId}/vpn
+            description: Get all site-to-site VPNs
+        GetAllSqlDb:
+            method: get
+            resourcePath: /ns/{nsId}/resources/sqlDb
+            description: Get all SQL Databases (TBD)
+        GetAllSshKey:
+            method: get
+            resourcePath: /ns/{nsId}/resources/sshKey
+            description: List all SSH Keys or SSH Keys' ID
+        GetAllSubnet:
+            method: get
+            resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/subnet
+            description: List all subnets
+        GetAllVNet:
+            method: get
+            resourcePath: /ns/{nsId}/resources/vNet
+            description: List all VNets or VNets' ID
+        GetAllVNetTemplate:
+            method: get
+            resourcePath: /ns/{nsId}/template/vNet
+            description: |-
+                List all vNet Templates in a namespace.
+                Optionally filter by keyword matching against template name or description (case-insensitive).
+        GetAssetsSummary:
+            method: get
+            resourcePath: /assetsSummary
+            description: Returns CSP-wise summary of specs and images in DB for a namespace, including priced/unpriced spec counts.
+        GetAvailableK8sNodeImage:
+            method: get
+            resourcePath: /availableK8sNodeImage
+            description: (UNDER DEVELOPMENT!!!) Get available kubernetes cluster node image
+        GetAvailableK8sVersion:
+            method: get
+            resourcePath: /availableK8sVersion
+            description: Get available kubernetes cluster version
+        GetAvailableRegionZonesForSpec:
+            method: post
+            resourcePath: /availableRegionZonesForSpec
+            description: Query the availability of a specific spec across all regions/zones
+        GetAvailableRegionZonesForSpecList:
+            method: post
+            resourcePath: /availableRegionZonesForSpecList
+            description: Query the availability for multiple specs in parallel and return batch results
+        GetAvailableZonesForSpec:
+            method: get
+            resourcePath: /availableZonesForSpec
+            description: Query verified zones for a spec based on connection configs. Returns zones that are both verified and available for the specified spec. For Alibaba Cloud, additional CSP API filtering is applied.
+        GetBastionNodes:
+            method: get
+            resourcePath: /ns/{nsId}/infra/{infraId}/node/{targetNodeId}/bastion
+            description: Get bastion nodes for a node
+        GetBenchmark:
+            method: post
+            resourcePath: /ns/{nsId}/benchmark/infra/{infraId}
+            description: Run Infra benchmark for a single performance metric and return results
+        GetCloudInfo:
+            method: get
+            resourcePath: /cloudInfo
+            description: Get cloud information
+        GetCmdInfraStream:
+            method: get
+            resourcePath: /ns/{nsId}/stream/cmd/infra/{infraId}
+            description: |-
+                Subscribe to Server-Sent Events (SSE) for real-time command execution logs.
+                Use the xRequestId returned from POST /ns/{nsId}/cmd/infra/{infraId}?async=true to connect.
+                Events: CommandStatus (status transitions), CommandLog (stdout/stderr lines), CommandDone (terminal).
+        GetConfig:
+            method: get
+            resourcePath: /config/{configId}
+            description: Get config
+        GetConnConfig:
+            method: get
+            resourcePath: /connConfig/{connConfigName}
+            description: Get registered ConnConfig info
+        GetConnConfigList:
+            method: get
+            resourcePath: /connConfig
+            description: List all registered ConnConfig
+        GetControlInfra:
+            method: get
+            resourcePath: /ns/{nsId}/control/infra/{infraId}
+            description: |-
+                Control the lifecycle of an Infra. Actions fall into three groups:
+
+                **Lifecycle (normal operation):**
+                - `suspend` / `resume` / `reboot`: power-cycle every Node.
+                - `terminate`: terminate every Node (Infra metadata is kept; call DELETE to remove).
+                - `refine`: delete Nodes whose status is `Failed` or `Undefined` from Infra metadata
+                (no CSP-side termination is issued for those Nodes).
+
+                **Hold gate (only valid right after `POST /infra` with option=hold):**
+                - `continue`: signal the holding goroutine to proceed with provisioning.
+                - `withdraw`: signal the holding goroutine to cancel provisioning.
+                - These actions only work while a holding goroutine is alive in memory.
+                After a server restart they will fail; use `reconcile`/`abort` instead.
+
+                **Crash recovery (Infra stuck after server restart or partial failure):**
+                - `reconcile`: forward-recover. For each transient Node, query Spider for the real
+                CSP status and absorb CSP-side orphan VMs (created before the crash but not
+                recorded in TB). Nodes that cannot be matched on the CSP are marked `Failed`
+                so a subsequent `refine` can remove them. No new Spider create calls are issued.
+                - `abort`: backward-recover. Force-terminate every non-final Node in parallel
+                (with orphan rescue) and sweep any `Failed` remnants via `refine`. The final
+                DELETE call is left to the operator.
+        GetControlInfraNode:
+            method: get
+            resourcePath: /ns/{nsId}/control/infra/{infraId}/node/{nodeId}
+            description: Control the lifecycle of node (suspend, resume, reboot, terminate)
+        GetControlK8sCluster:
+            method: get
+            resourcePath: /ns/{nsId}/control/k8sCluster/{k8sClusterId}
+            description: Control the creation of K8sCluster (continue, withdraw)
+        GetCredentialHolder:
+            method: get
+            resourcePath: /credentialHolder/{holderId}
+            description: Get credential holder info derived from registered connection configs.
+        GetCredentialHolderList:
+            method: get
+            resourcePath: /credentialHolder
+            description: |-
+                List all credential holders derived from registered connection configs.
+                Each holder includes associated providers, connection counts, and verification status.
+        GetCustomImage:
+            method: get
+            resourcePath: /ns/{nsId}/resources/customImage/{customImageId}
+            description: Get customImage
+        GetDataDisk:
+            method: get
+            resourcePath: /ns/{nsId}/resources/dataDisk/{dataDiskId}
+            description: Get Data Disk
+        GetDataObjectInfo:
+            method: head
+            resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/object/{objectKey}
+            description: |-
+                Get object info from an object storage (bucket)
+
+                **Important Notes:**
+                - This API retrieves the metadata of an object without downloading the actual content
+                - Returns metadata in response headers (Content-Length, Content-Type, ETag, Last-Modified)
+        GetDataObjectInfoLagacy:
+            method: head
+            resourcePath: /resources/objectStorage/{objectStorageName}/{objectKey}
+            description: |-
+                (To be deprecated) Get an object info from a bucket
+
+                **Important Notes:**
+                - The generated `Download file` link in Swagger UI may not work because this API get the object metadata only.
+        GetExecutionTask:
+            method: get
+            resourcePath: /ns/{nsId}/cmd/infra/{infraId}/task/{taskId}
+            description: Get detailed information about a specific execution task by taskId
+        GetFetchImagesAsyncResult:
+            method: get
+            resourcePath: /fetchImagesResult
+            description: Get detailed results from the last asynchronous image fetch operation
+        GetGlobalDnsRecord:
+            method: get
+            resourcePath: /resources/globalDns/record
+            description: Get DNS records for a domain from Route53. Includes routing policy and geoproximity info.
+        GetHostedZones:
+            method: get
+            resourcePath: /resources/globalDns/hostedZone
+            description: List all hosted zones available in Route53
+        GetImage:
+            method: get
+            resourcePath: /ns/{nsId}/resources/image/{imageId}
+            description: GetImage returns an image object if there are matched images for the given namespace and imageKey(imageId)
+        GetInfra:
+            method: get
+            resourcePath: /ns/{nsId}/infra/{infraId}
+            description: 'Get Infra object (option: status, accessInfo, nodeId)'
+        GetInfraAssociatedResources:
+            method: get
+            resourcePath: /ns/{nsId}/infra/{infraId}/associatedResources
+            description: Get associated resource ID list for a given Infra (VNet, Subnet, SecurityGroup, SSHKey, etc.)
+        GetInfraCluster:
+            method: get
+            resourcePath: /ns/{nsId}/infra/{infraId}/cluster/{clusterId}
+            description: Get a single implicit cluster synthesized at query-time from NodeGroups/Nodes in a specified Infra
+        GetInfraClusters:
+            method: get
+            resourcePath: /ns/{nsId}/infra/{infraId}/cluster
+            description: List implicit clusters synthesized at query-time from NodeGroups/Nodes in a specified Infra
+        GetInfraDynamicTemplate:
+            method: get
+            resourcePath: /ns/{nsId}/template/infra/{templateId}
+            description: Retrieve a specific Infra Dynamic Template by ID.
+        GetInfraExecutionTasks:
+            method: get
+            resourcePath: /ns/{nsId}/cmd/infra/{infraId}/task
+            description: List all running and completed execution tasks for a specific Infra. These tasks can be cancelled if still in progress. The task list is based on persistent node command status records.
+        GetInfraGroupIds:
+            method: get
+            resourcePath: /ns/{nsId}/infra/{infraId}/nodegroup
+            description: List NodeGroup IDs in a specified Infra
+        GetInfraGroupNodes:
+            method: get
+            resourcePath: /ns/{nsId}/infra/{infraId}/nodegroup/{nodegroupId}
+            description: List nodes with a NodeGroup label in a specified Infra
+        GetInfraHandlingCommandCount:
+            method: get
+            resourcePath: /ns/{nsId}/infra/{infraId}/handlingCount
+            description: Get the number of commands currently in 'Handling' status for all nodes in an Infra. Returns per-node counts and total count.
+        GetInfraNode:
+            method: get
+            resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}
+            description: Get node in specified Infra
+        GetInfraPolicy:
+            method: get
+            resourcePath: /ns/{nsId}/policy/infra/{infraId}
+            description: Get Infra Policy
+        GetInfraReqFromInfra:
+            method: get
+            resourcePath: /ns/{nsId}/infra/{infraId}/configCopy
+            description: |-
+                Reconstruct an Infra dynamic creation request body from an existing Infra's information.
+                Returns a dynamic request format where networking resources (vNet, subnet, SG, sshKey)
+                are auto-created, making it easy to clone or recreate a similar Infra configuration.
+
+                **Template Option:**
+                When the `template` query parameter is provided, the extracted configuration is
+                saved as a reusable Infra Dynamic Template with the given name.
+        GetK8sCluster:
+            method: get
+            resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}
+            description: Get K8sCluster
+        GetK8sClusterInfo:
+            method: get
+            resourcePath: /k8sClusterInfo
+            description: Get kubernetes cluster information
+        GetK8sClusterKubeconfig:
+            method: get
+            resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/kubeconfig
+            description: |-
+                Get a CSP native kubeconfig for the specified K8sCluster.
+                Returns a kubeconfig using CSP native auth plugins (e.g., aws-iam-authenticator for EKS, gke-gcloud-auth-plugin for GKE).
+        GetK8sClusterToken:
+            method: get
+            resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/token
+            description: |-
+                Get an access token for the specified K8sCluster.
+                Only applicable to CSPs that use exec-based authentication (e.g., GCP GKE, AWS EKS).
+        GetLabels:
+            method: get
+            resourcePath: /label/{labelType}/{uid}
+            description: Get labels for a resource identified by its uid
+        GetLatencyBenchmark:
+            method: get
+            resourcePath: /ns/{nsId}/benchmarkLatency/infra/{infraId}
+            description: Run Infra benchmark for network latency
+        GetMonitorData:
+            method: get
+            resourcePath: /ns/{nsId}/monitoring/infra/{infraId}/metric/{metric}
+            description: Get monitoring data of specified Infra for specified monitoring metric (cpu, memory, disk, network)
+        GetNLB:
+            method: get
+            resourcePath: /ns/{nsId}/infra/{infraId}/nlb/{nlbId}
+            description: Get NLB
+        GetNLBHealth:
+            method: get
+            resourcePath: /ns/{nsId}/infra/{infraId}/nlb/{nlbId}/healthz
+            description: Get NLB Health
+        GetNodeCommandStatus:
+            method: get
+            resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}/commandStatus/{index}
+            description: Get a specific command status record by index for a node
+        GetNodeDataDisk:
+            method: get
+            resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}/dataDisk
+            description: Get available dataDisks for a node
+        GetNodeHandlingCommandCount:
+            method: get
+            resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}/handlingCount
+            description: Get the number of commands currently in 'Handling' status for a specific node. Optimized for frequent polling.
+        GetNodeSshHostKey:
+            method: get
+            resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}/sshHostKey
+            description: Get the stored SSH host key information for a specific node. This is used for TOFU (Trust On First Use) verification.
+        GetNs:
+            method: get
+            resourcePath: /ns/{nsId}
+            description: Get namespace
+        GetObject:
+            method: get
+            resourcePath: /object
+            description: Get value of an object
+        GetObjectStorage:
+            method: get
+            resourcePath: /ns/{nsId}/resources/objectStorage/{osId}
+            description: Get details of an object storage (bucket)
+        GetObjectStorageCORS:
+            method: get
+            resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/cors
+            description: Get CORS configuration of an object storage (bucket)
+        GetObjectStorageCORSLagacy:
+            method: get
+            resourcePath: /resources/objectStorage/{objectStorageName}/cors
+            description: |-
+                (To be deprecated) Get CORS configuration of an object storage (bucket)
+
+                **Important Notes:**
+                - The actual response will be XML format with root element `CORSConfiguration`
+
+                **Actual XML Response Example:**
+                ```xml
+                <?xml version="1.0" encoding="UTF-8"?>
+                <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <CORSRule>
+                <AllowedOrigin>*</AllowedOrigin>
+                <AllowedMethod>GET</AllowedMethod>
+                <AllowedMethod>PUT</AllowedMethod>
+                <AllowedMethod>POST</AllowedMethod>
+                <AllowedMethod>DELETE</AllowedMethod>
+                <AllowedHeader>*</AllowedHeader>
+                <ExposeHeader>ETag</ExposeHeader>
+                <ExposeHeader>x-amz-server-side-encryption</ExposeHeader>
+                <ExposeHeader>x-amz-request-id</ExposeHeader>
+                <ExposeHeader>x-amz-id-2</ExposeHeader>
+                <MaxAgeSeconds>3000</MaxAgeSeconds>
+                </CORSRule>
+                </CORSConfiguration>
+                ```
+
+                **Error Response Example (if CORS not configured):**
+                ```xml
+                <?xml version="1.0" encoding="UTF-8"?>
+                <Error>
+                <Code>NoSuchCORSConfiguration</Code>
+                <Message>The CORS configuration does not exist</Message>
+                <Resource>/example-bucket</Resource>
+                <RequestId>656c76696e6727732072657175657374</RequestId>
+                </Error>
+                ```
+        GetObjectStorageLagacy:
+            method: get
+            resourcePath: /resources/objectStorage/{objectStorageName}
+            description: |-
+                (To be deprecated) Get details of an object storage (bucket)
+
+                **Important Notes:**
+                - The actual response will be XML format with root element `ListBucketResult`
+
+                **Actual XML Response Example:**
+                ```xml
+                <?xml version="1.0" encoding="UTF-8"?>
+                <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <Name>spider-test-bucket</Name>
+                <Prefix></Prefix>
+                <Marker></Marker>
+                <MaxKeys>1000</MaxKeys>
+                <IsTruncated>false</IsTruncated>
+                </ListBucketResult>
+                ```
+        GetObjectStorageLocation:
+            method: get
+            resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/location
+            description: Get the location of an object storage (bucket)
+        GetObjectStorageLocationLagacy:
+            method: get
+            resourcePath: /resources/objectStorage/{objectStorageName}/location
+            description: |-
+                (To be deprecated) Get the location of an object storage (bucket)
+
+                **Important Notes:**
+                - The actual response will be XML format with root element `LocationConstraint`
+
+                **Actual XML Response Example:**
+                ```xml
+                <?xml version="1.0" encoding="UTF-8"?>
+                <LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">ap-northeast-2</LocationConstraint>
+                ```
+        GetObjectStorageSupport:
+            method: get
+            resourcePath: /objectStorage/support
+            description: |-
+                Get CSP support information for object storage features (CORS, Versioning)
+                If cspType query parameter is provided, returns support information for that specific CSP
+                If cspType is not provided, returns support information for all CSPs
+        GetObjectStorageVersioning:
+            method: get
+            resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/versioning
+            description: Get versioning configuration of an object storage (bucket)
+        GetObjectStorageVersioningLagacy:
+            method: get
+            resourcePath: /resources/objectStorage/{objectStorageName}/versioning
+            description: |-
+                (To be deprecated) Get versioning status of an object storage (bucket)
+
+                **Important Notes:**
+                - The actual response will be XML format with root element `VersioningConfiguration`
+
+                **Actual XML Response Example:**
+                ```xml
+                <?xml version="1.0" encoding="UTF-8"?>
+                <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <Status>Enabled</Status>
+                </VersioningConfiguration>
+                ```
+        GetObjects:
+            method: get
+            resourcePath: /objects
+            description: List all objects for a given key
+        GetProviderList:
+            method: get
+            resourcePath: /provider
+            description: List all registered Providers
+        GetProvisioningLog:
+            method: get
+            resourcePath: /provisioning/log/{specId}
+            description: |-
+                Retrieve detailed provisioning history for a specific node specification including success/failure patterns and risk analysis.
+                This endpoint provides comprehensive insights into provisioning reliability:
+
+                **Historical Data Includes:**
+                - Success and failure counts with timestamps
+                - CSP-specific error messages and failure patterns
+                - Image compatibility tracking across different attempts
+                - Failure rate analysis and risk assessment
+                - Regional and provider-specific reliability metrics
+
+                **Use Cases:**
+                - **Pre-deployment Risk Assessment**: Check if a spec has historical failures before creating Infra
+                - **Troubleshooting**: Analyze failure patterns to identify root causes
+                - **Capacity Planning**: Understand reliability patterns for different specs and regions
+                - **Cost Optimization**: Avoid specs with high failure rates that waste resources
+
+                **Response Details:**
+                - `failureCount`: Total number of provisioning failures
+                - `successCount`: Number of successes (only tracked after failures occur)
+                - `failureImages`: List of CSP images that failed with this spec
+                - `successImages`: List of CSP images that succeeded with this spec
+                - `failureMessages`: Detailed error messages from CSP
+                - `lastUpdated`: Timestamp of most recent provisioning attempt
+        GetPublicKeyForCredentialEncryption:
+            method: get
+            resourcePath: /credential/publicKey
+            description: Generates an RSA key pair using a 4096-bit key size with the RSA algorithm. The public key is generated using the RSA algorithm with OAEP padding and SHA-256 as the hash function. This key is used to encrypt an AES key that will be used for hybrid encryption of credentials.
+        GetReadyz:
+            method: get
+            resourcePath: /readyz
+            description: Check Tumblebug is ready. Returns ready status and initialization status.
+        GetRegion:
+            method: get
+            resourcePath: /provider/{providerName}/region/{regionName}
+            description: Get registered region info
+        GetRegions:
+            method: get
+            resourcePath: /provider/{providerName}/region
+            description: Get registered region info
+        GetRequest:
+            method: get
+            resourcePath: /request/{reqId}
+            description: Get details of a specific request
+        GetRequestStatusOfSiteToSiteVpn:
+            method: get
+            resourcePath: /ns/{nsId}/infra/{infraId}/vpn/{vpnId}/request/{requestId}
+            description: Check the status of a specific request by its ID
+        GetRequiredK8sSubnetCount:
+            method: get
+            resourcePath: /requiredK8sSubnetCount
+            description: Get the required subnet count to create a K8sCluster
+        GetResourcesByLabelSelector:
+            method: get
+            resourcePath: /resources/{labelType}
+            description: |-
+                Get resources based on a label selector. The label selector supports the following operators:
+                - `=` : Selects resources where the label key equals the specified value (e.g., `env=production`).
+                - `!=` : Selects resources where the label key does not equal the specified value (e.g., `tier!=frontend`).
+                - `in` : Selects resources where the label key is in the specified set of values (e.g., `region in (us-west, us-east)`).
+                - `notin` : Selects resources where the label key is not in the specified set of values (e.g., `env notin (production, staging)`).
+                - `exists` : Selects resources where the label key exists (e.g., `env exists`).
+                - `!exists` : Selects resources where the label key does not exist (e.g., `env !exists`).
+        GetScheduleRegisterCspResourcesList:
+            method: get
+            resourcePath: /registerCspResources/schedule
+            description: Get a list of all scheduled CSP resource registration jobs (jobs are not scoped to namespaces)
+        GetScheduleRegisterCspResourcesStatus:
+            method: get
+            resourcePath: /registerCspResources/schedule/{jobId}
+            description: |-
+                Get the current status of a specific scheduled CSP resource registration job
+
+                **Response Fields Explanation:**
+                - `status`: Current job state (Scheduled/Executing/Stopped)
+                - `enabled`: Whether job is active (can be paused with false)
+                - `executionCount`: Total number of executions attempted
+                - `successCount`: Number of successful executions
+                - `failureCount`: Number of failed executions
+                - `consecutiveFailures`: Current streak of failures (resets on success)
+                - `autoDisabled`: True if job was auto-disabled due to 5+ consecutive failures
+                - `lastExecutedAt`: Timestamp of most recent execution
+                - `nextExecutionAt`: Scheduled time for next execution
+                - `lastError`: Error message from most recent failure (empty if success)
+                - `lastResult`: Result message from most recent execution
+
+                **Monitoring Recommendations:**
+                - Check `consecutiveFailures` - alert if >= 3
+                - Monitor `autoDisabled` - requires manual intervention if true
+                - Compare `successCount` vs `failureCount` for reliability metrics
+        GetSecurityGroup:
+            method: get
+            resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}
+            description: Get Security Group
+        GetSecurityGroupTemplate:
+            method: get
+            resourcePath: /ns/{nsId}/template/securityGroup/{templateId}
+            description: Retrieve a specific SecurityGroup Template by ID.
+        GetSiteToSiteVpn:
+            method: get
+            resourcePath: /ns/{nsId}/infra/{infraId}/vpn/{vpnId}
+            description: Get resource info of a site-to-site VPN
+        GetSitesInInfra:
+            method: get
+            resourcePath: /ns/{nsId}/infra/{infraId}/site
+            description: Get sites in Infra
+        GetSpec:
+            method: get
+            resourcePath: /ns/{nsId}/resources/spec/{specId}
+            description: Get spec
+        GetSqlDb:
+            method: get
+            resourcePath: /ns/{nsId}/resources/sqlDb/{sqlDbId}
+            description: Get resource info of a SQL datatbase
+        GetSshKey:
+            method: get
+            resourcePath: /ns/{nsId}/resources/sshKey/{sshKeyId}
+            description: Get SSH Key
+        GetSubnet:
+            method: get
+            resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}
+            description: Get Subnet
+        GetSystemLabelInfo:
+            method: get
+            resourcePath: /labelInfo
+            description: Return LabelTypes and system defined label keys with example
+        GetVNet:
+            method: get
+            resourcePath: /ns/{nsId}/resources/vNet/{vNetId}
+            description: Get VNet
+        GetVNetTemplate:
+            method: get
+            resourcePath: /ns/{nsId}/template/vNet/{templateId}
+            description: Retrieve a specific vNet Template by ID.
+        InitAllConfig:
+            method: delete
+            resourcePath: /config
+            description: Init all configs
+        InitConfig:
+            method: delete
+            resourcePath: /config/{configId}
+            description: Init config
+        InspectResources:
+            method: post
+            resourcePath: /inspectResources
+            description: Inspect Resources (vNet, securityGroup, sshKey, node) registered in CB-Tumblebug, CB-Spider, CSP
+        InspectResourcesOverview:
+            method: get
+            resourcePath: /inspectResourcesOverview
+            description: Inspect Resources Overview (vNet, securityGroup, sshKey, node) registered in CB-Tumblebug and CSP for all connections
+        ListDataObjects:
+            method: get
+            resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/object
+            description: List all objects in an object storage (bucket)
+        ListNodeCommandStatus:
+            method: get
+            resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}/commandStatus
+            description: List command status records for a node with various filtering options
+        ListObjectStorages:
+            method: get
+            resourcePath: /ns/{nsId}/resources/objectStorage
+            description: |-
+                Get the list of object storages (buckets)
+
+                **Filtering with filterKey and filterVal:**
+                Both parameters perform a case-insensitive substring match against the stored JSON of each resource.
+                A resource is included in the result only when its JSON contains **both** the filterKey string and the filterVal string.
+
+                Common filterKey examples:
+                - `connectionName` — filter by cloud connection (e.g. filterVal: `aws-ap-northeast-2`)
+                - `status`         — filter by resource status  (e.g. filterVal: `Available`)
+        ListObjectStoragesLagacy:
+            method: get
+            resourcePath: /resources/objectStorage
+            description: |-
+                (To be deprecated) Get the list of all object storages (buckets)
+
+                **Important Notes:**
+                - The actual response will be XML format with root element `ListAllMyBucketsResult`
+                - The response includes xmlns attribute: `xmlns="http://s3.amazonaws.com/doc/2006-03-01/"`
+                - Swagger UI may show `resource.ListAllMyBucketsResult` due to rendering limitations
+
+                **Actual XML Response Example:**
+                ```xml
+                <?xml version="1.0" encoding="UTF-8"?>
+                <ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <Owner>
+                <ID>aws-ap-northeast-2</ID>
+                <DisplayName>aws-ap-northeast-2</DisplayName>
+                </Owner>
+                <Buckets>
+                </Buckets>
+                </ListAllMyBucketsResult>
+                ```
+        ListObjectVersions:
+            method: get
+            resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/versions
+            description: List all versions of objects in an object storage (bucket)
+        ListObjectVersionsLagacy:
+            method: get
+            resourcePath: /resources/objectStorage/{objectStorageName}/versions
+            description: |-
+                (To be deprecated) List object versions in an object storage (bucket)
+
+                **Important Notes:**
+                - The actual response will be XML format with root element `ListVersionsResult`
+
+                **Actual XML Response Example:**
+                ```xml
+                <?xml version="1.0" encoding="UTF-8"?>
+                <ListVersionsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <Name>spider-test-bucket</Name>
+                <Prefix></Prefix>
+                <KeyMarker></KeyMarker>
+                <VersionIdMarker></VersionIdMarker>
+                <NextKeyMarker></NextKeyMarker>
+                <NextVersionIdMarker></NextVersionIdMarker>
+                <MaxKeys>1000</MaxKeys>
+                <IsTruncated>false</IsTruncated>
+                <Version>
+                <Key>test-file.txt</Key>
+                <VersionId>yb4PgjnFVD2LfRZHXBjjsHBkQRHlu.TZ</VersionId>
+                <IsLatest>true</IsLatest>
+                <LastModified>2025-09-04T04:24:12Z</LastModified>
+                <ETag>23228a38faecd0591107818c7281cece</ETag>
+                <Size>23</Size>
+                <StorageClass>STANDARD</StorageClass>
+                <Owner>
+                <ID>aws-config01</ID>
+                <DisplayName>aws-config01</DisplayName>
+                </Owner>
+                </Version>
+                </ListVersionsResult>
+                ```
+        LoadAssets:
+            method: get
+            resourcePath: /loadAssets
+            description: Load Common Resources from internal asset files (Spec, Image). By default, Azure images are excluded for faster initialization. Use includeAzure=true to fetch Azure images (may take 40+ minutes).
+        LookupImage:
+            method: post
+            resourcePath: /lookupImage
+            description: Lookup image (for debugging purposes)
+        LookupImageList:
+            method: post
+            resourcePath: /lookupImages
+            description: Lookup image list (for debugging purposes)
+        LookupSpec:
+            method: post
+            resourcePath: /lookupSpec
+            description: Lookup spec (for debugging purposes)
+        LookupSpecList:
+            method: post
+            resourcePath: /lookupSpecs
+            description: Lookup spec list (for debugging purposes)
+        MergeCSPResourceLabel:
+            method: put
+            resourcePath: /mergeCSPLabel/{labelType}/{uid}
+            description: Fetch the labels in the CSP and merge them with the existing labels
+        PostBuildAgnosticImage:
+            method: post
+            resourcePath: /ns/{nsId}/buildAgnosticImage
+            description: Creates an Infra infrastructure, executes post-deployment commands, creates snapshots from each nodegroup, and optionally cleans up the Infra. This is a complete workflow for building CSP-agnostic custom images.
+        PostCmdInfra:
+            method: post
+            resourcePath: /ns/{nsId}/cmd/infra/{infraId}
+            description: |-
+                Send a command to specified Infra. Use query parameters to target specific nodeGroup or node.
+                When async=true, returns immediately with xRequestId and streams results via SSE at GET /stream/ns/{nsId}/cmd/infra/{infraId}?xRequestId={xRequestId}
+        PostCmdK8sCluster:
+            method: post
+            resourcePath: /ns/{nsId}/cmd/k8sCluster/{k8sClusterId}
+            description: |-
+                Send a command to specified Container in K8sCluster
+                [note] This feature is not intended for general use
+                This API is provided as an exceptional and limited function for specific purposes such as migration.
+                Kubernetes resource information required as input for this API is not currently provided, and its availability in the future is uncertain.
+        PostConfig:
+            method: post
+            resourcePath: /config
+            description: Create or Update config (TB_SPIDER_REST_URL, TB_DRAGONFLY_REST_URL, ...)
+        PostCustomImage:
+            method: post
+            resourcePath: /ns/{nsId}/resources/customImage
+            description: Register existing Custom Image in a CSP (option=register)
+        PostDataDisk:
+            method: post
+            resourcePath: /ns/{nsId}/resources/dataDisk
+            description: Create Data Disk
+        PostDownloadFileFromInfraNode:
+            method: post
+            resourcePath: /ns/{nsId}/downloadFile/infra/{infraId}/node/{nodeId}
+            description: |-
+                Download a file from a specific node in Infra via SCP through bastion host.
+                The file size should be less than 200MB.
+        PostFileAndCmdToInfra:
+            method: post
+            resourcePath: /ns/{nsId}/transferFileAndCmd/infra/{infraId}
+            description: |-
+                Transfer a file to all targeted nodes in Infra via SCP, then optionally run a shell command on each node where the transfer succeeded.
+                Useful for deploying files directly to privileged locations (e.g., nginx document root) in a single API call.
+                Example: upload index.html to /tmp and run "sudo mv /tmp/index.html /var/www/html/" as the post-transfer command.
+                The file size should be less than 50MB.
+        PostFileToInfra:
+            method: post
+            resourcePath: /ns/{nsId}/transferFile/infra/{infraId}
+            description: |-
+                Transfer a file to specified Infra to the specified path.
+                The file size should be less than 10MB.
+                Not for gerneral file transfer but for specific purpose (small configuration files).
+        PostFileToK8sCluster:
+            method: post
+            resourcePath: /ns/{nsId}/transferFile/k8sCluster/{k8sClusterId}
+            description: |-
+                Transfer a file to specified Container in K8sCluster. The tar command is required in the container.
+                [note] This feature is not intended for general use
+                This API is provided as an exceptional and limited function for specific purposes such as migration.
+                Kubernetes resource information required as input for this API is not currently provided, and its availability in the future is uncertain.
+        PostFirewallRules:
+            method: post
+            resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}/rules
+            description: |-
+                Add new FirewallRules: Add the provided firewall rules to the existing rules in the Security Group.
+                This API will only add new rules without deleting or modifying existing ones.
+                If a rule with identical properties already exists, it will be skipped to avoid duplicates.
+
+                Usage:
+                Use this API to add new firewall rules to a Security Group while preserving existing rules.
+                - Only new rules that don't already exist will be added.
+                - Existing rules remain unchanged.
+                - If an identical rule already exists, it will be skipped.
+
+                Notes:
+                - "Ports" field supports single port ("22"), port range ("80-100"), and multiple ports/ranges ("22,80-100,443").
+                - The valid port number range is 0 to 65535 (inclusive).
+                - "Protocol" can be TCP, UDP, ICMP, ALL, etc. (as supported by the cloud provider).
+                - "Direction" must be either "inbound" or "outbound".
+                - "CIDR" is the allowed IP range.
+        PostImage:
+            method: post
+            resourcePath: /ns/{nsId}/resources/image
+            description: Register image
+        PostInfra:
+            method: post
+            resourcePath: /ns/{nsId}/infra
+            description: |-
+                Create Infra with detailed node specifications and resource configuration.
+                This endpoint creates a complete multi-cloud infrastructure by:
+                1. **node Provisioning**: Creates nodes across multiple cloud providers using predefined specs and images
+                2. **Resource Management**: Automatically handles VPC/VNet, security groups, SSH keys, and network configuration
+                3. **Status Tracking**: Monitors node creation progress and handles failures based on policy settings
+                4. **Post-Deployment**: Optionally installs monitoring agents and executes custom commands
+
+                **Key Features:**
+                - Multi-cloud node deployment with heterogeneous configurations
+                - Automatic resource dependency management (VPC → Security Group → node)
+                - Built-in failure handling with configurable policies (continue/rollback/refine)
+                - Optional CB-Dragonfly monitoring agent installation
+                - Post-deployment command execution support
+                - Real-time status updates and progress tracking
+
+                **node Lifecycle:**
+                1. Creating → Running (successful deployment)
+                2. Creating → Failed (deployment error, handled by failure policy)
+                3. Running → Terminated (manual or policy-driven cleanup)
+
+                **Failure Policies:**
+                - `continue`: Keep successful nodes, mark failed ones for later refinement
+                - `rollback`: Delete entire Infra if any node fails (all-or-nothing)
+                - `refine`: Automatically clean up failed nodes, keep successful ones
+
+                **Resource Requirements:**
+                - Valid node specifications (must exist in system namespace)
+                - Valid images (must be available in target CSP regions)
+                - Sufficient CSP quotas and permissions
+                - Network connectivity between components
+        PostInfraDynamic:
+            method: post
+            resourcePath: /ns/{nsId}/infraDynamic
+            description: |-
+                Create multi-cloud infrastructure dynamically using common specifications and images with automatic resource discovery and optimization.
+                This is the **recommended approach** for Infra creation, providing simplified configuration with powerful automation:
+
+                **Dynamic Resource Creation:**
+                1. **Automatic Resource Discovery**: Validates and selects optimal node specifications and images from common namespace
+                2. **Intelligent Network Setup**: Creates VNets, subnets, security groups, and SSH keys automatically per provider
+                3. **Cross-Cloud Orchestration**: Coordinates node provisioning across multiple cloud providers simultaneously
+                4. **Dependency Management**: Handles resource creation order and inter-dependencies automatically
+                5. **Failure Recovery**: Implements configurable failure policies for robust deployment
+
+                **Key Advantages Over Static Infra:**
+                - **Simplified Configuration**: Use common spec/image IDs instead of provider-specific resources
+                - **Automatic Resource Management**: No need to pre-create VNets, security groups, or SSH keys
+                - **Multi-Cloud Optimization**: Intelligent placement and configuration across providers
+                - **Built-in Best Practices**: Security groups, network isolation, and access controls applied automatically
+                - **Scalable Architecture**: Supports large-scale deployments with optimized resource utilization
+
+                **Configuration Process:**
+                1. **Resource Discovery**: Use `/recommendSpec` to find suitable node specifications
+                2. **Image Selection**: Use system namespace to discover compatible images
+                3. **Request Validation**: Use `/infraDynamicCheckRequest` to validate configuration before deployment
+                4. **Optional Preview**: Use `/infraDynamicReview` to estimate costs and review configuration
+                5. **Deployment**: Submit Infra dynamic request with failure policy and deployment options
+
+                **Failure Policies (PolicyOnPartialFailure):**
+                - **`continue`** (default): Create Infra with successful nodes, failed nodes remain for manual refinement
+                - **`rollback`**: Delete entire Infra if any node fails (all-or-nothing deployment)
+                - **`refine`**: Automatically clean up failed nodes, keep successful ones (recommended for large deployments)
+
+                **Deployment Options:**
+                - **`hold`**: Create Infra object but hold node provisioning for manual approval
+                - **Normal**: Proceed with immediate node provisioning after resource creation
+
+                **Multi-Cloud Example Configuration:**
+                ```json
+                {
+                "name": "multi-cloud-web-tier",
+                "description": "Web application across AWS, Azure, and GCP",
+                "policyOnPartialFailure": "refine",
+                "nodeGroups": [
+                {
+                "name": "aws-web-servers",
+                "nodeGroupSize": "3",
+                "specId": "aws+us-east-1+t3.medium",
+                "imageId": "ami-0abcdef1234567890",
+                "rootDiskSize": "100",
+                "label": {"tier": "web", "provider": "aws"}
+                },
+                {
+                "name": "azure-api-servers",
+                "nodeGroupSize": "2",
+                "specId": "azure+eastus+Standard_B2s",
+                "imageId": "Canonical:0001-com-ubuntu-server-jammy:22_04-lts",
+                "label": {"tier": "api", "provider": "azure"}
+                }
+                ]
+                }
+                ```
+
+                **Performance Considerations:**
+                - node provisioning occurs in parallel across providers
+                - Network resources are created concurrently where possible
+                - Large deployments (>10 nodes) automatically use optimized batching
+                - Built-in rate limiting prevents CSP API throttling
+
+                **Monitoring and Post-Deployment:**
+                - Optional CB-Dragonfly monitoring agent installation
+                - Custom post-deployment command execution
+                - Real-time status tracking and progress updates
+                - Automatic resource labeling and metadata management
+        PostInfraDynamicCheckRequest:
+            method: post
+            resourcePath: /infraDynamicCheckRequest
+            description: |-
+                **⚠️ DEPRECATED: This endpoint is deprecated and will be removed in a future version. Please use `/infraDynamicReview` instead for comprehensive validation and cost estimation.**
+
+                Validate resource availability and discover optimal connection configurations before creating Infra dynamically.
+                This endpoint provides comprehensive resource validation and connection discovery for Infra planning:
+
+                **Resource Validation Process:**
+                1. **Specification Analysis**: Validates that requested common specs exist and are accessible
+                2. **Provider Discovery**: Identifies available cloud providers and regions for each specification
+                3. **Connectivity Assessment**: Tests connection configurations and CSP API accessibility
+                4. **Quota Verification**: Checks available quotas and resource limits where possible
+                5. **Compatibility Matrix**: Generates matrix of viable spec-provider-region combinations
+
+                **Connection Configuration Discovery:**
+                - **Available Providers**: Lists all configured cloud providers (AWS, Azure, GCP, etc.)
+                - **Active Regions**: Shows available regions per provider with connectivity status
+                - **Specification Mapping**: Maps common specs to provider-specific instance types
+                - **Image Compatibility**: Validates image availability across different providers/regions
+                - **Network Capabilities**: Identifies supported network features and configurations
+
+                **Pre-Deployment Validation:**
+                - **Resource Existence**: Confirms all specified resources exist in system namespace
+                - **Permission Verification**: Validates CSP credentials and required permissions
+                - **API Connectivity**: Tests connection to CSP APIs and service endpoints
+                - **Dependency Resolution**: Identifies any missing dependencies or prerequisites
+
+                **Optimization Recommendations:**
+                - **Cost-Effective Regions**: Suggests regions with lower pricing for specified resources
+                - **Performance Optimization**: Recommends regions with better network performance
+                - **Availability Zone**: Identifies optimal AZ distribution for high availability
+                - **Resource Bundling**: Suggests efficient resource combinations and groupings
+
+                **Output Information:**
+                - **Connection Candidates**: List of viable connection configurations
+                - **Provider Capabilities**: Detailed capabilities matrix per provider
+                - **Resource Status**: Real-time availability status for each requested resource
+                - **Recommendation Summary**: Actionable recommendations for optimal deployment
+
+                **Use Cases:**
+                - Pre-validate Infra configuration before expensive deployment operations
+                - Discover optimal provider/region combinations for cost or performance
+                - Troubleshoot resource availability issues during Infra planning
+                - Generate connection configuration templates for standardized deployments
+                - Assess infrastructure capacity and planning constraints
+
+                **Integration Workflow:**
+                1. Use this endpoint to validate and discover connection options
+                2. Review recommendations and adjust specifications if needed
+                3. Use `/infraDynamicReview` for detailed cost estimation and final validation
+                4. Proceed with `/infraDynamic` using validated configuration
+        PostInfraDynamicFromTemplate:
+            method: post
+            resourcePath: /ns/{nsId}/infra/template/{templateId}
+            description: |-
+                Create a new Infra by applying an Infra Dynamic Template.
+                The template provides the base node configuration, and the apply request
+                allows overriding the Infra name and description.
+
+                **Override Behavior (Phase 1):**
+                - `name` (required): Name for the new Infra
+                - `description` (optional): Overrides the template's description
+                - All other configuration (specs, images, nodegroups) comes from the template
+        PostInfraDynamicNodeGroupNodeReview:
+            method: post
+            resourcePath: /ns/{nsId}/infra/{infraId}/nodeGroupDynamicReview
+            description: |-
+                Review and validate a node dynamic addition request for an existing Infra before actual provisioning.
+                This endpoint provides comprehensive validation for adding new nodes to existing Infras without actually creating resources.
+                It checks resource availability, validates specifications and images, estimates costs, and provides detailed recommendations.
+
+                **Key Features:**
+                - Validates node specification and image against CSP availability
+                - Checks compatibility with existing Infra configuration
+                - Provides cost estimation for the new node addition
+                - Identifies potential configuration issues and warnings
+                - Recommends optimization strategies
+                - Non-invasive validation (no resources are created)
+
+                **Review Status:**
+                - `Ready`: node can be added successfully
+                - `Warning`: node can be added but with configuration warnings
+                - `Error`: Critical errors prevent node addition
+
+                **Infra Integration Validation:**
+                - Ensures target Infra exists and is in a compatible state
+                - Validates network integration possibilities
+                - Checks resource naming conflicts
+                - Verifies security group and SSH key compatibility
+
+                **Use Cases:**
+                - Pre-validation before expensive node addition operations
+                - Cost estimation for scaling decisions
+                - Configuration optimization before deployment
+                - Risk assessment for node addition to existing infrastructure
+        PostInfraDynamicReview:
+            method: post
+            resourcePath: /ns/{nsId}/infraDynamicReview
+            description: |-
+                Review and validate Infra dynamic request comprehensively before actual provisioning.
+                This endpoint performs comprehensive validation of Infra dynamic creation requests without actually creating resources.
+                It checks resource availability, validates specifications and images, estimates costs, and provides detailed recommendations.
+
+                **Key Features:**
+                - Validates all node specifications and images against CSP availability
+                - Provides cost estimation (including partial estimates when some costs are unknown)
+                - Identifies potential configuration issues and warnings
+                - Recommends optimization strategies
+                - Shows provider and region distribution
+                - Non-invasive validation (no resources are created)
+
+                **Review Status:**
+                - `Ready`: All nodes can be created successfully
+                - `Warning`: nodes can be created but with configuration warnings
+                - `Error`: Critical errors prevent Infra creation
+
+                **Use Cases:**
+                - Pre-validation before expensive Infra creation
+                - Cost estimation and planning
+                - Configuration optimization
+                - Multi-cloud resource planning
+        PostInfraDynamicTemplate:
+            method: post
+            resourcePath: /ns/{nsId}/template/infra
+            description: |-
+                Create a reusable Infra Dynamic Template. Templates store Infra dynamic creation
+                request configurations that can be applied later to create Infras with consistent settings.
+
+                **Template Contents:**
+                - node specifications (specId, imageId) for each nodegroup
+                - NodeGroup sizing and naming
+                - Network and disk configuration
+                - Post-deployment commands
+                - Monitoring agent options
+
+                Templates can be created manually or extracted from existing Infras.
+        PostInfraNode:
+            method: post
+            resourcePath: /ns/{nsId}/infra/{infraId}/node
+            description: |-
+                Create and add a group of identical virtual machines (nodegroup) to an existing Infra using detailed specifications.
+                This endpoint provides precise control over node configuration and placement within existing infrastructure:
+
+                **NodeGroup Creation Process:**
+                1. **Infra Integration**: Validates target Infra exists and can accommodate new nodes
+                2. **Resource Validation**: Verifies all specified resources (specs, images, networks) exist and are accessible
+                3. **Homogeneous Deployment**: Creates multiple identical nodes with consistent configuration
+                4. **Network Integration**: Integrates new nodes with existing Infra networking and security policies
+                5. **Group Management**: Establishes nodegroup for collective management and operations
+
+                **Detailed Configuration Control:**
+                - **Specific Resource References**: Uses exact resource IDs rather than common specifications
+                - **Network Placement**: Precise control over VNet, subnet, and security group assignment
+                - **Storage Configuration**: Detailed disk configuration including type, size, and performance tiers
+                - **Instance Customization**: Full control over node specifications, images, and metadata
+                - **Security Settings**: Explicit security group and SSH key configuration
+
+                **NodeGroup Benefits:**
+                - **Collective Operations**: Perform operations on entire nodegroup simultaneously
+                - **Homogeneous Scaling**: All nodes in nodegroup share identical configuration
+                - **Simplified Management**: Single configuration template for multiple nodes
+                - **Consistent Naming**: Automatic sequential naming (e.g., web-1, web-2, web-3)
+                - **Group Policies**: Apply scaling, monitoring, and lifecycle policies at nodegroup level
+
+                **Use Cases:**
+                - **Application Tiers**: Deploy multiple instances of web servers, application servers, or databases
+                - **Load Distribution**: Create multiple identical nodes for load balancing scenarios
+                - **High Availability**: Deploy redundant instances across availability zones
+                - **Batch Processing**: Create worker nodes for distributed computing workloads
+                - **Development Environments**: Provision identical development or testing instances
+
+                **Configuration Requirements:**
+                - **Resource IDs**: Must specify exact resource identifiers (not common specs)
+                - **Network Configuration**: VNet, subnet, and security group must exist and be compatible
+                - **SSH Keys**: Must specify valid SSH key pairs for access management
+                - **Image Compatibility**: Specified image must be available in target region
+                - **Quota Validation**: Sufficient CSP quotas must be available for all requested nodes
+
+                **NodeGroup Size Considerations:**
+                - **Small Groups (1-5 nodes)**: Fast deployment, minimal resource contention
+                - **Medium Groups (6-20 nodes)**: Optimized parallel deployment with resource batching
+                - **Large Groups (21+ nodes)**: Advanced deployment strategies to avoid CSP rate limits
+                - **Resource Limits**: Respects CSP quotas and CB-Tumblebug configuration limits
+
+                **Post-Deployment Integration:**
+                - NodeGroup becomes integral part of parent Infra
+                - All nodes inherit Infra-level monitoring and management policies
+                - Can be scaled out further or individual nodes can be managed separately
+                - Supports all standard CB-Tumblebug node lifecycle operations
+        PostInfraNodeGroupDynamic:
+            method: post
+            resourcePath: /ns/{nsId}/infra/{infraId}/nodeGroupDynamic
+            description: |-
+                Dynamically add new virtual machines to an existing Infra using common specifications and automated resource management.
+                This endpoint provides elastic scaling capabilities for running Infras:
+
+                **Dynamic node Addition Process:**
+                1. **Infra Validation**: Verifies target Infra exists and is in a valid state for expansion
+                2. **Resource Discovery**: Resolves common spec and image to provider-specific resources
+                3. **Network Integration**: Automatically configures new nodes to use existing Infra network resources
+                4. **NodeGroup Management**: Creates new nodegroups or expands existing ones based on configuration
+                5. **Status Synchronization**: Updates Infra status and metadata to reflect new node additions
+
+                **Integration with Existing Infrastructure:**
+                - **Network Reuse**: New nodes automatically join existing VNets and security groups
+                - **SSH Key Sharing**: Uses existing SSH keys for consistent access management
+                - **Monitoring Integration**: New nodes inherit monitoring configuration from parent Infra
+                - **Label Propagation**: Applies Infra-level labels and policies to new nodes
+                - **Resource Consistency**: Maintains naming conventions and resource organization
+
+                **Scaling Scenarios:**
+                - **Horizontal Scaling**: Add more instances to handle increased workload
+                - **Multi-Region Expansion**: Deploy nodes in new regions while maintaining Infra cohesion
+                - **Provider Diversification**: Add nodes from different cloud providers for redundancy
+                - **Workload Specialization**: Deploy nodes with different specifications for specific tasks
+
+                **Configuration Requirements:**
+                - `specId`: Must specify valid node specification from system namespace
+                - `imageId`: Must specify valid image compatible with target provider/region
+                - `name`: Becomes nodegroup name; nodes will be named with sequential suffixes
+                - `nodeGroupSize`: Number of identical nodes to create (default: 1)
+
+                **Network and Security:**
+                - New nodes automatically inherit security group rules from existing Infra
+                - Network connectivity to existing nodes is established automatically
+                - Firewall rules and access policies are applied consistently
+                - SSH access is configured using existing key pairs
+
+                **Example Use Cases:**
+                - Scale out web tier during traffic spikes
+                - Add GPU instances for machine learning workloads
+                - Deploy edge nodes in additional geographic regions
+                - Add specialized storage or database nodes to existing application stack
+
+                **Post-Addition Operations:**
+                - New nodes are immediately available for standard Infra operations
+                - Can be individually managed or grouped with existing nodegroups
+                - Monitoring and logging are automatically configured
+                - Application deployment and configuration management can proceed immediately
+        PostInfraNodeGroupScaleOut:
+            method: post
+            resourcePath: /ns/{nsId}/infra/{infraId}/nodegroup/{nodegroupId}
+            description: |-
+                Horizontally scale an existing node nodegroup by adding more identical instances for increased capacity.
+                This endpoint provides elastic scaling capabilities for running application tiers:
+
+                **Scale-Out Process:**
+                1. **NodeGroup Validation**: Verifies target nodegroup exists and is in scalable state
+                2. **Template Replication**: Uses existing node configuration as template for new instances
+                3. **Resource Allocation**: Ensures sufficient CSP quotas and network resources
+                4. **Parallel Deployment**: Deploys multiple new nodes simultaneously for faster scaling
+                5. **Integration**: Seamlessly integrates new nodes into existing nodegroup and Infra
+
+                **Configuration Inheritance:**
+                - **node Specifications**: New nodes inherit exact specifications from existing nodegroup members
+                - **Network Settings**: Automatically placed in same VNet, subnet, and security groups
+                - **SSH Keys**: Use same SSH key pairs for consistent access management
+                - **Monitoring**: Inherit monitoring agent configuration and policies
+                - **Labels and Metadata**: Propagate all labels and metadata from parent nodegroup
+
+                **Scaling Scenarios:**
+                - **Traffic Spikes**: Quickly add capacity during high-demand periods
+                - **Seasonal Scaling**: Scale out for predictable demand increases
+                - **Performance Optimization**: Add instances to reduce per-node resource utilization
+                - **Geographic Expansion**: Scale existing workloads to handle broader user base
+                - **Fault Tolerance**: Increase redundancy by adding more instances
+
+                **Intelligent Scaling:**
+                - **Sequential Naming**: New nodes follow established naming pattern (e.g., web-4, web-5, web-6)
+                - **Load Distribution**: New nodes are distributed optimally across availability zones
+                - **Resource Efficiency**: Reuses existing network and security infrastructure
+                - **Minimal Disruption**: Scaling occurs without affecting existing node operations
+                - **Consistent Configuration**: Ensures all nodes in nodegroup remain homogeneous
+
+                **Operational Benefits:**
+                - **Zero Downtime**: Existing nodes continue running during scale-out operation
+                - **Immediate Availability**: New nodes are ready for traffic as soon as deployment completes
+                - **Unified Management**: All nodes (old and new) managed through single nodegroup
+                - **Policy Consistency**: All scaling and management policies apply uniformly
+                - **Monitoring Integration**: New nodes automatically included in existing monitoring dashboards
+
+                **Scale-Out Considerations:**
+                - **CSP Quotas**: Verifies sufficient instance, network, and storage quotas
+                - **Region Capacity**: Ensures target region has capacity for requested instance types
+                - **Network Limits**: Validates that VNet can accommodate additional nodes
+                - **Cost Impact**: Additional nodes incur proportional CSP billing costs
+                - **Application Readiness**: Applications should be designed to handle additional instances
+
+                **Post-Scale Operations:**
+                - New nodes immediately participate in nodegroup operations
+                - Can be individually managed while maintaining nodegroup membership
+                - Support for further scaling operations (scale-out or scale-in)
+                - Ready for application deployment and load balancer integration
+
+                **Best Practices:**
+                - Monitor application performance before and after scaling
+                - Ensure load balancers are configured to include new instances
+                - Verify application clustering and session management handle new instances
+                - Consider database connection limits and other resource constraints
+        PostInfraNodeSnapshot:
+            method: post
+            resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}/snapshot
+            description: Snapshot node and create a Custom Image Object using the Snapshot
+        PostInfraPolicy:
+            method: post
+            resourcePath: /ns/{nsId}/policy/infra/{infraId}
+            description: Create Infra Automation policy
+        PostInfraSnapshot:
+            method: post
+            resourcePath: /ns/{nsId}/infra/{infraId}/snapshot
+            description: Create snapshots for the first running node in each nodegroup of an Infra in parallel
+        PostInstallBenchmarkAgentToInfra:
+            method: post
+            resourcePath: /ns/{nsId}/installBenchmarkAgent/infra/{infraId}
+            description: Install the benchmark agent to specified Infra
+        PostInstallMonitorAgentToInfra:
+            method: post
+            resourcePath: /ns/{nsId}/monitoring/install/infra/{infraId}
+            description: Install monitoring agent (CB-Dragonfly agent) to Infra
+        PostK8sCluster:
+            method: post
+            resourcePath: /ns/{nsId}/k8sCluster
+            description: Create K8sCluster<br>Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1614
+        PostK8sClusterDynamic:
+            method: post
+            resourcePath: /ns/{nsId}/k8sClusterDynamic
+            description: Create K8sCluster Dynamically from common spec and image
+        PostK8sClusterDynamicCheckRequest:
+            method: post
+            resourcePath: /k8sClusterDynamicCheckRequest
+            description: Check available ConnectionConfig list before create K8sCluster Dynamically from common spec and image
+        PostK8sMultiClusterDynamic:
+            method: post
+            resourcePath: /ns/{nsId}/k8sMultiClusterDynamic
+            description: |-
+                (PoC API. For developers only, and do not use in production.)
+                Create multiple K8sClusters in parallel from common spec and image.
+                If namePrefix is provided, cluster names will be auto-generated as '{namePrefix}-{csp}-{number}' (e.g., 'across-aws-1', 'across-alibaba-2').
+
+                If namePrefix is not provided, each cluster must have a name specified.
+
+                **Example request body:**
+                ```json
+                {
+                "namePrefix": "across",
+                "clusters": [
+                {
+                "imageId": "default",
+                "specId": "aws+eu-west-2+t3a.xlarge"
+                },
+                {
+                "nodeGroupName": "ng-1",
+                "imageId": "default",
+                "specId": "azure+germanywestcentral+standard_b4ms"
+                },
+                {
+                "nodeGroupName": "ng-1",
+                "imageId": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-2204-jammy-v20251120",
+                "specId": "gcp+europe-west9+e2-highmem-4"
+                }
+                ]
+                }
+                ```
+        PostK8sNodeGroup:
+            method: post
+            resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup
+            description: Add a K8sNodeGroup
+        PostK8sNodeGroupDynamic:
+            method: post
+            resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroupDynamic
+            description: Create K8sNodeGroup Dynamically from common spec and image
+        PostMcNLB:
+            method: post
+            resourcePath: /ns/{nsId}/infra/{infraId}/mcSwNlb
+            description: Create a special purpose Infra for NLB and depoly and setting SW NLB
+        PostNLB:
+            method: post
+            resourcePath: /ns/{nsId}/infra/{infraId}/nlb
+            description: Create NLB
+        PostNodeDataDisk:
+            method: post
+            resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}/dataDisk
+            description: Provisioning (Create and attach) dataDisk
+        PostNs:
+            method: post
+            resourcePath: /ns
+            description: Create namespace
+        PostRegisterCSPNativeNode:
+            method: post
+            resourcePath: /ns/{nsId}/registerCspNode
+            description: |-
+                Import and register pre-existing virtual machines from cloud service providers into CB-Tumblebug management.
+                This endpoint allows you to bring existing CSP resources under CB-Tumblebug control without recreating them:
+
+                **Registration Process:**
+                1. **Discovery**: Validates that the specified node exists in the target CSP
+                2. **Metadata Import**: Retrieves node configuration, network settings, and current status
+                3. **Resource Mapping**: Creates CB-Tumblebug resource objects that reference the existing CSP resources
+                4. **Status Synchronization**: Aligns CB-Tumblebug status with actual CSP node state
+                5. **Management Integration**: Enables CB-Tumblebug operations on the registered nodes
+
+                **Supported node States:**
+                - Running nodes (most common use case)
+                - Stopped nodes (will be registered with current state)
+                - nodes with attached storage and network interfaces
+
+                **Resource Compatibility:**
+                - node must exist in a supported CSP (AWS, Azure, GCP, etc.)
+                - Network resources (VPC, subnets, security groups) will be discovered and mapped
+                - Storage volumes and attached disks will be registered automatically
+                - SSH keys and security configurations will be imported
+
+                **Post-Registration Capabilities:**
+                - Standard CB-Tumblebug node lifecycle operations (start, stop, terminate)
+                - Monitoring agent installation (if CB-Dragonfly is configured)
+                - Command execution and automation
+                - Integration with other CB-Tumblebug Infras
+
+                **Important Notes:**
+                - Registration does not modify the existing node configuration
+                - Original CSP billing and resource management still applies
+                - CB-Tumblebug provides additional management layer and automation
+                - Ensure proper CSP credentials and permissions are configured
+        PostRegisterSubnet:
+            method: post
+            resourcePath: /ns/{nsId}/registerCspResource/vNet/{vNetId}/subnet
+            description: Register Subnet, which was created in CSP
+        PostRegisterVNet:
+            method: post
+            resourcePath: /ns/{nsId}/registerCspResource/vNet
+            description: Register the VNet, which was created in CSP
+        PostScheduleRegisterCspResources:
+            method: post
+            resourcePath: /registerCspResources/schedule
+            description: |-
+                Create a scheduled job to periodically register CSP-native resources (vNet, securityGroup, sshKey, node) into CB-Tumblebug
+
+                **Resource Registration Behavior:**
+                This job registers CSP-native resources based on the `connectionName` field:
+                - If `connectionName` is specified: Registers resources from the **specified connection only**
+                - If `connectionName` is empty or omitted: Registers resources from **all available connections**
+
+                **Usage Examples:**
+                - Single connection: `{"jobType": "registerCspResources", "nsId": "default", "intervalSeconds": 60, "connectionName": "aws-ap-northeast-2", "infraNamePrefix": "infra-01"}`
+                - All connections: `{"jobType": "registerCspResources", "nsId": "default", "intervalSeconds": 60, "connectionName": "", "infraNamePrefix": "infra-all"}` or `{"jobType": "registerCspResources", "nsId": "default", "intervalSeconds": 60, "infraNamePrefix": "infra-all"}`
+
+                **Job Status Values:**
+                - `Scheduled`: Job is scheduled and waiting for the next execution time
+                - `Executing`: Job is currently running the task
+                - `Stopped`: Job has been stopped and deleted
+
+                **Job Lifecycle:**
+                1. Create job (this API) → Status: `Scheduled`, **executes immediately**
+                2. First execution starts → Status: `Executing`
+                3. Execution completes → Status: `Scheduled` (waits for interval)
+                4. After interval → Status: `Executing` (cycles back to step 3)
+                5. Pause job → `enabled: false`, Status: `Scheduled` (no execution)
+                6. Resume job → `enabled: true`, Status: `Scheduled` (resumes execution)
+                7. Delete job → Status: `Stopped`, job removed permanently
+
+                **Failure Handling:**
+                - Tracks `successCount`, `failureCount`, `consecutiveFailures`
+                - Auto-disables after 5 consecutive failures (`autoDisabled: true`)
+                - Auto-recovers when next execution succeeds
+
+                **Timeout Protection:**
+                - Default execution timeout: 30 minutes
+                - Jobs exceeding timeout are marked as failed
+                - Server restart during execution marks job as interrupted
+
+                **Duplicate Prevention:**
+                - System checks for existing jobs with same configuration
+                - Configuration uniqueness based on: jobType + nsId + connectionName + infraNamePrefix + option + infraFlag
+                - Returns 409 Conflict if duplicate job exists with existing job ID
+        PostSecurityGroup:
+            method: post
+            resourcePath: /ns/{nsId}/resources/securityGroup
+            description: Create Security Group
+        PostSecurityGroupFromTemplate:
+            method: post
+            resourcePath: /ns/{nsId}/resources/securityGroup/template/{templateId}
+            description: |-
+                Create a new SecurityGroup by applying a SecurityGroup Template.
+                The template provides the base SecurityGroup configuration (connectionName, vNetId, firewallRules),
+                and the apply request allows overriding the SecurityGroup name and description.
+
+                **Override Behavior (Phase 1):**
+                - `name` (required): Name for the new SecurityGroup
+                - `description` (optional): Overrides the template's description
+                - All other configuration (connectionName, vNetId, firewallRules) comes from the template
+        PostSecurityGroupTemplate:
+            method: post
+            resourcePath: /ns/{nsId}/template/securityGroup
+            description: |-
+                Create a reusable SecurityGroup Template. Templates store SecurityGroup creation
+                request configurations that can be applied later to create SecurityGroups with consistent settings.
+
+                **Template Contents:**
+                - Connection name (cloud provider and region)
+                - vNet ID for the security group
+                - Firewall rules (ports, protocol, direction, CIDR)
+                - Description
+
+                Templates can be created manually with desired SecurityGroup configurations.
+        PostSiteToSiteVpn:
+            method: post
+            resourcePath: /ns/{nsId}/infra/{infraId}/vpn
+            description: |
+                Create a site-to-site VPN
+
+                The supported CSP sets are as follows:
+
+                - AWS and one of CSPs in Azure, GCP, Alibaba, Tencent, and IBM
+
+                - Note: It will take about `15 ~ 45 minutes`.
+
+                - Note: A one-time retry is performed to handle transient failures caused by CSP-internal timing issues between dependent resources.
+        PostSpec:
+            method: post
+            resourcePath: /ns/{nsId}/resources/spec
+            description: Register spec
+        PostSpecImagePairReview:
+            method: post
+            resourcePath: /specImagePairReview
+            description: |-
+                Validate whether a spec and image pair is compatible for node provisioning.
+                This lightweight API checks:
+                - Spec availability in DB and CSP
+                - Image availability in DB and CSP (auto-registers if found in CSP but not in DB)
+                - Cost estimation based on spec
+
+                **Use Cases:**
+                - Quick validation before node creation
+                - Pre-check for dynamic provisioning
+                - Verify custom image IDs entered by user
+        PostSqlDb:
+            method: post
+            resourcePath: /ns/{nsId}/resources/sqlDb
+            description: |
+                Create a SQL Databases
+
+                Supported CSPs: AWS, Azure, GCP, NCP
+                - Note - `connectionName` example: aws-ap-northeast-2, azure-koreacentral, gcp-asia-northeast3, ncp-kr
+
+                - Note - Please check the `requiredCSPResource` property which includes CSP specific values.
+
+                - Note - You can find the API usage examples on this link, https://github.com/cloud-barista/mc-terrarium/discussions/110
+        PostSshKey:
+            method: post
+            resourcePath: /ns/{nsId}/resources/sshKey
+            description: Create SSH Key
+        PostSubnet:
+            method: post
+            resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/subnet
+            description: Create Subnet
+        PostSystemInfra:
+            method: post
+            resourcePath: /systemInfra
+            description: |-
+                Create specialized Infra instances for CB-Tumblebug system operations and infrastructure probing.
+                This endpoint provisions system-level infrastructure that supports CB-Tumblebug's internal functions:
+
+                **System Infra Types:**
+                - `probe`: Creates lightweight nodes for network connectivity testing and CSP capability discovery
+                - `monitor`: Deploys monitoring infrastructure for system health and performance tracking
+                - `test`: Provisions test environments for validating CSP integrations and features
+
+                **Probe Infra Features:**
+                - **Connectivity Testing**: Validates network paths between different CSP regions
+                - **Latency Measurement**: Measures inter-region and inter-provider network performance
+                - **Feature Discovery**: Tests CSP-specific capabilities and service availability
+                - **Resource Validation**: Verifies that CB-Tumblebug can successfully provision resources
+
+                **System Namespace:**
+                - All system Infras are created in the special `system` namespace
+                - Isolated from user workloads and regular Infra operations
+                - Managed automatically by CB-Tumblebug internal processes
+                - May be used for background maintenance and monitoring tasks
+
+                **Automatic Configuration:**
+                - Uses optimized node specifications for system tasks (typically minimal resources)
+                - Automatically selects appropriate regions and providers based on probe requirements
+                - Configures necessary network access and security policies
+                - Deploys with minimal attack surface and security hardening
+
+                **Lifecycle Management:**
+                - System Infras may be automatically created, updated, or destroyed by CB-Tumblebug
+                - Typically short-lived for specific system tasks
+                - Resource cleanup is handled automatically
+                - Status and results are logged for system administrators
+
+                **Use Cases:**
+                - Infrastructure health checks and validation
+                - Performance benchmarking across cloud providers
+                - Automated testing of new CSP integrations
+                - Network topology discovery and optimization
+        PostTestStreamResponse:
+            method: post
+            resourcePath: /testStreamResponse
+            description: Receives a number and streams the decrementing number every second until zero
+        PostUtilToDesignNetwork:
+            method: post
+            resourcePath: /util/net/design
+            description: Design a hierarchical network configuration of a VPC network or multi-cloud network consisting of multiple VPC networks
+        PostUtilToDesignVNet:
+            method: post
+            resourcePath: /util/vNet/design
+            description: Design VNet and subnets based on user-friendly properties
+        PostUtilToValidateNetwork:
+            method: post
+            resourcePath: /util/net/validate
+            description: Validate a hierarchical configuration of a VPC network or multi-cloud network consisting of multiple VPC networks
+        PostVNet:
+            method: post
+            resourcePath: /ns/{nsId}/resources/vNet
+            description: Create a new VNet
+        PostVNetFromTemplate:
+            method: post
+            resourcePath: /ns/{nsId}/resources/vNet/template/{templateId}
+            description: |-
+                Create a new vNet by applying a vNet Template.
+                The template provides the base vNet configuration (connectionName, cidrBlock, subnets),
+                and the apply request allows overriding the vNet name and description.
+
+                **Override Behavior (Phase 1):**
+                - `name` (required): Name for the new vNet
+                - `description` (optional): Overrides the template's description
+                - All other configuration (connectionName, cidrBlock, subnets) comes from the template
+        PostVNetTemplate:
+            method: post
+            resourcePath: /ns/{nsId}/template/vNet
+            description: |-
+                Create a reusable vNet Template. Templates store vNet creation
+                request configurations that can be applied later to create vNets with consistent settings.
+
+                **Template Contents:**
+                - Connection name (cloud provider and region)
+                - CIDR block configuration
+                - Subnet definitions (names, CIDR blocks, zones)
+                - Description
+
+                Templates can be created manually with desired vNet configurations.
+        PostVpnHealthCheck:
+            method: post
+            resourcePath: /ns/{nsId}/infra/{infraId}/vpn/{vpnId}/health
+            description: |-
+                Perform a bidirectional ping test on a site-to-site VPN using existing Infra nodes and return the results.
+
+                It finds nodes that belong to the VPN's two sites and runs ping tests
+                in both directions (site1→site2 and site2→site1) via private IP.
+                The VPN is considered healthy only when both directions succeed.
+
+                A retry strategy is used with configurable interval and max attempts
+                (default: 15s interval, 20 attempts).
+        PutChangeK8sNodeGroupAutoscaleSize:
+            method: put
+            resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}/autoscaleSize
+            description: Change a K8sNodeGroup's Autoscale Size
+        PutDataDisk:
+            method: put
+            resourcePath: /ns/{nsId}/resources/dataDisk/{dataDiskId}
+            description: Upsize Data Disk
+        PutGlobalDnsRecord:
+            method: put
+            resourcePath: /resources/globalDns/record
+            description: |-
+                Update (UPSERT) a DNS record for a domain in Route53.
+                Supports two routing policies: "simple" (default) and "geoproximity" (location-based).
+                Choose exactly one IP source method in 'setBy':
+                1. Infra ID (infraId): Fetch Public IPs of all nodes in the Infra.
+                2. Label Selector (labelSelector): Fetch IPs of matching resources.
+                3. Manual IP Values (values): Manually provide IP addresses (simple routing only).
+        PutImage:
+            method: put
+            resourcePath: /ns/{nsId}/resources/image/{imageId}
+            description: Update image
+        PutInfraAssociatedSecurityGroups:
+            method: put
+            resourcePath: /ns/{nsId}/infra/{infraId}/associatedSecurityGroups
+            description: |-
+                Update all Security Groups associated with a given Infra. The firewall rules of all Security Groups will be synchronized to match the requested set.
+                Update all Security Groups associated with a given Infra. The firewall rules of all associated Security Groups will be synchronized to match the requested set.
+
+                This API will add missing rules and delete extra rules so that each Security Group's rules become identical to the requested set.
+                Only firewall rules are updated; other metadata (name, description, etc.) is not changed.
+
+                Usage:
+                Use this API to update (synchronize) the firewall rules of all Security Groups associated with the specified Infra. The rules in the request body will become the only rules in each Security Group after the operation.
+                - All existing rules not present in the request will be deleted.
+                - All rules in the request that do not exist will be added.
+                - If a rule exists but differs in CIDR or port range, it will be replaced.
+                - Special protocols (ICMP, etc.) are handled in the same way.
+
+                Notes:
+                - "Ports" field supports single port ("22"), port range ("80-100"), and multiple ports/ranges ("22,80-100,443").
+                - The valid port number range is 0 to 65535 (inclusive).
+                - "Protocol" can be TCP, UDP, ICMP, etc. (as supported by the cloud provider).
+                - "Direction" must be either "inbound" or "outbound".
+                - "CIDR" is the allowed IP range.
+                - All existing rules not in the request (including default ICMP, etc.) will be deleted.
+                - Metadata (name, description, etc.) is not changed.
+        PutInfraDynamicTemplate:
+            method: put
+            resourcePath: /ns/{nsId}/template/infra/{templateId}
+            description: Update an existing Infra Dynamic Template.
+        PutMonitorAgentStatusInstalled:
+            method: put
+            resourcePath: /ns/{nsId}/monitoring/status/infra/{infraId}/node/{nodeId}
+            description: Set monitoring agent (CB-Dragonfly agent) installation status installed (for Windows node only)
+        PutNodeDataDisk:
+            method: put
+            resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}/dataDisk
+            description: Attach/Detach available dataDisk
+        PutNs:
+            method: put
+            resourcePath: /ns/{nsId}
+            description: Update namespace
+        PutScheduleRegisterCspResources:
+            method: put
+            resourcePath: /registerCspResources/schedule/{jobId}
+            description: |-
+                Update the configuration of a scheduled CSP resource registration job (interval, enabled status)
+
+                **Updatable Fields:**
+                - `intervalSeconds`: Change execution frequency (minimum 10 seconds)
+                - `enabled`: Enable (true) or disable (false) the job
+
+                **Usage Examples:**
+                - Change interval: `{"intervalSeconds": 30}` (30 seconds)
+                - Pause job: `{"enabled": false}`
+                - Resume job: `{"enabled": true}`
+                - Change both: `{"intervalSeconds": 10, "enabled": true}`
+
+                **Note:** For simpler pause/resume operations, consider using dedicated `/pause` and `/resume` endpoints
+        PutScheduleRegisterCspResourcesPause:
+            method: put
+            resourcePath: /registerCspResources/schedule/{jobId}/pause
+            description: |-
+                Temporarily pause a scheduled job without deleting it. The job can be resumed later.
+                This sets enabled=false and preserves all job state and execution history.
+        PutScheduleRegisterCspResourcesResume:
+            method: put
+            resourcePath: /registerCspResources/schedule/{jobId}/resume
+            description: |-
+                Resume a previously paused scheduled job to continue periodic execution.
+                This sets enabled=true and restarts the job scheduler.
+        PutSecurityGroup:
+            method: put
+            resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}
+            description: |-
+                Update Security Group: Synchronize the firewall rules of the specified Security Group to match the requested list exactly.
+                This API will add missing rules and delete extra rules so that the Security Group's rules become identical to the requested set.
+                Only firewall rules are updated; other metadata (name, description, etc.) is not changed.
+
+                Usage:
+                Use this API to update (synchronize) the firewall rules of a Security Group. The rules in the request body will become the only rules in the Security Group after the operation.
+                - All existing rules not present in the request will be deleted.
+                - All rules in the request that do not exist will be added.
+                - If a rule exists but differs in CIDR or port range, it will be replaced.
+                - Special protocols (ICMP, etc.) are handled in the same way.
+
+                Notes:
+                - "Ports" field supports single port ("22"), port range ("80-100"), and multiple ports/ranges ("22,80-100,443").
+                - The valid port number range is 0 to 65535 (inclusive).
+                - "Protocol" can be TCP, UDP, ICMP, etc. (as supported by the cloud provider).
+                - "Direction" must be either "inbound" or "outbound".
+                - "CIDR" is the allowed IP range.
+                - All existing rules not in the request (including default ICMP, etc.) will be deleted.
+                - Metadata (name, description, etc.) is not changed.
+        PutSecurityGroupTemplate:
+            method: put
+            resourcePath: /ns/{nsId}/template/securityGroup/{templateId}
+            description: Update an existing SecurityGroup Template.
+        PutSetK8sNodeGroupAutoscaling:
+            method: put
+            resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}/onAutoscaling
+            description: Set a K8sNodeGroup's Autoscaling On/Off
+        PutSpec:
+            method: put
+            resourcePath: /ns/{nsId}/resources/spec/{specId}
+            description: Update spec
+        PutSshKey:
+            method: put
+            resourcePath: /ns/{nsId}/resources/sshKey/{sshKeyId}
+            description: Update SSH Key
+        PutUpgradeK8sCluster:
+            method: put
+            resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/upgrade
+            description: Upgrade a K8sCluster's version
+        PutVNetTemplate:
+            method: put
+            resourcePath: /ns/{nsId}/template/vNet/{templateId}
+            description: Update an existing vNet Template.
+        RecommendK8sNode:
+            method: post
+            resourcePath: /k8sClusterRecommendNode
+            description: Recommend K8sCluster's Node plan (filter and priority) Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234
+        RecommendSpec:
+            method: post
+            resourcePath: /recommendSpec
+            description: |-
+                Recommend specs for configuring an infrastructure (filter and priority)
+                Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234
+                Get available options by /recommendSpecOptions for filtering and prioritizing specs in RecommendSpec API
+        RecommendSpecOptions:
+            method: get
+            resourcePath: /recommendSpecOptions
+            description: Get available options for filtering and prioritizing specs in RecommendSpec API
+        RecordProvisioningEvent:
+            method: post
+            resourcePath: /provisioning/event
+            description: |-
+                Manually record a provisioning success or failure event for historical tracking and analysis.
+                This endpoint allows external systems or manual processes to contribute to provisioning history:
+
+                **Use Cases:**
+                - **External Provisioning Tools**: Record events from non-CB-Tumblebug provisioning systems
+                - **Manual Testing**: Log results from manual deployment tests
+                - **Migration**: Import historical data from other systems
+                - **Integration**: Connect with CI/CD pipelines for comprehensive tracking
+
+                **Event Types:**
+                - **Success Events**: Only recorded if previous failures exist for the spec
+                - **Failure Events**: Always recorded to build failure pattern database
+
+                **Data Quality:**
+                - Provide accurate timestamps for proper chronological analysis
+                - Include detailed error messages for failure events
+                - Use consistent spec ID and image name formats
+
+                **Impact on System:**
+                - Contributes to risk analysis algorithms
+                - Affects future Infra review recommendations
+                - Builds historical baseline for reliability metrics
+        RegisterCredential:
+            method: post
+            resourcePath: /credential
+            description: This API registers credential information using hybrid encryption. The process involves compressing and encrypting sensitive data with AES-256, encrypting the AES key with a 4096-bit RSA public key (retrieved via `GET /credential/publicKey`), and using OAEP padding with SHA-256. All values, including the AES key, must be base64 encoded before sending, and the public key token ID must be included in the request.
+        RegisterCspNativeResources:
+            method: post
+            resourcePath: /registerCspResources
+            description: |-
+                Register CSP Native Resources (vNet, securityGroup, sshKey, node) to CB-Tumblebug.
+
+                **New filtering approach (recommended):**
+                - Provider only: Registers resources from all connections of the specified provider
+                - Provider + Region: Registers resources from all zones within the region
+                - Provider + Region + Zone: Registers resources from specific zone
+                - All empty: Registers resources from **all available connections**
+
+                **Backward compatibility:**
+                - `connectionName` is still supported but deprecated. Use provider/region/zone instead.
+
+                **Usage Examples:**
+                - All AWS: `{"provider": "aws", "nsId": "default"}`
+                - AWS Seoul region: `{"provider": "aws", "region": "ap-northeast-2", "nsId": "default"}`
+                - AWS Seoul zone 2a: `{"provider": "aws", "region": "ap-northeast-2", "zone": "ap-northeast-2a", "nsId": "default"}`
+                - All connections: `{"nsId": "default", "infraNamePrefix": "infra-all"}`
+                - Single connection (deprecated): `{"connectionName": "aws-ap-northeast-2", "nsId": "default"}`
+        RegisterCspNativeResourcesAll:
+            method: post
+            resourcePath: /registerCspResourcesAll
+            description: |-
+                **DEPRECATED**: This endpoint is deprecated. Please use `/registerCspResources` with empty `connectionName` instead.
+
+                This endpoint now redirects to `/registerCspResources` for unified API behavior.
+
+                **Migration Guide:**
+                - Old: `POST /registerCspResourcesAll` with `{"nsId": "default", "infraNamePrefix": "infra-all"}`
+                - New: `POST /registerCspResources` with `{"connectionName": "", "nsId": "default", "infraNamePrefix": "infra-all"}`
+        RemoveBastionNodes:
+            method: delete
+            resourcePath: /ns/{nsId}/infra/{infraId}/bastion/{bastionNodeId}
+            description: Remove a bastion node from all vNets
+        RemoveBastionNodesWithInfra:
+            method: delete
+            resourcePath: /ns/{nsId}/infra/{infraId}/bastion/{bastionInfraId}/{bastionNodeId}
+            description: Remove a specific cross-Infra bastion from all vNets of the target Infra
+        RemoveBastionNodesWithNs:
+            method: delete
+            resourcePath: /ns/{nsId}/infra/{infraId}/bastion/{bastionNsId}/{bastionInfraId}/{bastionNodeId}
+            description: Remove a specific cross-namespace bastion from all vNets of the target Infra
+        RemoveLabel:
+            method: delete
+            resourcePath: /label/{labelType}/{uid}/{key}
+            description: Remove a label from a resource identified by its uid
+        RemoveNLBNodes:
+            method: delete
+            resourcePath: /ns/{nsId}/infra/{infraId}/nlb/{nlbId}/node
+            description: Delete nodes from NLB
+        RestDeleteObjectStorage:
+            method: delete
+            resourcePath: /ns/{nsId}/resources/objectStorage/{osId}
+            description: |-
+                Delete an object storage (bucket).
+
+                **Query option (mutually exclusive — specify at most one):**
+
+                | option | Description |
+                |--------|-------------|
+                | (none) | Standard delete. Fails if the bucket is not empty. |
+                | `empty` | Empty the bucket first, then delete. |
+                | `force` | Force delete bucket with all contents (passed to Spider as `force=true`). Behaviour varies by CSP; use when standard delete is not sufficient. |
+                | `reconcile` | Do not call the CSP delete API. Instead, check whether the CSP bucket actually exists and remove only the Tumblebug metadata if the bucket is absent. Use this to clean up orphaned metadata that cannot be deleted through normal means (e.g., a bucket stuck in `Failed` status after a partial creation or a CSP-side deletion error such as Tencent 405). Returns a reconcile result object instead of 204. |
+        RetrieveRegionListFromCsp:
+            method: get
+            resourcePath: /regionFromCsp
+            description: RetrieveR all region lists from CSPs
+        SearchImage:
+            method: post
+            resourcePath: /ns/{nsId}/resources/searchImage
+            description: Search image
+        SearchImageOptions:
+            method: get
+            resourcePath: /ns/{nsId}/resources/searchImageOptions
+            description: Get all available options for image search fields
+        SetBastionNodes:
+            method: put
+            resourcePath: /ns/{nsId}/infra/{infraId}/node/{targetNodeId}/bastion/{bastionNodeId}
+            description: Set bastion nodes for a node
+        SetBastionNodesWithInfra:
+            method: put
+            resourcePath: /ns/{nsId}/infra/{infraId}/node/{targetNodeId}/bastion/{bastionInfraId}/{bastionNodeId}
+            description: Set bastion nodes for a target node, specifying a bastion node that belongs to a different Infra within the same namespace (cross-Infra bastion). This allows, for example, an AWS node to serve as a bastion for an OpenStack node.
+        SetBastionNodesWithNs:
+            method: put
+            resourcePath: /ns/{nsId}/infra/{infraId}/node/{targetNodeId}/bastion/{bastionNsId}/{bastionInfraId}/{bastionNodeId}
+            description: Set bastion nodes for a target node, specifying a bastion node that belongs to a different namespace and Infra (cross-namespace bastion). This allows, for example, a node in a shared-services namespace to act as a bastion for nodes in other namespaces.
+        SetObjectStorageCORS:
+            method: put
+            resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/cors
+            description: Set CORS configuration of an object storage (bucket)
+        SetObjectStorageCORSLagacy:
+            method: put
+            resourcePath: /resources/objectStorage/{objectStorageName}/cors
+            description: |-
+                (To be deprecated) Set CORS configuration of an object storage (bucket)
+
+                **Important Notes:**
+                - The CORS configuration must be provided in the request body in XML format.
+                - The actual request body should have root element `CORSConfiguration`
+
+                **Actual XML Request Body Example:**
+                ```xml
+                <?xml version="1.0" encoding="UTF-8"?>
+                <CORSConfiguration>
+                <CORSRule>
+                <AllowedOrigin>https://example.com</AllowedOrigin>
+                <AllowedOrigin>https://app.example.com</AllowedOrigin>
+                <AllowedMethod>GET</AllowedMethod>
+                <AllowedMethod>PUT</AllowedMethod>
+                <AllowedHeader>Content-Type</AllowedHeader>
+                <AllowedHeader>Authorization</AllowedHeader>
+                <ExposeHeader>ETag</ExposeHeader>
+                <MaxAgeSeconds>1800</MaxAgeSeconds>
+                </CORSRule>
+                <CORSRule>
+                <AllowedOrigin>*</AllowedOrigin>
+                <AllowedMethod>GET</AllowedMethod>
+                <MaxAgeSeconds>300</MaxAgeSeconds>
+                </CORSRule>
+                </CORSConfiguration>
+                ```
+        SetObjectStorageVersioning:
+            method: put
+            resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/versioning
+            description: |
+                Set versioning configuration of an object storage (bucket)
+
+                **Note: **
+                - Versioning options: "Enabled", "Suspended", "Unversioned"
+        SetObjectStorageVersioningLagacy:
+            method: put
+            resourcePath: /resources/objectStorage/{objectStorageName}/versioning
+            description: |-
+                (To be deprecated) Set versioning status of an object storage (bucket)
+
+                **Important Notes:**
+                - The request body must be XML format with root element `VersioningConfiguration`
+                - The `Status` field can be either `Enabled` or `Suspended`
+
+                **Request Body Example:**
+                ```xml
+                <?xml version="1.0" encoding="UTF-8"?>
+                <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <Status>Enabled</Status>
+                </VersioningConfiguration>
+                ```
+        SetSystemInitialized:
+            method: put
+            resourcePath: /readyz/init
+            description: Set the system initialization status to true. Called by init.py after completing initialization.
+        TestJWTAuth:
+            method: get
+            resourcePath: /auth/test
+            description: Test JWT authentication
+        UnsetSystemInitialized:
+            method: delete
+            resourcePath: /readyz/init
+            description: Reset the system initialization status to false. Useful for re-initialization scenarios.
+        UpdateExistingSpecListByAvailableRegionZones:
+            method: post
+            resourcePath: /ns/{nsId}/updateExistingSpecListByAvailableRegionZones
+            description: Query all specs for a specific provider across all regions, check their availability, and remove specs that are not available in their respective regions
+        UpdateImagesFromAsset:
+            method: post
+            resourcePath: /updateImagesFromAsset
+            description: Update image information based on the cloudimage.csv asset file
     mc-workflow-manager:
         _meta:
             version: 0.5.0
             repository: https://github.com/m-cmp/mc-workflow-manager
-            generatedAt: "2026-03-03T01:56:15Z"
+            generatedAt: "2026-06-01T02:11:43Z"
         checkConnectionUsingGET:
             method: get
             resourcePath: /readyz

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -9409,6 +9409,129 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update the details of an existing user.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Update user",
+                "operationId": "updateUser",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "User Info",
+                        "name": "user",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.User"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.User"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete a user by their ID.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Delete user",
+                "operationId": "deleteUser",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/users/id/{userId}/access-summary": {
@@ -10962,131 +11085,6 @@ const docTemplate = `{
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/model.RoleMaster"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/users/{id}": {
-            "put": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Update the details of an existing user.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "users"
-                ],
-                "summary": "Update user",
-                "operationId": "updateUser",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "User ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "User Info",
-                        "name": "user",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/model.User"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/model.User"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Delete a user by their ID.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "users"
-                ],
-                "summary": "Delete user",
-                "operationId": "deleteUser",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "User ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
                             }
                         }
                     },

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -4861,7 +4861,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Register or update menus from a local YAML file specified by the filePath query parameter, or from the MCWEBCONSOLE_MENUYAML URL in .env if not provided. If loaded from URL, the file is saved to asset/menu/menu.yaml.",
+                "description": "Register or update menus from a local YAML file specified by the filePath query parameter, or from the MC_WEB_CONSOLE_MENUYAML URL in .env if not provided. If loaded from URL, the file is saved to asset/menu/menu.yaml.",
                 "consumes": [
                     "application/json"
                 ],
@@ -9403,6 +9403,129 @@
                         }
                     }
                 }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update the details of an existing user.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Update user",
+                "operationId": "updateUser",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "User Info",
+                        "name": "user",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.User"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.User"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete a user by their ID.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Delete user",
+                "operationId": "deleteUser",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/users/id/{userId}/access-summary": {
@@ -10956,131 +11079,6 @@
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/model.RoleMaster"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/users/{id}": {
-            "put": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Update the details of an existing user.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "users"
-                ],
-                "summary": "Update user",
-                "operationId": "updateUser",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "User ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "User Info",
-                        "name": "user",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/model.User"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/model.User"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Delete a user by their ID.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "users"
-                ],
-                "summary": "Delete user",
-                "operationId": "deleteUser",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "User ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
                             }
                         }
                     },

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -5046,8 +5046,8 @@ paths:
       consumes:
       - application/json
       description: Register or update menus from a local YAML file specified by the
-        filePath query parameter, or from the MC_WEB_CONSOLE_MENUYAML URL in .env if
-        not provided. If loaded from URL, the file is saved to asset/menu/menu.yaml.
+        filePath query parameter, or from the MC_WEB_CONSOLE_MENUYAML URL in .env
+        if not provided. If loaded from URL, the file is saved to asset/menu/menu.yaml.
       operationId: registerMenusFromYAML
       parameters:
       - description: YAML file path (optional, uses .env URL or default local path
@@ -7942,87 +7942,6 @@ paths:
       summary: Create new user
       tags:
       - users
-  /api/users/{id}:
-    delete:
-      consumes:
-      - application/json
-      description: Delete a user by their ID.
-      operationId: deleteUser
-      parameters:
-      - description: User ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "204":
-          description: No Content
-        "404":
-          description: Not Found
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "500":
-          description: Internal Server Error
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-      security:
-      - BearerAuth: []
-      summary: Delete user
-      tags:
-      - users
-    put:
-      consumes:
-      - application/json
-      description: Update the details of an existing user.
-      operationId: updateUser
-      parameters:
-      - description: User ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: User Info
-        in: body
-        name: user
-        required: true
-        schema:
-          $ref: '#/definitions/model.User'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/model.User'
-        "400":
-          description: Bad Request
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "404":
-          description: Not Found
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "500":
-          description: Internal Server Error
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-      security:
-      - BearerAuth: []
-      summary: Update user
-      tags:
-      - users
   /api/users/{userId}/organizations:
     get:
       description: 사용자가 소속된 조직 목록을 조회합니다. hierarchy=true이면 path/level 포함.
@@ -8130,6 +8049,39 @@ paths:
       tags:
       - organizations
   /api/users/id/{userId}:
+    delete:
+      consumes:
+      - application/json
+      description: Delete a user by their ID.
+      operationId: deleteUser
+      parameters:
+      - description: User ID
+        in: path
+        name: userId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Delete user
+      tags:
+      - users
     get:
       consumes:
       - application/json
@@ -8163,6 +8115,53 @@ paths:
       security:
       - BearerAuth: []
       summary: Get user by ID
+      tags:
+      - users
+    put:
+      consumes:
+      - application/json
+      description: Update the details of an existing user.
+      operationId: updateUser
+      parameters:
+      - description: User ID
+        in: path
+        name: userId
+        required: true
+        type: string
+      - description: User Info
+        in: body
+        name: user
+        required: true
+        schema:
+          $ref: '#/definitions/model.User'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.User'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Update user
       tags:
       - users
   /api/users/id/{userId}/access-summary:


### PR DESCRIPTION
## 변경 내용

`src/docs/swagger.yaml`이 commit `758b7029`(DeleteUser/UpdateUser 어노테이션 수정)에서 재생성되지 않아 `src/docs`와 `docs/`의 swagger가 불일치 상태였음.

### 수정 사항

- `src/docs/swagger.yaml`, `swagger.json`, `docs.go` 재생성 via `swag init`
  - deleteUser: `/api/users/{id}` → `/api/users/id/{userId}` (올바른 Echo 라우트 반영)
  - updateUser: 동일
- `asset/mcmpapi/service-actions.yaml` 재생성 via swagger-to-actions
- `conf/mc-iam-manager/service-actions.yaml` 재생성
