### PR TITLE
fix(IAM): nil pointer dereference in GetUserByID when Keycloak fields are unset

### DIFF
--- a/src/service/user_service.go
+++ b/src/service/user_service.go
@@ -338,12 +338,12 @@ func (s *UserService) GetUserByID(ctx context.Context, id uint) (*model.User, er
 		// If user not found in Keycloak, maybe return DB data but log inconsistency?
 		return dbUser, nil
 	}
-	dbUser.Email = *kcUser.Email
-	dbUser.FirstName = *kcUser.FirstName
-	dbUser.LastName = *kcUser.LastName
-	dbUser.Enabled = *kcUser.Enabled
-	if dbUser.Username != *kcUser.Username {
-		log.Printf("Warning: Username mismatch for user ID %d (DB: %s, KC: %s)", id, dbUser.Username, *kcUser.Username)
+	dbUser.Email = ptrStr(kcUser.Email)
+	dbUser.FirstName = ptrStr(kcUser.FirstName)
+	dbUser.LastName = ptrStr(kcUser.LastName)
+	dbUser.Enabled = ptrBool(kcUser.Enabled)
+	if dbUser.Username != ptrStr(kcUser.Username) {
+		log.Printf("Warning: Username mismatch for user ID %d (DB: %s, KC: %s)", id, dbUser.Username, ptrStr(kcUser.Username))
 	}
 	return dbUser, nil
 }


### PR DESCRIPTION
## Summary

- `AssignPlatformRole` 호출 시 UserID=13 사용자에 대해 반복적으로 PANIC이 발생하던 버그 수정
- Keycloak optional 필드(`LastName`, `FirstName`, `Email`, `Enabled`, `Username`)가 nil인 사용자에 대해 직접 역참조(`*kcUser.LastName`)하여 `nil pointer dereference` panic 발생
- 동일 파일 내 이미 정의된 nil-safe 헬퍼(`ptrStr`, `ptrBool`)로 교체하여 수정

## Root Cause

`service/user_service.go`의 `GetUserByID` 함수에서 Keycloak 조회 성공(`err == nil`) 후 optional 필드를 nil 체크 없이 직접 역참조:

```go
// Before (panic 발생)
dbUser.LastName = *kcUser.LastName  // kcUser.LastName == nil → panic
```

같은 파일의 `GetUsers()`는 이미 `ptrStr(kcUser.LastName)`을 올바르게 사용 중이었으나, `GetUserByID`만 누락됨.

## Fix

```go
// After (nil-safe)
dbUser.Email     = ptrStr(kcUser.Email)
dbUser.FirstName = ptrStr(kcUser.FirstName)
dbUser.LastName  = ptrStr(kcUser.LastName)
dbUser.Enabled   = ptrBool(kcUser.Enabled)
if dbUser.Username != ptrStr(kcUser.Username) {
```

## Test

- Docker 이미지 재빌드 후 배포하여 직접 검증
- `POST /api/roles/assign/platform-role` (UserID=13) → HTTP 200 정상 응답 확인
- PANIC 로그 없음 확인