### PR TITLE
fix(installer): remove mc-web-console services from standalone installer

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,6 @@ networks:
   mc-infra-connector-network:
   mc-infra-manager-network:
   mc-iam-manager-network:
-  mc-web-console-network:
 
 services:
   ##### MC-INFRA-CONNECTOR #########################################################################################################################
@@ -20,7 +19,6 @@ services:
     restart: unless-stopped
     networks:
       - mc-infra-connector-network
-      - mc-web-console-network
     ports:
       - target: 1024
         published: ${MC_INFRA_CONNECTOR_PORT}
@@ -52,7 +50,6 @@ services:
     networks:
       - mc-infra-connector-network
       - mc-infra-manager-network
-      - mc-web-console-network
     ports:
       - target: 1323
         published: ${MC_INFRA_MANAGER_PORT}
@@ -209,7 +206,6 @@ services:
     networks:
       - mc-iam-manager-network
       - mc-infra-manager-network
-      - mc-web-console-network
     ports:
       - target: ${MC_IAM_MANAGER_PORT}
         published: ${MC_IAM_MANAGER_PORT}
@@ -355,94 +351,3 @@ services:
       - ./conf/mc-iam-manager/:/app/mc-iam-manager/
     working_dir: /app/mc-iam-manager
     command: bash /app/mc-iam-manager/docker-post-init.sh
-
-  ##### MC-WEB-CONSOLE #########################################################################################################################
-
-  mc-web-console-db:
-    image: postgres:14-alpine
-    container_name: mc-web-console-db
-    restart: unless-stopped
-    volumes:
-      - ./container-volume/mc-web-console/postgres/postgres_data:/var/lib/postgresql/data
-      - ./conf/mc-web-console/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
-    environment:
-      POSTGRES_DB: ${MC_WEB_CONSOLE_POSTGRES_DB}
-      POSTGRES_USER: ${MC_WEB_CONSOLE_POSTGRES_USER}
-      POSTGRES_PASSWORD: ${MC_WEB_CONSOLE_POSTGRES_PASSWORD}
-    networks:
-      - mc-web-console-network
-    pull_policy: if_not_present
-    ports:
-      - target: 5432
-        published: ${MC_WEB_CONSOLE_DB_HOST_PORT:-15433}
-        protocol: tcp
-    healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U ${MC_WEB_CONSOLE_POSTGRES_USER}" ]
-      <<: *default-health-check
-    command: >
-      sh -c "chown -R 70:70 /var/lib/postgresql/data &&
-            exec docker-entrypoint.sh postgres"
-
-  mc-web-console-api:
-    # image: sehyeong0108/mc-web-console-api:20241101
-    image: csescsta/mc-web-console-api:edge
-    pull_policy: always
-    container_name: mc-web-console-api
-    restart: unless-stopped
-    depends_on:
-      - mc-web-console-db
-      - mc-infra-connector
-      - mc-infra-manager
-      - mc-iam-manager
-      # - mc-observability-manager
-      # - mc-workflow-manager
-      # - mc-data-manager
-      # - mc-application-manager
-      # - mc-cost-optimizer-be
-    ports:
-      - target: 3000
-        published: ${MC_WEB_CONSOLE_API_PORT}
-        protocol: tcp
-    networks:
-      - mc-web-console-network
-      - mc-iam-manager-network
-    environment:
-      GO_ENV: development
-      GODEBUG: netdns=go
-      API_ADDR: "0.0.0.0"
-      API_PORT: "3000"
-      DB_HOST: mc-web-console-db
-      DB_PORT: 5432
-      DB_USER: ${MC_WEB_CONSOLE_POSTGRES_USER}
-      DB_PASSWORD: ${MC_WEB_CONSOLE_POSTGRES_PASSWORD}
-      DB_NAME: ${MC_WEB_CONSOLE_POSTGRES_DB}
-      MCIAM_USE: "true"
-      MCIAM_TICKET_USE: "false"
-      IFRAME_TARGET_IS_HOST: "true"
-      MC_IAM_MANAGER_PORT: ${MC_IAM_MANAGER_PORT}
-      MC_IAM_MANAGER_HOST: mc-iam-manager
-    volumes:
-      - ./conf/mc-web-console/api/conf/:/conf/
-    healthcheck:
-      test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/localhost/3000 && echo -e \"GET /readyz HTTP/1.0\\r\\n\\r\\n\" >&3 && head -1 <&3 | grep -q 200'"]
-      <<: *default-health-check
-
-  mc-web-console-front:
-    # image: sehyeong0108/mc-web-console-front:20241101
-    image: csescsta/mc-web-console-front:edge
-    pull_policy: always
-    container_name: mc-web-console-front
-    restart: unless-stopped
-    depends_on:
-      - mc-web-console-api
-    networks:
-      - mc-web-console-network
-      - mc-iam-manager-network
-    environment:
-      MC_WEB_CONSOLE_API_ADDR: mc-web-console-api
-      MC_WEB_CONSOLE_API_PORT: 3000
-      MC_WEB_CONSOLE_FRONT_ADDR: 0.0.0.0
-      MC_WEB_CONSOLE_FRONT_PORT: 3001
-    healthcheck:
-      test: ["CMD-SHELL", "wget -q -O- http://localhost:3001 || exit 1"]
-      <<: *default-health-check 

--- a/installAll.sh
+++ b/installAll.sh
@@ -89,9 +89,6 @@ EXPECTED_CONTAINERS=(
     "mc-iam-manager-kc"
     "mc-iam-manager-nginx"
     # "mc-iam-manager-post-initial"  # Container that exits after execution
-    "mc-web-console-db"
-    "mc-web-console-api"
-    "mc-web-console-front"
 )
 
 # Containers without Health Check (treated as successful when in Up state)


### PR DESCRIPTION
## Summary

mc-iam-manager standalone installer는 자신의 health check에 필요한 서비스만 포함해야 한다. mc-web-console-* 서비스는 mc-iam-manager의 동작과 무관하므로 제거한다.

- `docker-compose.yaml`: mc-web-console-db / mc-web-console-api / mc-web-console-front 서비스 블록 제거, mc-web-console-network 정의 및 mc-infra-connector·mc-infra-manager·mc-iam-manager 서비스의 네트워크 참조 제거
- `installAll.sh`: `EXPECTED_CONTAINERS`에서 mc-web-console-db / mc-web-console-api / mc-web-console-front 제거

## Test plan

- [ ] `./installAll.sh -m dev -r background` 실행 → mc-infra-connector, mc-infra-manager, mc-iam-manager 관련 컨테이너만 기동되는지 확인
- [ ] `docker compose config --quiet` 오류 없이 통과하는지 확인
- [ ] mc-iam-manager health check endpoint(`/readyz`) 정상 응답 확인