### PR TITLE
fix: delete user FK constraint violation by clearing role mappings first

### DIFF
--- a/src/service/user_service.go
+++ b/src/service/user_service.go
@@ -461,6 +461,11 @@ func (s *UserService) DeleteUser(ctx context.Context, id uint) error {
 		log.Printf("Warning: User with DB ID %d has no KcId. Skipping Keycloak deletion.", id)
 	}
 
+	if err = s.userRepo.DeleteAllRoleMappings(id); err != nil {
+		log.Printf("CRITICAL: Failed to delete role mappings for user (ID: %d). Manual cleanup needed. Error: %v", id, err)
+		return fmt.Errorf("failed to delete role mappings for user (id: %d): %w", id, err)
+	}
+
 	err = s.userRepo.Delete(id)
 	if err != nil {
 		log.Printf("CRITICAL: Failed to delete user from DB (ID: %d) after Keycloak deletion attempt. Manual cleanup needed. Error: %v", id, err)


### PR DESCRIPTION
## Summary

- `DeleteUser` 호출 시 `mcmp_user_platform_roles` 외래 키 제약 위반으로 삭제 실패하는 버그 수정
- `userRepo.Delete(id)` 호출 전 `userRepo.DeleteAllRoleMappings(id)`를 먼저 호출하도록 변경
- `DeleteAllRoleMappings`는 이미 구현되어 있었으나 `DeleteUser` 서비스 레이어에서 호출되지 않고 있었음

## Root Cause

`mcmp_user_platform_roles`, `mcmp_user_workspace_roles`, `mcmp_user_organization` 테이블이 `mcmp_users.id`에 외래 키(`fk_mcmp_user_platform_roles_user`)를 가지고 있어, 연관 레코드를 먼저 삭제하지 않으면 `mcmp_users` 레코드 삭제 시 `SQLSTATE 23503` 오류가 발생함.

## Delete Order (After Fix)

1. Keycloak 사용자 삭제
2. `mcmp_user_platform_roles` 삭제
3. `mcmp_user_workspace_roles` 삭제
4. `mcmp_user_organization` 삭제
5. `mcmp_users` 삭제

## Test plan

- [ ] 플랫폼 역할이 할당된 사용자 삭제 시 정상 처리 확인
- [ ] 워크스페이스 역할이 할당된 사용자 삭제 시 정상 처리 확인
- [ ] 역할 미할당 사용자 삭제 시 정상 처리 확인