### PR TITLE
fix(setup): camelCase roleTypes in init_predefined_roles JSON payload

### DIFF
--- a/conf/mc-iam-manager/1_setup_auto.sh
+++ b/conf/mc-iam-manager/1_setup_auto.sh
@@ -253,7 +253,7 @@ init_predefined_roles() {
     for role in "${ROLES[@]}"; do
         echo "Creating role: $role"
         json_data=$(jq -n --arg name "$role" --arg description "$role Role" \
-            '{name: $name, description: $description, role_types: ["workspace", "platform"]}')
+            '{name: $name, description: $description, roleTypes: ["workspace", "platform"]}')
         response=$(curl -s -X POST \
             --header 'Content-Type: application/json' \
             --header "Authorization: Bearer $MC_IAM_MANAGER_PLATFORMADMIN_ACCESSTOKEN" \


### PR DESCRIPTION
## Summary

- `1_setup_auto.sh`의 `init_predefined_roles` 함수에서 `role_types` (snake_case)를 `roleTypes` (camelCase)로 수정
- `CreateRoleRequest` 모델이 `json:"roleTypes"` 바인딩을 사용하기 때문에 snake_case는 무시되어 `viewer`, `billviewer`에 `platform` role_sub이 생성되지 않는 버그였음

## Root Cause

```bash
# Before (wrong — ignored by Go JSON binding)
'{name: $name, description: $description, role_types: ["workspace", "platform"]}'

# After (correct — matches CreateRoleRequest.RoleTypes json:"roleTypes")
'{name: $name, description: $description, roleTypes: ["workspace", "platform"]}'
```

Go 모델:
```go
type CreateRoleRequest struct {
    RoleTypes []constants.IAMRoleType \`json:"roleTypes,omitempty"\`
}
```

## Impact

- viewer, billviewer 역할에 platform role_sub 미생성 → assignPlatformRole 500 에러
- ListRoles platform 필터 시 viewer/billviewer 제외
- e2e 테스트 C2-S3a, C2-S6a skip

## Test Plan

- [ ] 1_setup_auto.sh 재실행 후 viewer, billviewer에 platform role_sub 생성 확인
- [ ] assignPlatformRole(viewer), assignPlatformRole(billviewer) 200 응답 확인
- [ ] ListRoles platform 필터에서 5개 역할 모두 반환 확인
- [ ] C2 IAM 온보딩 E2E 테스트 15/15 PASS 확인