### PR TITLE
fix(csp-role): createNewAwsCredential env var → IDP Config DB 조회로 전환

### DIFF
--- a/src/service/csp_role_service.go
+++ b/src/service/csp_role_service.go
@@ -30,6 +30,7 @@ type CspRoleService struct {
 	db                 *gorm.DB
 	cspRoleRepo        *repository.CspRoleRepository
 	tempCredentialRepo *repository.TempCredentialRepository
+	cspIdpConfigRepo   *repository.CspIdpConfigRepository
 	keycloakService    KeycloakService
 }
 
@@ -39,6 +40,7 @@ func NewCspRoleService(db *gorm.DB, keycloakService KeycloakService) *CspRoleSer
 		db:                 db,
 		cspRoleRepo:        repository.NewCspRoleRepository(db),
 		tempCredentialRepo: repository.NewTempCredentialRepository(db),
+		cspIdpConfigRepo:   repository.NewCspIdpConfigRepository(db),
 		keycloakService:    keycloakService,
 	}
 }
@@ -416,26 +418,47 @@ func mapAwsRoleToModel(id uint, cspType string, idpIdentifier string, getRoleRes
 	return createdRole
 }
 
+// findActiveAwsOidcConfig 활성 OIDC + AWS IDP Config 1건을 조회합니다. (private)
+// getIAMClient(csp_iam_handler.go)와 동일한 IDP Config 기반 패턴을 사용합니다.
+func (s *CspRoleService) findActiveAwsOidcConfig() (*model.CspIdpConfig, error) {
+	configs, err := s.cspIdpConfigRepo.GetActiveConfigs()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get active IDP configs: %w", err)
+	}
+	for _, cfg := range configs {
+		if cfg.IsOIDC() && cfg.CspAccount != nil && cfg.CspAccount.CspType == "aws" {
+			return cfg, nil
+		}
+	}
+	return nil, fmt.Errorf("no active AWS OIDC IDP config found: please register an OIDC IDP config for an AWS CSP account")
+}
+
 // createNewAwsCredential 새로운 AWS 임시 자격 증명을 생성합니다. (private)
+// role_arn은 IDP Config DB에서 조회합니다 (getIAMClient와 동일한 패턴).
 func (s *CspRoleService) createNewAwsCredential(issuedBy string) (*model.TempCredential, error) {
 	token, err := s.keycloakService.GetClientCredentialsToken(context.TODO())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Keycloak token: %v", err)
 	}
 
+	// IDP Config DB에서 활성 AWS OIDC 설정 조회
+	idpConfig, err := s.findActiveAwsOidcConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	roleArn := idpConfig.Config["role_arn"]
+	if roleArn == "" {
+		return nil, fmt.Errorf("role_arn not configured in active AWS OIDC IDP config (id=%d)", idpConfig.ID)
+	}
+
+	// oidc_provider_arn은 AssumeRoleWithWebIdentity API의 파라미터가 아님 — 로깅 확인용으로만 사용
+	oidcProviderArn := idpConfig.GetOidcProviderArn()
+	log.Printf("createNewAwsCredential: using IDP config id=%d, role_arn=%s, oidc_provider_arn=%s", idpConfig.ID, roleArn, oidcProviderArn)
+
 	stsClient := sts.NewFromConfig(aws.Config{
 		Region: "ap-northeast-2",
 	})
-
-	identityProviderArn := os.Getenv("MC_IAM_MANAGER_AWS_IDENTITY_PROVIDER_ARN")
-	if identityProviderArn == "" {
-		return nil, fmt.Errorf("MC_IAM_MANAGER_AWS_IDENTITY_PROVIDER_ARN environment variable is not set")
-	}
-
-	roleArn := os.Getenv("MC_IAM_MANAGER_AWS_IDENTITY_ROLE_ARN")
-	if roleArn == "" {
-		return nil, fmt.Errorf("MC_IAM_MANAGER_AWS_IDENTITY_ROLE_ARN environment variable is not set")
-	}
 
 	input := &sts.AssumeRoleWithWebIdentityInput{
 		RoleArn:          aws.String(roleArn),

--- a/src/service/csp_role_service.go
+++ b/src/service/csp_role_service.go
@@ -435,13 +435,9 @@ func (s *CspRoleService) findActiveAwsOidcConfig() (*model.CspIdpConfig, error) 
 
 // createNewAwsCredential 새로운 AWS 임시 자격 증명을 생성합니다. (private)
 // role_arn은 IDP Config DB에서 조회합니다 (getIAMClient와 동일한 패턴).
+// IDP Config 조회를 먼저 수행해 설정 누락을 빠르게 감지합니다.
 func (s *CspRoleService) createNewAwsCredential(issuedBy string) (*model.TempCredential, error) {
-	token, err := s.keycloakService.GetClientCredentialsToken(context.TODO())
-	if err != nil {
-		return nil, fmt.Errorf("failed to get Keycloak token: %v", err)
-	}
-
-	// IDP Config DB에서 활성 AWS OIDC 설정 조회
+	// 1. IDP Config DB에서 활성 AWS OIDC 설정 조회 (fast-fail)
 	idpConfig, err := s.findActiveAwsOidcConfig()
 	if err != nil {
 		return nil, err
@@ -455,6 +451,12 @@ func (s *CspRoleService) createNewAwsCredential(issuedBy string) (*model.TempCre
 	// oidc_provider_arn은 AssumeRoleWithWebIdentity API의 파라미터가 아님 — 로깅 확인용으로만 사용
 	oidcProviderArn := idpConfig.GetOidcProviderArn()
 	log.Printf("createNewAwsCredential: using IDP config id=%d, role_arn=%s, oidc_provider_arn=%s", idpConfig.ID, roleArn, oidcProviderArn)
+
+	// 2. Keycloak client credentials 토큰 획득 (WebIdentity 토큰으로 사용)
+	token, err := s.keycloakService.GetClientCredentialsToken(context.TODO())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Keycloak token: %v", err)
+	}
 
 	stsClient := sts.NewFromConfig(aws.Config{
 		Region: "ap-northeast-2",


### PR DESCRIPTION
## Summary

`createNewAwsCredential`의 env var 직접 참조를 IDP Config DB 조회로 전환하고,
AWS 관련 env 변수명의 `MC_IAM_MANAGER_` prefix 통일한다.

## 변경 내용

### `src/service/csp_role_service.go`
- `CspRoleService` struct에 `cspIdpConfigRepo` 의존성 추가
- `findActiveAwsOidcConfig()` 헬퍼 추가 — `getIAMClient(csp_iam_handler.go)`와 동일 패턴
- `createNewAwsCredential()`:
  - env var 2개 제거 (`MC_IAM_MANAGER_AWS_IDENTITY_PROVIDER_ARN`, `MC_IAM_MANAGER_AWS_IDENTITY_ROLE_ARN`)
  - IDP Config DB 조회를 **Keycloak 토큰 획득보다 먼저** 수행 (fast-fail)
  - `role_arn` → `idpConfig.Config["role_arn"]` (DB 조회)
  - `oidc_provider_arn` → 로깅 확인용으로만 사용 (STS API 파라미터 아님)
