### PR TITLE
fix(IAM): correct swagger @Router paths for user-organization endpoints

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -9925,6 +9925,170 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/users/id/{userId}/organizations": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "사용자가 소속된 조직 목록을 조회합니다. hierarchy=true이면 path/level 포함.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "사용자 소속 조직 조회",
+                "operationId": "getUserOrganizations",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "사용자 ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "계층 정보(path, level) 포함 여부 (기본: false)",
+                        "name": "hierarchy",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.OrganizationTree"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "사용자를 하나 이상의 조직에 할당합니다 (다중 소속 가능).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "사용자-조직 할당",
+                "operationId": "assignUserOrganizations",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "사용자 ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "조직 할당 요청",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.AssignUserOrganizationsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/users/id/{userId}/organizations/{organizationId}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "사용자를 특정 조직에서 제거합니다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "사용자-조직 매핑 제거",
+                "operationId": "removeUserOrganization",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "사용자 ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "조직 ID",
+                        "name": "organizationId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/users/id/{userId}/password": {
             "put": {
                 "security": [
@@ -11090,170 +11254,6 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/users/{userId}/organizations": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "사용자가 소속된 조직 목록을 조회합니다. hierarchy=true이면 path/level 포함.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "organizations"
-                ],
-                "summary": "사용자 소속 조직 조회",
-                "operationId": "getUserOrganizations",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "사용자 ID",
-                        "name": "userId",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "boolean",
-                        "description": "계층 정보(path, level) 포함 여부 (기본: false)",
-                        "name": "hierarchy",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/model.OrganizationTree"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "사용자를 하나 이상의 조직에 할당합니다 (다중 소속 가능).",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "organizations"
-                ],
-                "summary": "사용자-조직 할당",
-                "operationId": "assignUserOrganizations",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "사용자 ID",
-                        "name": "userId",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "조직 할당 요청",
-                        "name": "body",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/model.AssignUserOrganizationsRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/users/{userId}/organizations/{organizationId}": {
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "사용자를 특정 조직에서 제거합니다.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "organizations"
-                ],
-                "summary": "사용자-조직 매핑 제거",
-                "operationId": "removeUserOrganization",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "사용자 ID",
-                        "name": "userId",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "조직 ID",
-                        "name": "organizationId",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -9919,6 +9919,170 @@
                 }
             }
         },
+        "/api/users/id/{userId}/organizations": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "사용자가 소속된 조직 목록을 조회합니다. hierarchy=true이면 path/level 포함.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "사용자 소속 조직 조회",
+                "operationId": "getUserOrganizations",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "사용자 ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "계층 정보(path, level) 포함 여부 (기본: false)",
+                        "name": "hierarchy",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.OrganizationTree"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "사용자를 하나 이상의 조직에 할당합니다 (다중 소속 가능).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "사용자-조직 할당",
+                "operationId": "assignUserOrganizations",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "사용자 ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "조직 할당 요청",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.AssignUserOrganizationsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/users/id/{userId}/organizations/{organizationId}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "사용자를 특정 조직에서 제거합니다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "사용자-조직 매핑 제거",
+                "operationId": "removeUserOrganization",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "사용자 ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "조직 ID",
+                        "name": "organizationId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/users/id/{userId}/password": {
             "put": {
                 "security": [
@@ -11084,170 +11248,6 @@
                     },
                     "500": {
                         "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/users/{userId}/organizations": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "사용자가 소속된 조직 목록을 조회합니다. hierarchy=true이면 path/level 포함.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "organizations"
-                ],
-                "summary": "사용자 소속 조직 조회",
-                "operationId": "getUserOrganizations",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "사용자 ID",
-                        "name": "userId",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "boolean",
-                        "description": "계층 정보(path, level) 포함 여부 (기본: false)",
-                        "name": "hierarchy",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/model.OrganizationTree"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "사용자를 하나 이상의 조직에 할당합니다 (다중 소속 가능).",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "organizations"
-                ],
-                "summary": "사용자-조직 할당",
-                "operationId": "assignUserOrganizations",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "사용자 ID",
-                        "name": "userId",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "조직 할당 요청",
-                        "name": "body",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/model.AssignUserOrganizationsRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/users/{userId}/organizations/{organizationId}": {
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "사용자를 특정 조직에서 제거합니다.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "organizations"
-                ],
-                "summary": "사용자-조직 매핑 제거",
-                "operationId": "removeUserOrganization",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "사용자 ID",
-                        "name": "userId",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "조직 ID",
-                        "name": "organizationId",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -7942,112 +7942,6 @@ paths:
       summary: Create new user
       tags:
       - users
-  /api/users/{userId}/organizations:
-    get:
-      description: 사용자가 소속된 조직 목록을 조회합니다. hierarchy=true이면 path/level 포함.
-      operationId: getUserOrganizations
-      parameters:
-      - description: 사용자 ID
-        in: path
-        name: userId
-        required: true
-        type: integer
-      - description: '계층 정보(path, level) 포함 여부 (기본: false)'
-        in: query
-        name: hierarchy
-        type: boolean
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/model.OrganizationTree'
-            type: array
-        "400":
-          description: Bad Request
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-      security:
-      - BearerAuth: []
-      summary: 사용자 소속 조직 조회
-      tags:
-      - organizations
-    post:
-      consumes:
-      - application/json
-      description: 사용자를 하나 이상의 조직에 할당합니다 (다중 소속 가능).
-      operationId: assignUserOrganizations
-      parameters:
-      - description: 사용자 ID
-        in: path
-        name: userId
-        required: true
-        type: integer
-      - description: 조직 할당 요청
-        in: body
-        name: body
-        required: true
-        schema:
-          $ref: '#/definitions/model.AssignUserOrganizationsRequest'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "400":
-          description: Bad Request
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-      security:
-      - BearerAuth: []
-      summary: 사용자-조직 할당
-      tags:
-      - organizations
-  /api/users/{userId}/organizations/{organizationId}:
-    delete:
-      description: 사용자를 특정 조직에서 제거합니다.
-      operationId: removeUserOrganization
-      parameters:
-      - description: 사용자 ID
-        in: path
-        name: userId
-        required: true
-        type: integer
-      - description: 조직 ID
-        in: path
-        name: organizationId
-        required: true
-        type: integer
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "400":
-          description: Bad Request
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-      security:
-      - BearerAuth: []
-      summary: 사용자-조직 매핑 제거
-      tags:
-      - organizations
   /api/users/id/{userId}:
     delete:
       consumes:
@@ -8417,6 +8311,112 @@ paths:
       summary: 사용자를 그룹에서 제거 (Keycloak 동기화 포함)
       tags:
       - groups
+  /api/users/id/{userId}/organizations:
+    get:
+      description: 사용자가 소속된 조직 목록을 조회합니다. hierarchy=true이면 path/level 포함.
+      operationId: getUserOrganizations
+      parameters:
+      - description: 사용자 ID
+        in: path
+        name: userId
+        required: true
+        type: integer
+      - description: '계층 정보(path, level) 포함 여부 (기본: false)'
+        in: query
+        name: hierarchy
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.OrganizationTree'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 사용자 소속 조직 조회
+      tags:
+      - organizations
+    post:
+      consumes:
+      - application/json
+      description: 사용자를 하나 이상의 조직에 할당합니다 (다중 소속 가능).
+      operationId: assignUserOrganizations
+      parameters:
+      - description: 사용자 ID
+        in: path
+        name: userId
+        required: true
+        type: integer
+      - description: 조직 할당 요청
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/model.AssignUserOrganizationsRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 사용자-조직 할당
+      tags:
+      - organizations
+  /api/users/id/{userId}/organizations/{organizationId}:
+    delete:
+      description: 사용자를 특정 조직에서 제거합니다.
+      operationId: removeUserOrganization
+      parameters:
+      - description: 사용자 ID
+        in: path
+        name: userId
+        required: true
+        type: integer
+      - description: 조직 ID
+        in: path
+        name: organizationId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 사용자-조직 매핑 제거
+      tags:
+      - organizations
   /api/users/id/{userId}/password:
     put:
       consumes:

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -9925,6 +9925,170 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/users/id/{userId}/organizations": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "사용자가 소속된 조직 목록을 조회합니다. hierarchy=true이면 path/level 포함.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "사용자 소속 조직 조회",
+                "operationId": "getUserOrganizations",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "사용자 ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "계층 정보(path, level) 포함 여부 (기본: false)",
+                        "name": "hierarchy",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.OrganizationTree"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "사용자를 하나 이상의 조직에 할당합니다 (다중 소속 가능).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "사용자-조직 할당",
+                "operationId": "assignUserOrganizations",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "사용자 ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "조직 할당 요청",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.AssignUserOrganizationsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/users/id/{userId}/organizations/{organizationId}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "사용자를 특정 조직에서 제거합니다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "사용자-조직 매핑 제거",
+                "operationId": "removeUserOrganization",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "사용자 ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "조직 ID",
+                        "name": "organizationId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/users/id/{userId}/password": {
             "put": {
                 "security": [
@@ -11090,170 +11254,6 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/users/{userId}/organizations": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "사용자가 소속된 조직 목록을 조회합니다. hierarchy=true이면 path/level 포함.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "organizations"
-                ],
-                "summary": "사용자 소속 조직 조회",
-                "operationId": "getUserOrganizations",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "사용자 ID",
-                        "name": "userId",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "boolean",
-                        "description": "계층 정보(path, level) 포함 여부 (기본: false)",
-                        "name": "hierarchy",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/model.OrganizationTree"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "사용자를 하나 이상의 조직에 할당합니다 (다중 소속 가능).",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "organizations"
-                ],
-                "summary": "사용자-조직 할당",
-                "operationId": "assignUserOrganizations",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "사용자 ID",
-                        "name": "userId",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "조직 할당 요청",
-                        "name": "body",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/model.AssignUserOrganizationsRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/users/{userId}/organizations/{organizationId}": {
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "사용자를 특정 조직에서 제거합니다.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "organizations"
-                ],
-                "summary": "사용자-조직 매핑 제거",
-                "operationId": "removeUserOrganization",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "사용자 ID",
-                        "name": "userId",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "조직 ID",
-                        "name": "organizationId",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -9919,6 +9919,170 @@
                 }
             }
         },
+        "/api/users/id/{userId}/organizations": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "사용자가 소속된 조직 목록을 조회합니다. hierarchy=true이면 path/level 포함.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "사용자 소속 조직 조회",
+                "operationId": "getUserOrganizations",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "사용자 ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "계층 정보(path, level) 포함 여부 (기본: false)",
+                        "name": "hierarchy",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.OrganizationTree"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "사용자를 하나 이상의 조직에 할당합니다 (다중 소속 가능).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "사용자-조직 할당",
+                "operationId": "assignUserOrganizations",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "사용자 ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "조직 할당 요청",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.AssignUserOrganizationsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/users/id/{userId}/organizations/{organizationId}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "사용자를 특정 조직에서 제거합니다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "사용자-조직 매핑 제거",
+                "operationId": "removeUserOrganization",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "사용자 ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "조직 ID",
+                        "name": "organizationId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/users/id/{userId}/password": {
             "put": {
                 "security": [
@@ -11084,170 +11248,6 @@
                     },
                     "500": {
                         "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/users/{userId}/organizations": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "사용자가 소속된 조직 목록을 조회합니다. hierarchy=true이면 path/level 포함.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "organizations"
-                ],
-                "summary": "사용자 소속 조직 조회",
-                "operationId": "getUserOrganizations",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "사용자 ID",
-                        "name": "userId",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "boolean",
-                        "description": "계층 정보(path, level) 포함 여부 (기본: false)",
-                        "name": "hierarchy",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/model.OrganizationTree"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "사용자를 하나 이상의 조직에 할당합니다 (다중 소속 가능).",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "organizations"
-                ],
-                "summary": "사용자-조직 할당",
-                "operationId": "assignUserOrganizations",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "사용자 ID",
-                        "name": "userId",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "조직 할당 요청",
-                        "name": "body",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/model.AssignUserOrganizationsRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/users/{userId}/organizations/{organizationId}": {
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "사용자를 특정 조직에서 제거합니다.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "organizations"
-                ],
-                "summary": "사용자-조직 매핑 제거",
-                "operationId": "removeUserOrganization",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "사용자 ID",
-                        "name": "userId",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "조직 ID",
-                        "name": "organizationId",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -7942,112 +7942,6 @@ paths:
       summary: Create new user
       tags:
       - users
-  /api/users/{userId}/organizations:
-    get:
-      description: 사용자가 소속된 조직 목록을 조회합니다. hierarchy=true이면 path/level 포함.
-      operationId: getUserOrganizations
-      parameters:
-      - description: 사용자 ID
-        in: path
-        name: userId
-        required: true
-        type: integer
-      - description: '계층 정보(path, level) 포함 여부 (기본: false)'
-        in: query
-        name: hierarchy
-        type: boolean
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/model.OrganizationTree'
-            type: array
-        "400":
-          description: Bad Request
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-      security:
-      - BearerAuth: []
-      summary: 사용자 소속 조직 조회
-      tags:
-      - organizations
-    post:
-      consumes:
-      - application/json
-      description: 사용자를 하나 이상의 조직에 할당합니다 (다중 소속 가능).
-      operationId: assignUserOrganizations
-      parameters:
-      - description: 사용자 ID
-        in: path
-        name: userId
-        required: true
-        type: integer
-      - description: 조직 할당 요청
-        in: body
-        name: body
-        required: true
-        schema:
-          $ref: '#/definitions/model.AssignUserOrganizationsRequest'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "400":
-          description: Bad Request
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-      security:
-      - BearerAuth: []
-      summary: 사용자-조직 할당
-      tags:
-      - organizations
-  /api/users/{userId}/organizations/{organizationId}:
-    delete:
-      description: 사용자를 특정 조직에서 제거합니다.
-      operationId: removeUserOrganization
-      parameters:
-      - description: 사용자 ID
-        in: path
-        name: userId
-        required: true
-        type: integer
-      - description: 조직 ID
-        in: path
-        name: organizationId
-        required: true
-        type: integer
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "400":
-          description: Bad Request
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-      security:
-      - BearerAuth: []
-      summary: 사용자-조직 매핑 제거
-      tags:
-      - organizations
   /api/users/id/{userId}:
     delete:
       consumes:
@@ -8417,6 +8311,112 @@ paths:
       summary: 사용자를 그룹에서 제거 (Keycloak 동기화 포함)
       tags:
       - groups
+  /api/users/id/{userId}/organizations:
+    get:
+      description: 사용자가 소속된 조직 목록을 조회합니다. hierarchy=true이면 path/level 포함.
+      operationId: getUserOrganizations
+      parameters:
+      - description: 사용자 ID
+        in: path
+        name: userId
+        required: true
+        type: integer
+      - description: '계층 정보(path, level) 포함 여부 (기본: false)'
+        in: query
+        name: hierarchy
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.OrganizationTree'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 사용자 소속 조직 조회
+      tags:
+      - organizations
+    post:
+      consumes:
+      - application/json
+      description: 사용자를 하나 이상의 조직에 할당합니다 (다중 소속 가능).
+      operationId: assignUserOrganizations
+      parameters:
+      - description: 사용자 ID
+        in: path
+        name: userId
+        required: true
+        type: integer
+      - description: 조직 할당 요청
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/model.AssignUserOrganizationsRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 사용자-조직 할당
+      tags:
+      - organizations
+  /api/users/id/{userId}/organizations/{organizationId}:
+    delete:
+      description: 사용자를 특정 조직에서 제거합니다.
+      operationId: removeUserOrganization
+      parameters:
+      - description: 사용자 ID
+        in: path
+        name: userId
+        required: true
+        type: integer
+      - description: 조직 ID
+        in: path
+        name: organizationId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 사용자-조직 매핑 제거
+      tags:
+      - organizations
   /api/users/id/{userId}/password:
     put:
       consumes:

--- a/src/handler/organization_handler.go
+++ b/src/handler/organization_handler.go
@@ -391,7 +391,7 @@ func (h *OrganizationHandler) GetOrganizationDeletable(c echo.Context) error {
 // @Success 200 {object} map[string]string
 // @Failure 400 {object} map[string]string
 // @Security BearerAuth
-// @Router /api/users/{userId}/organizations [post]
+// @Router /api/users/id/{userId}/organizations [post]
 // @Id assignUserOrganizations
 func (h *OrganizationHandler) AssignUserOrganizations(c echo.Context) error {
 	userID, err := strconv.ParseUint(c.Param("userId"), 10, 32)
@@ -427,7 +427,7 @@ func (h *OrganizationHandler) AssignUserOrganizations(c echo.Context) error {
 // @Success 200 {array} model.OrganizationTree
 // @Failure 400 {object} map[string]string
 // @Security BearerAuth
-// @Router /api/users/{userId}/organizations [get]
+// @Router /api/users/id/{userId}/organizations [get]
 // @Id getUserOrganizations
 func (h *OrganizationHandler) GetUserOrganizations(c echo.Context) error {
 	userID, err := strconv.ParseUint(c.Param("userId"), 10, 32)
@@ -493,7 +493,7 @@ func (h *OrganizationHandler) ReplaceUserGroups(c echo.Context) error {
 // @Success 200 {object} map[string]string
 // @Failure 400 {object} map[string]string
 // @Security BearerAuth
-// @Router /api/users/{userId}/organizations/{organizationId} [delete]
+// @Router /api/users/id/{userId}/organizations/{organizationId} [delete]
 // @Id removeUserOrganization
 func (h *OrganizationHandler) RemoveUserOrganization(c echo.Context) error {
 	userID, err := strconv.ParseUint(c.Param("userId"), 10, 32)


### PR DESCRIPTION
## Summary
- `AssignUserOrganizations`, `GetUserOrganizations`, `RemoveUserOrganization` 핸들러의 `@Router` swagger 주석이 실제 라우팅 경로와 달랐음 (`/api/users/{userId}/organizations` vs 실제 등록된 `/api/users/id/{userId}/organizations`)
- `organization_handler.go`의 `@Router` 주석 3곳을 실제 라우트(`main.go`)와 일치하도록 수정
- `swag init`으로 `src/docs/`, `docs/` 하위 swagger 산출물 재생성
