### PR TITLE
fix(IAM): user role 버그 보완

### DIFF
--- a/src/handler/role_handler.go
+++ b/src/handler/role_handler.go
@@ -1431,6 +1431,15 @@ func (h *RoleHandler) AssignPlatformRole(c echo.Context) error {
 		userID = uint(uid)
 	}
 
+	// RoleName이 없으면 DB에서 roleID로 조회
+	if req.RoleName == "" {
+		role, err := h.roleService.GetRoleByID(roleID, constants.RoleTypePlatform)
+		if err != nil || role == nil {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("역할 조회 실패 (roleId=%d): %v", roleID, err)})
+		}
+		req.RoleName = role.Name
+	}
+
 	// User 찾기
 	//user, err := h.userService.GetUserByUsername(c.Request().Context(), req.Username)
 	user, err := h.userService.GetUserByID(c.Request().Context(), userID)

--- a/src/handler/role_handler.go
+++ b/src/handler/role_handler.go
@@ -1610,14 +1610,18 @@ func (h *RoleHandler) RemovePlatformRole(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("플랫폼 역할 제거 실패: %v", err)})
 	}
 
-	// Keycloak에서 역할 제거
+	// Keycloak에서 역할 제거 (KC 유저가 없는 경우 404는 무시 — DB는 이미 정리됨)
 	if err := h.keycloakService.RemoveRealmRoleFromUser(c.Request().Context(), user.KcId, role.Name); err != nil {
-		log.Printf("Failed to remove realm role from user: %v", err)
-		// DB 롤백을 위해 역할 재할당
-		if rollbackErr := h.roleService.AssignPlatformRole(userID, roleID); rollbackErr != nil {
-			log.Printf("Failed to rollback platform role removal: %v", rollbackErr)
+		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "User not found") {
+			log.Printf("[WARN] RemovePlatformRole: KC user not found (%s), skipping KC removal", user.KcId)
+		} else {
+			log.Printf("Failed to remove realm role from user: %v", err)
+			// DB 롤백을 위해 역할 재할당
+			if rollbackErr := h.roleService.AssignPlatformRole(userID, roleID); rollbackErr != nil {
+				log.Printf("Failed to rollback platform role removal: %v", rollbackErr)
+			}
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("키클로크 역할 제거 실패: %v", err)})
 		}
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("키클로크 역할 제거 실패: %v", err)})
 	}
 
 	return c.JSON(http.StatusOK, map[string]string{"message": "플랫폼 역할이 성공적으로 제거되었습니다"})

--- a/src/handler/user_handler.go
+++ b/src/handler/user_handler.go
@@ -298,10 +298,10 @@ func (h *UserHandler) SignupUser(c echo.Context) error {
 // @Id ResetUserPassword
 func (h *UserHandler) ResetUserPassword(c echo.Context) error {
 	// 관리자 권한 확인
-	requiredRoles := []string{"platformAdmin"}
+	requiredRoles := []string{"admin", "platformAdmin"}
 	if !checkRoleFromContext(c, requiredRoles) {
 		return c.JSON(http.StatusForbidden, map[string]string{
-			"error": "Forbidden: Platform Administrator access required",
+			"error": "Forbidden: Administrator access required",
 		})
 	}
 

--- a/src/main.go
+++ b/src/main.go
@@ -350,14 +350,14 @@ func main() {
 	users := api.Group("/users")
 	{
 		users.POST("/list", userHandler.ListUsers, middleware.PlatformRoleMiddleware(middleware.Read))
-		users.POST("", userHandler.CreateUser, middleware.PlatformRoleMiddleware(middleware.Manage))
+		users.POST("", userHandler.CreateUser, middleware.PlatformRoleMiddleware(middleware.Write))
 		users.GET("/id/:userId", userHandler.GetUserByID, middleware.PlatformRoleMiddleware(middleware.Read))
 		users.GET("/kc/:kcUserId", userHandler.GetUserByKcID, middleware.PlatformRoleMiddleware(middleware.Read))
 		users.GET("/name/:username", userHandler.GetUserByUsername, middleware.PlatformRoleMiddleware(middleware.Read))
-		users.PUT("/id/:userId", userHandler.UpdateUser, middleware.PlatformRoleMiddleware(middleware.Manage))
-		users.DELETE("/id/:userId", userHandler.DeleteUser, middleware.PlatformRoleMiddleware(middleware.Manage))
-		users.POST("/id/:userId/status", userHandler.UpdateUserStatus, middleware.PlatformRoleMiddleware(middleware.Manage))
-		users.PUT("/id/:userId/password", userHandler.ResetUserPassword, middleware.PlatformRoleMiddleware(middleware.Manage))
+		users.PUT("/id/:userId", userHandler.UpdateUser, middleware.PlatformRoleMiddleware(middleware.Write))
+		users.DELETE("/id/:userId", userHandler.DeleteUser, middleware.PlatformRoleMiddleware(middleware.Write))
+		users.POST("/id/:userId/status", userHandler.UpdateUserStatus, middleware.PlatformRoleMiddleware(middleware.Write))
+		users.PUT("/id/:userId/password", userHandler.ResetUserPassword, middleware.PlatformRoleMiddleware(middleware.Write))
 		users.GET("/me", userHandler.GetMyInfo)                                                            // 사용자 본인 정보 조회
 		users.PUT("/me/password", userHandler.ChangeMyPassword)                                            // 사용자 본인 패스워드 변경
 		users.GET("/me/platform-roles", userHandler.GetMyPlatformRoles)                                    // 내 유효 플랫폼 역할 목록

--- a/src/main.go
+++ b/src/main.go
@@ -489,8 +489,8 @@ func main() {
 		cspIdpConfigs.POST("/health-check", cspIdpConfigHandler.BulkHealthCheck, middleware.PlatformAdminMiddleware)
 	}
 
-	// 조직 관리 라우트 (platformAdmin 전용)
-	organizations := api.Group("/organizations", middleware.PlatformAdminMiddleware)
+	// 조직 관리 라우트 (admin 이상)
+	organizations := api.Group("/organizations", middleware.PlatformRoleMiddleware(middleware.Write))
 	{
 		organizations.POST("", organizationHandler.CreateOrganization)
 		organizations.GET("", organizationHandler.GetOrganizations)
@@ -509,14 +509,14 @@ func main() {
 		organizations.GET("/id/:organizationId/deletable", organizationHandler.GetOrganizationDeletable)
 	}
 
-	// 사용자-조직 라우트 (users 그룹에 추가, platformAdmin 전용)
-	users.POST("/id/:userId/organizations", organizationHandler.AssignUserOrganizations, middleware.PlatformAdminMiddleware)
-	users.GET("/id/:userId/organizations", organizationHandler.GetUserOrganizations, middleware.PlatformAdminMiddleware)
-	users.DELETE("/id/:userId/organizations/:organizationId", organizationHandler.RemoveUserOrganization, middleware.PlatformAdminMiddleware)
+	// 사용자-조직 라우트 (admin 이상)
+	users.POST("/id/:userId/organizations", organizationHandler.AssignUserOrganizations, middleware.PlatformRoleMiddleware(middleware.Write))
+	users.GET("/id/:userId/organizations", organizationHandler.GetUserOrganizations, middleware.PlatformRoleMiddleware(middleware.Read))
+	users.DELETE("/id/:userId/organizations/:organizationId", organizationHandler.RemoveUserOrganization, middleware.PlatformRoleMiddleware(middleware.Write))
 
-	// 그룹 관리 라우트 (/api/groups - organizations의 별칭, platformAdmin 전용)
+	// 그룹 관리 라우트 (/api/groups - organizations의 별칭, admin 이상)
 	// 주의: organizationId 파라미터 이름 유지 (기존 핸들러 호환)
-	groups := api.Group("/groups", middleware.PlatformAdminMiddleware)
+	groups := api.Group("/groups", middleware.PlatformRoleMiddleware(middleware.Write))
 	{
 		groups.POST("", organizationHandler.CreateOrganization)
 		groups.GET("", organizationHandler.GetOrganizations)

--- a/src/service/user_service.go
+++ b/src/service/user_service.go
@@ -338,12 +338,12 @@ func (s *UserService) GetUserByID(ctx context.Context, id uint) (*model.User, er
 		// If user not found in Keycloak, maybe return DB data but log inconsistency?
 		return dbUser, nil
 	}
-	dbUser.Email = *kcUser.Email
-	dbUser.FirstName = *kcUser.FirstName
-	dbUser.LastName = *kcUser.LastName
-	dbUser.Enabled = *kcUser.Enabled
-	if dbUser.Username != *kcUser.Username {
-		log.Printf("Warning: Username mismatch for user ID %d (DB: %s, KC: %s)", id, dbUser.Username, *kcUser.Username)
+	dbUser.Email = ptrStr(kcUser.Email)
+	dbUser.FirstName = ptrStr(kcUser.FirstName)
+	dbUser.LastName = ptrStr(kcUser.LastName)
+	dbUser.Enabled = ptrBool(kcUser.Enabled)
+	if dbUser.Username != ptrStr(kcUser.Username) {
+		log.Printf("Warning: Username mismatch for user ID %d (DB: %s, KC: %s)", id, dbUser.Username, ptrStr(kcUser.Username))
 	}
 	return dbUser, nil
 }

--- a/src/service/user_service.go
+++ b/src/service/user_service.go
@@ -160,8 +160,10 @@ func (s *UserService) CreateUser(ctx context.Context, user *model.User) error {
 	user.KcId = kcId
 	_, err = s.userRepo.Create(user)
 	if err != nil {
-		log.Printf("CRITICAL: Failed to create user in DB after Keycloak creation (kcId: %s). Manual cleanup needed. Error: %v", kcId, err)
-		// TODO: Compensation - delete user from Keycloak?
+		log.Printf("CRITICAL: Failed to create user in DB after Keycloak creation (kcId: %s). Rolling back KC user. Error: %v", kcId, err)
+		if rollbackErr := ks.DeleteUser(ctx, kcId); rollbackErr != nil {
+			log.Printf("CRITICAL: KC rollback also failed (kcId: %s): %v", kcId, rollbackErr)
+		}
 		return fmt.Errorf("failed to create user in DB after Keycloak: %w", err)
 	}
 	return nil


### PR DESCRIPTION
## Summary
Parameter setting 로직 보완
빈 path param 호출시 오류 보완
권한 레벨 확대 : 기존 platform admin 만 가능 -> admin 가능

## 수정 항목

### 1. nil pointer dereference in GetUserByID (P0)
- **파일**: `service/user_service.go`
- Keycloak optional 필드(`Email`, `FirstName`, `LastName`, `Enabled`, `Username`)가 nil인 사용자에 대해 `AssignPlatformRole` 호출 시 panic 발생
- 기존 `ptrStr`/`ptrBool` 헬퍼로 교체 (같은 파일의 `GetUsers`와 동일 패턴)

### 2. AssignPlatformRole — RoleName 없이 호출 시 500
- **파일**: `handler/role_handler.go`
- `roleId`만 전달하면 `roleName`이 빈 값 → Keycloak 역할 연동 실패
- `roleName == ""` 일 때 DB에서 `GetRoleByID`로 자동 조회

### 3. 권한 레벨 조정 — admin 역할 허용 범위 확대
- **파일**: `main.go`, `handler/user_handler.go`
- `CreateUser`, `UpdateUser`, `DeleteUser`, `ResetUserPassword` 등 사용자 관리 API: `Manage`(platformAdmin 전용) → `Write`(admin 포함)
- `/organizations`, `/groups` 라우트: `PlatformAdminMiddleware` → `PlatformRoleMiddleware(Write)`
- `ResetUserPassword` 핸들러 내부 권한 체크: `["platformAdmin"]` → `["admin", "platformAdmin"]`
