### PR TITLE
feat: add generate Data Migrations menus to permission.csv

### DIFF
--- a/asset/menu/permission.csv
+++ b/asset/menu/permission.csv
@@ -41,6 +41,9 @@ mc-web-console,pmkworkloads,TRUE,,,TRUE,
 mc-web-console,workflows,TRUE,,,TRUE,
 mc-web-console,swcatalogs,TRUE,,,TRUE,
 mc-web-console,datamigrations,TRUE,,,TRUE,
+mc-web-console,mcdatamanager,TRUE,,,TRUE,
+mc-web-console,generateobjectstorage,TRUE,,,TRUE,
+mc-web-console,generaterdb,TRUE,,,TRUE,
 mc-web-console,analytics,TRUE,TRUE,TRUE,TRUE,TRUE
 mc-web-console,monitorings,TRUE,,,TRUE,TRUE
 mc-web-console,mcismonitoring,TRUE,,,TRUE,TRUE


### PR DESCRIPTION
## Summary
- `permission.csv`에 `mcdatamanager` / `generateobjectstorage` / `generaterdb` 역할 매핑을 추가합니다.
- admin·operator 권한은 기존 `datamigrations`와 동일하게 맞춥니다.

## Test plan
- [ ] `GET /api/setup/initial-role-menu-permission` 후 admin 사용자 메뉴 트리에 Generate OSS/RDB 및 기존 메뉴 동시 노출
- [ ] operator 역할에도 동일 generate 메뉴 매핑 확인