### PR TITLE
[feat]: Role permission backup and restore APIs

### DIFF
--- a/asset/mcmpapi/service-actions.yaml
+++ b/asset/mcmpapi/service-actions.yaml
@@ -834,6 +834,14 @@ serviceActions:
             method: get
             resourcePath: /api/setup/initial-role-menu-permission
             description: CSV 파일을 읽어서 메뉴 권한을 초기화합니다
+        backupRolePermissions:
+            method: get
+            resourcePath: /api/setup/backup-role-permissions
+            description: DB의 현재 플랫폼 역할 권한을 role-permission-backup 문서로 내보냅니다
+        restoreRolePermissions:
+            method: post
+            resourcePath: /api/setup/restore-role-permissions
+            description: role-permission-backup 문서로 역할 권한을 복구합니다 (additive|replace-role)
         listAllInvitations:
             method: get
             resourcePath: /api/invitations

--- a/asset/menu/backups/README.md
+++ b/asset/menu/backups/README.md
@@ -1,0 +1,1 @@
+# role-permission-backup-*.yaml files are written here when save=true

--- a/conf/mc-iam-manager/service-actions.yaml
+++ b/conf/mc-iam-manager/service-actions.yaml
@@ -834,6 +834,14 @@ serviceActions:
             method: get
             resourcePath: /api/setup/initial-role-menu-permission
             description: CSV 파일을 읽어서 메뉴 권한을 초기화합니다
+        backupRolePermissions:
+            method: get
+            resourcePath: /api/setup/backup-role-permissions
+            description: DB의 현재 플랫폼 역할 권한을 role-permission-backup 문서로 내보냅니다
+        restoreRolePermissions:
+            method: post
+            resourcePath: /api/setup/restore-role-permissions
+            description: role-permission-backup 문서로 역할 권한을 복구합니다 (additive|replace-role)
         listAllInvitations:
             method: get
             resourcePath: /api/invitations

--- a/docs/ROLE-PERMISSION-BACKUP-TC.md
+++ b/docs/ROLE-PERMISSION-BACKUP-TC.md
@@ -1,0 +1,49 @@
+# Role Permission Backup / Restore — Test Cases
+
+## 단위 테스트 (자동)
+
+위치: `src/service/role_permission_backup_test.go`
+
+| TC ID | 시나리오 | 기대 |
+|---|---|---|
+| TC-RPB-U01 | admin에 menus 매핑 후 Backup | kind=`role-permission-backup`, role=admin, menus 정렬 목록 |
+| TC-RPB-U02 | Backup → 매핑 삭제 → Restore additive(+menu) | MenusAdded=3, DB에 3개 매핑 |
+| TC-RPB-U03 | 3개 매핑 → Restore replace-role(2개) | Removed=3, Added=2, DB는 백업 2개만 |
+| TC-RPB-U04 | YAML Parse | viewer / operations 파싱 성공 |
+
+실행:
+
+```bash
+cd mc-iam-manager/.worktrees/feat-iam-role-permission-backup/src
+go test ./service/ -run 'TestBackupAndRestore|TestRestoreRolePermissions_Replace|TestParseRolePermission' -count=1
+```
+
+## API TC (수동 / 통합)
+
+전제: IAM 기동, platform admin 토큰, 플랫폼 역할·메뉴 시드됨.
+
+| TC ID | 절차 | 기대 |
+|---|---|---|
+| TC-RPB-A01 | `GET /backup-role-permissions` | 200, YAML, `kind: role-permission-backup` |
+| TC-RPB-A02 | `GET ...?roles=admin&format=json` | 200 JSON, permissions[0].role=admin |
+| TC-RPB-A03 | `GET ...?save=true` | 200 + 헤더 `X-Role-Permission-Backup-Path`, 파일 존재 |
+| TC-RPB-A04 | body YAML로 `POST /restore-role-permissions?mode=additive` | 200, menusAdded ≥ 0 |
+| TC-RPB-A05 | `mode=replace-role` + 축소된 menus 백업 | 해당 role 메뉴가 백업과 일치 |
+| TC-RPB-A06 | `filePath=` 로컬 백업 | 200, body 없이 복구 |
+| TC-RPB-A07 | body/filePath 없음 | 400 |
+| TC-RPB-A08 | 존재하지 않는 role 이름 | 500 (role not found) |
+| TC-RPB-A09 | non-admin 토큰 | 401/403 |
+
+## 회귀 체크리스트
+
+- [ ] 기존 `GET /api/setup/initial-role-menu-permission` (CSV) 동작 유지
+- [ ] Backup이 다른 역할 매핑을 변경하지 않음
+- [ ] Additive 재호출 시 중복 행 증가 없음 (이미 있으면 skip)
+- [ ] Replace 후 백업에 없는 메뉴 매핑 제거 확인
+
+## 결과 기록
+
+| TC ID | 결과 | 일자 | 비고 |
+|---|---|---|---|
+| TC-RPB-U01~U04 | PASS | 2026-07-15 | go test ./service/ -run TestBackup… |
+| TC-RPB-A01~A09 | (환경 검증 후 기입) | | |

--- a/docs/ROLE-PERMISSION-BACKUP-USAGE.md
+++ b/docs/ROLE-PERMISSION-BACKUP-USAGE.md
@@ -1,0 +1,95 @@
+# Role Permission Backup / Restore — 사용 방안
+
+worktree: `mc-iam-manager/.worktrees/feat-iam-role-permission-backup`  
+branch: `feat-iam-role-permission-backup`
+
+## 목적
+
+- **Backup**: DB에 실제로 걸려 있는 **역할 권한**(지금은 menus)을 `role-permission-backup` 문서로 보관
+- **Restore**: 보관 문서로 역할 권한을 되돌림
+- `permission.yaml` / initial 시드와 **별개** — 시드는 desired 템플릿, 백업은 actual 운영 상태
+
+## API
+
+| Method | Path | 설명 |
+|---|---|---|
+| `GET` | `/api/setup/backup-role-permissions` | 현재 역할 권한 백업 |
+| `POST` | `/api/setup/restore-role-permissions` | 백업 문서 복구 |
+
+인증: Platform Admin (`PlatformAdminMiddleware`)
+
+### Backup
+
+```bash
+# 전체 플랫폼 역할, menus, YAML 응답
+curl -sk -H "Authorization: Bearer $TOKEN" \
+  'https://<host>:5000/api/setup/backup-role-permissions'
+
+# 특정 역할 + 파일 저장 (asset/menu/backups/)
+curl -sk -H "Authorization: Bearer $TOKEN" \
+  'https://<host>:5000/api/setup/backup-role-permissions?roles=admin,operator&sections=menus&save=true' \
+  -o role-permission-backup.yaml
+
+# JSON
+curl -sk -H "Authorization: Bearer $TOKEN" \
+  'https://<host>:5000/api/setup/backup-role-permissions?format=json'
+```
+
+Query
+
+| 파라미터 | 기본 | 설명 |
+|---|---|---|
+| `roles` | (전체 platform) | `admin,operator` |
+| `sections` | `menus` | `menus` (`operations`/`csps`는 reserved, 빈 배열) |
+| `format` | `yaml` | `yaml` \| `json` |
+| `save` | false | `true` 시 `asset/menu/backups/role-permission-backup-*.yaml` 저장. 경로는 응답 헤더 `X-Role-Permission-Backup-Path` |
+
+### Restore
+
+```bash
+# body에 YAML 전달 (additive: 없는 매핑만 추가)
+curl -sk -X POST -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/yaml' \
+  --data-binary @role-permission-backup.yaml \
+  'https://<host>:5000/api/setup/restore-role-permissions?mode=additive&sections=menus'
+
+# 서버 로컬 파일
+curl -sk -X POST -H "Authorization: Bearer $TOKEN" \
+  'https://<host>:5000/api/setup/restore-role-permissions?mode=replace-role&filePath=asset/menu/backups/role-permission-backup-20260715-120000.yaml'
+```
+
+| mode | 동작 |
+|---|---|
+| `additive` (기본) | 백업에 있는 (role, menu)만 없으면 추가. 기존 커스텀 유지 |
+| `replace-role` | 백업에 등장한 role의 메뉴 매핑을 백업 집합으로 **교체**(기존 삭제 후 재생성) |
+
+## 권장 운영 순서 (initial 재실행 전)
+
+```
+1) GET  .../backup-role-permissions?save=true
+2) (선택) initial / permission 시드 재실행
+3) 문제 시 POST .../restore-role-permissions?mode=additive|replace-role
+4) 일상 변경은 메뉴-역할 개별 API 사용
+```
+
+## 백업 문서 예시
+
+```yaml
+kind: role-permission-backup
+backupAt: "2026-07-15T13:00:00+09:00"
+source: db
+sections: [menus]
+permissions:
+  - role: admin
+    menus: [operations, observability]
+    operations: []
+    csps: []
+```
+
+- 키는 **`role` 이름** (`role_masters.name`). numeric `role_id` 없음.
+- 스키마 변경 없음 (`mcmp_role_menu_mappings`만 사용).
+
+## 제한 (1단계)
+
+- `operations` / `csps` section은 응답 자리만 유지 (시드/복구 미구현)
+- replace-role은 해당 role의 **menus 전체**를 백업 기준으로 맞추므로 운영 커스텀이 삭제될 수 있음 → 먼저 backup 필수

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -9031,6 +9031,71 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/setup/backup-role-permissions": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "플랫폼 역할의 현재 메뉴(및 reserved ops/csp) 권한을 role-permission-backup 문서로 내보냅니다",
+                "produces": [
+                    "application/json",
+                    "application/yaml"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Backup current role permissions from DB",
+                "operationId": "backupRolePermissions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Comma-separated role names (default: all platform roles)",
+                        "name": "roles",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Comma-separated sections (menus,operations,csps). Default: menus",
+                        "name": "sections",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "yaml or json (default yaml)",
+                        "name": "format",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "If true, also write under asset/menu/backups/",
+                        "name": "save",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.RolePermissionBackup"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/api/setup/check-user-roles": {
             "get": {
                 "description": "Check all roles assigned to a user. 특정 유저가 가진 role 목록을 조회합니다.",
@@ -9251,6 +9316,76 @@ const docTemplate = `{
                             "additionalProperties": {
                                 "type": "string"
                             }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/setup/restore-role-permissions": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "role-permission-backup YAML/JSON(또는 filePath)으로 역할 메뉴 권한을 복구합니다. mode=additive|replace-role",
+                "consumes": [
+                    "application/json",
+                    "application/yaml"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Restore role permissions from backup document",
+                "operationId": "restoreRolePermissions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "additive (default) or replace-role",
+                        "name": "mode",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Comma-separated sections. Default: menus",
+                        "name": "sections",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Local backup file path (if body empty)",
+                        "name": "filePath",
+                        "in": "query"
+                    },
+                    {
+                        "description": "Backup document",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/model.RolePermissionBackup"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.RolePermissionRestoreResult"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
                         }
                     }
                 }
@@ -13396,6 +13531,9 @@ const docTemplate = `{
                 "displayName": {
                     "type": "string"
                 },
+                "frameworkService": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -13406,6 +13544,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "parentId": {
+                    "type": "string"
+                },
+                "path": {
                     "type": "string"
                 },
                 "priority": {
@@ -13420,6 +13561,9 @@ const docTemplate = `{
                     "items": {
                         "type": "integer"
                     }
+                },
+                "viewType": {
+                    "type": "string"
                 }
             }
         },
@@ -14278,6 +14422,9 @@ const docTemplate = `{
                 "displayName": {
                     "type": "string"
                 },
+                "frameworkService": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -14290,10 +14437,16 @@ const docTemplate = `{
                 "parentId": {
                     "type": "string"
                 },
+                "path": {
+                    "type": "string"
+                },
                 "priority": {
                     "type": "integer"
                 },
                 "resType": {
+                    "type": "string"
+                },
+                "viewType": {
                     "type": "string"
                 }
             }
@@ -14311,6 +14464,9 @@ const docTemplate = `{
                 "displayName": {
                     "type": "string"
                 },
+                "frameworkService": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -14323,10 +14479,16 @@ const docTemplate = `{
                 "parentId": {
                     "type": "string"
                 },
+                "path": {
+                    "type": "string"
+                },
                 "priority": {
                     "type": "integer"
                 },
                 "resType": {
+                    "type": "string"
+                },
+                "viewType": {
                     "type": "string"
                 }
             }
@@ -14868,6 +15030,78 @@ const docTemplate = `{
                 },
                 "updated_at": {
                     "type": "string"
+                }
+            }
+        },
+        "model.RolePermissionBackup": {
+            "type": "object",
+            "properties": {
+                "backupAt": {
+                    "type": "string"
+                },
+                "kind": {
+                    "type": "string"
+                },
+                "permissions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.RolePermissionEntry"
+                    }
+                },
+                "sections": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "source": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.RolePermissionEntry": {
+            "type": "object",
+            "properties": {
+                "csps": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "menus": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "operations": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "role": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.RolePermissionRestoreResult": {
+            "type": "object",
+            "properties": {
+                "menusAdded": {
+                    "type": "integer"
+                },
+                "menusRemoved": {
+                    "type": "integer"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "mode": {
+                    "type": "string"
+                },
+                "rolesProcessed": {
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -9025,6 +9025,71 @@
                 }
             }
         },
+        "/api/setup/backup-role-permissions": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "플랫폼 역할의 현재 메뉴(및 reserved ops/csp) 권한을 role-permission-backup 문서로 내보냅니다",
+                "produces": [
+                    "application/json",
+                    "application/yaml"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Backup current role permissions from DB",
+                "operationId": "backupRolePermissions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Comma-separated role names (default: all platform roles)",
+                        "name": "roles",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Comma-separated sections (menus,operations,csps). Default: menus",
+                        "name": "sections",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "yaml or json (default yaml)",
+                        "name": "format",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "If true, also write under asset/menu/backups/",
+                        "name": "save",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.RolePermissionBackup"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/api/setup/check-user-roles": {
             "get": {
                 "description": "Check all roles assigned to a user. 특정 유저가 가진 role 목록을 조회합니다.",
@@ -9245,6 +9310,76 @@
                             "additionalProperties": {
                                 "type": "string"
                             }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/setup/restore-role-permissions": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "role-permission-backup YAML/JSON(또는 filePath)으로 역할 메뉴 권한을 복구합니다. mode=additive|replace-role",
+                "consumes": [
+                    "application/json",
+                    "application/yaml"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Restore role permissions from backup document",
+                "operationId": "restoreRolePermissions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "additive (default) or replace-role",
+                        "name": "mode",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Comma-separated sections. Default: menus",
+                        "name": "sections",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Local backup file path (if body empty)",
+                        "name": "filePath",
+                        "in": "query"
+                    },
+                    {
+                        "description": "Backup document",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/model.RolePermissionBackup"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.RolePermissionRestoreResult"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
                         }
                     }
                 }
@@ -13390,6 +13525,9 @@
                 "displayName": {
                     "type": "string"
                 },
+                "frameworkService": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -13400,6 +13538,9 @@
                     "type": "string"
                 },
                 "parentId": {
+                    "type": "string"
+                },
+                "path": {
                     "type": "string"
                 },
                 "priority": {
@@ -13414,6 +13555,9 @@
                     "items": {
                         "type": "integer"
                     }
+                },
+                "viewType": {
+                    "type": "string"
                 }
             }
         },
@@ -14272,6 +14416,9 @@
                 "displayName": {
                     "type": "string"
                 },
+                "frameworkService": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -14284,10 +14431,16 @@
                 "parentId": {
                     "type": "string"
                 },
+                "path": {
+                    "type": "string"
+                },
                 "priority": {
                     "type": "integer"
                 },
                 "resType": {
+                    "type": "string"
+                },
+                "viewType": {
                     "type": "string"
                 }
             }
@@ -14305,6 +14458,9 @@
                 "displayName": {
                     "type": "string"
                 },
+                "frameworkService": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -14317,10 +14473,16 @@
                 "parentId": {
                     "type": "string"
                 },
+                "path": {
+                    "type": "string"
+                },
                 "priority": {
                     "type": "integer"
                 },
                 "resType": {
+                    "type": "string"
+                },
+                "viewType": {
                     "type": "string"
                 }
             }
@@ -14862,6 +15024,78 @@
                 },
                 "updated_at": {
                     "type": "string"
+                }
+            }
+        },
+        "model.RolePermissionBackup": {
+            "type": "object",
+            "properties": {
+                "backupAt": {
+                    "type": "string"
+                },
+                "kind": {
+                    "type": "string"
+                },
+                "permissions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.RolePermissionEntry"
+                    }
+                },
+                "sections": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "source": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.RolePermissionEntry": {
+            "type": "object",
+            "properties": {
+                "csps": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "menus": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "operations": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "role": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.RolePermissionRestoreResult": {
+            "type": "object",
+            "properties": {
+                "menusAdded": {
+                    "type": "integer"
+                },
+                "menusRemoved": {
+                    "type": "integer"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "mode": {
+                    "type": "string"
+                },
+                "rolesProcessed": {
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -556,6 +556,8 @@ definitions:
     properties:
       displayName:
         type: string
+      frameworkService:
+        type: string
       id:
         type: string
       isAction:
@@ -563,6 +565,8 @@ definitions:
       menuNumber:
         type: string
       parentId:
+        type: string
+      path:
         type: string
       priority:
         type: string
@@ -573,6 +577,8 @@ definitions:
         items:
           type: integer
         type: array
+      viewType:
+        type: string
     required:
     - id
     type: object
@@ -1151,6 +1157,8 @@ definitions:
     properties:
       displayName:
         type: string
+      frameworkService:
+        type: string
       id:
         type: string
       isAction:
@@ -1159,9 +1167,13 @@ definitions:
         type: integer
       parentId:
         type: string
+      path:
+        type: string
       priority:
         type: integer
       resType:
+        type: string
+      viewType:
         type: string
     type: object
   model.MenuTreeNode:
@@ -1173,6 +1185,8 @@ definitions:
         type: array
       displayName:
         type: string
+      frameworkService:
+        type: string
       id:
         type: string
       isAction:
@@ -1181,9 +1195,13 @@ definitions:
         type: integer
       parentId:
         type: string
+      path:
+        type: string
       priority:
         type: integer
       resType:
+        type: string
+      viewType:
         type: string
     type: object
   model.MoveOrganizationRequest:
@@ -1542,6 +1560,53 @@ definitions:
         type: integer
       updated_at:
         type: string
+    type: object
+  model.RolePermissionBackup:
+    properties:
+      backupAt:
+        type: string
+      kind:
+        type: string
+      permissions:
+        items:
+          $ref: '#/definitions/model.RolePermissionEntry'
+        type: array
+      sections:
+        items:
+          type: string
+        type: array
+      source:
+        type: string
+    type: object
+  model.RolePermissionEntry:
+    properties:
+      csps:
+        items:
+          type: string
+        type: array
+      menus:
+        items:
+          type: string
+        type: array
+      operations:
+        items:
+          type: string
+        type: array
+      role:
+        type: string
+    type: object
+  model.RolePermissionRestoreResult:
+    properties:
+      menusAdded:
+        type: integer
+      menusRemoved:
+        type: integer
+      message:
+        type: string
+      mode:
+        type: string
+      rolesProcessed:
+        type: integer
     type: object
   model.RoleSub:
     properties:
@@ -7734,6 +7799,49 @@ paths:
       summary: Get workspace role by Name
       tags:
       - roles
+  /api/setup/backup-role-permissions:
+    get:
+      description: 플랫폼 역할의 현재 메뉴(및 reserved ops/csp) 권한을 role-permission-backup 문서로
+        내보냅니다
+      operationId: backupRolePermissions
+      parameters:
+      - description: 'Comma-separated role names (default: all platform roles)'
+        in: query
+        name: roles
+        type: string
+      - description: 'Comma-separated sections (menus,operations,csps). Default: menus'
+        in: query
+        name: sections
+        type: string
+      - description: yaml or json (default yaml)
+        in: query
+        name: format
+        type: string
+      - description: If true, also write under asset/menu/backups/
+        in: query
+        name: save
+        type: boolean
+      produces:
+      - application/json
+      - application/yaml
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.RolePermissionBackup'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/model.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/model.Response'
+      security:
+      - BearerAuth: []
+      summary: Backup current role permissions from DB
+      tags:
+      - admin
   /api/setup/check-user-roles:
     get:
       consumes:
@@ -7879,6 +7987,52 @@ paths:
       summary: mc-infra-manager와 프로젝트 동기화 차이 조회
       tags:
       - projects
+  /api/setup/restore-role-permissions:
+    post:
+      consumes:
+      - application/json
+      - application/yaml
+      description: role-permission-backup YAML/JSON(또는 filePath)으로 역할 메뉴 권한을 복구합니다.
+        mode=additive|replace-role
+      operationId: restoreRolePermissions
+      parameters:
+      - description: additive (default) or replace-role
+        in: query
+        name: mode
+        type: string
+      - description: 'Comma-separated sections. Default: menus'
+        in: query
+        name: sections
+        type: string
+      - description: Local backup file path (if body empty)
+        in: query
+        name: filePath
+        type: string
+      - description: Backup document
+        in: body
+        name: body
+        schema:
+          $ref: '#/definitions/model.RolePermissionBackup'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.RolePermissionRestoreResult'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/model.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/model.Response'
+      security:
+      - BearerAuth: []
+      summary: Restore role permissions from backup document
+      tags:
+      - admin
   /api/setup/sync-projects:
     post:
       consumes:

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -9031,6 +9031,71 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/setup/backup-role-permissions": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "플랫폼 역할의 현재 메뉴(및 reserved ops/csp) 권한을 role-permission-backup 문서로 내보냅니다",
+                "produces": [
+                    "application/json",
+                    "application/yaml"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Backup current role permissions from DB",
+                "operationId": "backupRolePermissions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Comma-separated role names (default: all platform roles)",
+                        "name": "roles",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Comma-separated sections (menus,operations,csps). Default: menus",
+                        "name": "sections",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "yaml or json (default yaml)",
+                        "name": "format",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "If true, also write under asset/menu/backups/",
+                        "name": "save",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.RolePermissionBackup"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/api/setup/check-user-roles": {
             "get": {
                 "description": "Check all roles assigned to a user. 특정 유저가 가진 role 목록을 조회합니다.",
@@ -9251,6 +9316,76 @@ const docTemplate = `{
                             "additionalProperties": {
                                 "type": "string"
                             }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/setup/restore-role-permissions": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "role-permission-backup YAML/JSON(또는 filePath)으로 역할 메뉴 권한을 복구합니다. mode=additive|replace-role",
+                "consumes": [
+                    "application/json",
+                    "application/yaml"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Restore role permissions from backup document",
+                "operationId": "restoreRolePermissions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "additive (default) or replace-role",
+                        "name": "mode",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Comma-separated sections. Default: menus",
+                        "name": "sections",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Local backup file path (if body empty)",
+                        "name": "filePath",
+                        "in": "query"
+                    },
+                    {
+                        "description": "Backup document",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/model.RolePermissionBackup"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.RolePermissionRestoreResult"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
                         }
                     }
                 }
@@ -13396,6 +13531,9 @@ const docTemplate = `{
                 "displayName": {
                     "type": "string"
                 },
+                "frameworkService": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -13406,6 +13544,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "parentId": {
+                    "type": "string"
+                },
+                "path": {
                     "type": "string"
                 },
                 "priority": {
@@ -13420,6 +13561,9 @@ const docTemplate = `{
                     "items": {
                         "type": "integer"
                     }
+                },
+                "viewType": {
+                    "type": "string"
                 }
             }
         },
@@ -14278,6 +14422,9 @@ const docTemplate = `{
                 "displayName": {
                     "type": "string"
                 },
+                "frameworkService": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -14290,10 +14437,16 @@ const docTemplate = `{
                 "parentId": {
                     "type": "string"
                 },
+                "path": {
+                    "type": "string"
+                },
                 "priority": {
                     "type": "integer"
                 },
                 "resType": {
+                    "type": "string"
+                },
+                "viewType": {
                     "type": "string"
                 }
             }
@@ -14311,6 +14464,9 @@ const docTemplate = `{
                 "displayName": {
                     "type": "string"
                 },
+                "frameworkService": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -14323,10 +14479,16 @@ const docTemplate = `{
                 "parentId": {
                     "type": "string"
                 },
+                "path": {
+                    "type": "string"
+                },
                 "priority": {
                     "type": "integer"
                 },
                 "resType": {
+                    "type": "string"
+                },
+                "viewType": {
                     "type": "string"
                 }
             }
@@ -14868,6 +15030,78 @@ const docTemplate = `{
                 },
                 "updated_at": {
                     "type": "string"
+                }
+            }
+        },
+        "model.RolePermissionBackup": {
+            "type": "object",
+            "properties": {
+                "backupAt": {
+                    "type": "string"
+                },
+                "kind": {
+                    "type": "string"
+                },
+                "permissions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.RolePermissionEntry"
+                    }
+                },
+                "sections": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "source": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.RolePermissionEntry": {
+            "type": "object",
+            "properties": {
+                "csps": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "menus": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "operations": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "role": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.RolePermissionRestoreResult": {
+            "type": "object",
+            "properties": {
+                "menusAdded": {
+                    "type": "integer"
+                },
+                "menusRemoved": {
+                    "type": "integer"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "mode": {
+                    "type": "string"
+                },
+                "rolesProcessed": {
+                    "type": "integer"
                 }
             }
         },

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -9025,6 +9025,71 @@
                 }
             }
         },
+        "/api/setup/backup-role-permissions": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "플랫폼 역할의 현재 메뉴(및 reserved ops/csp) 권한을 role-permission-backup 문서로 내보냅니다",
+                "produces": [
+                    "application/json",
+                    "application/yaml"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Backup current role permissions from DB",
+                "operationId": "backupRolePermissions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Comma-separated role names (default: all platform roles)",
+                        "name": "roles",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Comma-separated sections (menus,operations,csps). Default: menus",
+                        "name": "sections",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "yaml or json (default yaml)",
+                        "name": "format",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "If true, also write under asset/menu/backups/",
+                        "name": "save",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.RolePermissionBackup"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/api/setup/check-user-roles": {
             "get": {
                 "description": "Check all roles assigned to a user. 특정 유저가 가진 role 목록을 조회합니다.",
@@ -9245,6 +9310,76 @@
                             "additionalProperties": {
                                 "type": "string"
                             }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/setup/restore-role-permissions": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "role-permission-backup YAML/JSON(또는 filePath)으로 역할 메뉴 권한을 복구합니다. mode=additive|replace-role",
+                "consumes": [
+                    "application/json",
+                    "application/yaml"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Restore role permissions from backup document",
+                "operationId": "restoreRolePermissions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "additive (default) or replace-role",
+                        "name": "mode",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Comma-separated sections. Default: menus",
+                        "name": "sections",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Local backup file path (if body empty)",
+                        "name": "filePath",
+                        "in": "query"
+                    },
+                    {
+                        "description": "Backup document",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/model.RolePermissionBackup"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.RolePermissionRestoreResult"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
                         }
                     }
                 }
@@ -13390,6 +13525,9 @@
                 "displayName": {
                     "type": "string"
                 },
+                "frameworkService": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -13400,6 +13538,9 @@
                     "type": "string"
                 },
                 "parentId": {
+                    "type": "string"
+                },
+                "path": {
                     "type": "string"
                 },
                 "priority": {
@@ -13414,6 +13555,9 @@
                     "items": {
                         "type": "integer"
                     }
+                },
+                "viewType": {
+                    "type": "string"
                 }
             }
         },
@@ -14272,6 +14416,9 @@
                 "displayName": {
                     "type": "string"
                 },
+                "frameworkService": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -14284,10 +14431,16 @@
                 "parentId": {
                     "type": "string"
                 },
+                "path": {
+                    "type": "string"
+                },
                 "priority": {
                     "type": "integer"
                 },
                 "resType": {
+                    "type": "string"
+                },
+                "viewType": {
                     "type": "string"
                 }
             }
@@ -14305,6 +14458,9 @@
                 "displayName": {
                     "type": "string"
                 },
+                "frameworkService": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -14317,10 +14473,16 @@
                 "parentId": {
                     "type": "string"
                 },
+                "path": {
+                    "type": "string"
+                },
                 "priority": {
                     "type": "integer"
                 },
                 "resType": {
+                    "type": "string"
+                },
+                "viewType": {
                     "type": "string"
                 }
             }
@@ -14862,6 +15024,78 @@
                 },
                 "updated_at": {
                     "type": "string"
+                }
+            }
+        },
+        "model.RolePermissionBackup": {
+            "type": "object",
+            "properties": {
+                "backupAt": {
+                    "type": "string"
+                },
+                "kind": {
+                    "type": "string"
+                },
+                "permissions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.RolePermissionEntry"
+                    }
+                },
+                "sections": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "source": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.RolePermissionEntry": {
+            "type": "object",
+            "properties": {
+                "csps": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "menus": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "operations": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "role": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.RolePermissionRestoreResult": {
+            "type": "object",
+            "properties": {
+                "menusAdded": {
+                    "type": "integer"
+                },
+                "menusRemoved": {
+                    "type": "integer"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "mode": {
+                    "type": "string"
+                },
+                "rolesProcessed": {
+                    "type": "integer"
                 }
             }
         },

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -556,6 +556,8 @@ definitions:
     properties:
       displayName:
         type: string
+      frameworkService:
+        type: string
       id:
         type: string
       isAction:
@@ -563,6 +565,8 @@ definitions:
       menuNumber:
         type: string
       parentId:
+        type: string
+      path:
         type: string
       priority:
         type: string
@@ -573,6 +577,8 @@ definitions:
         items:
           type: integer
         type: array
+      viewType:
+        type: string
     required:
     - id
     type: object
@@ -1151,6 +1157,8 @@ definitions:
     properties:
       displayName:
         type: string
+      frameworkService:
+        type: string
       id:
         type: string
       isAction:
@@ -1159,9 +1167,13 @@ definitions:
         type: integer
       parentId:
         type: string
+      path:
+        type: string
       priority:
         type: integer
       resType:
+        type: string
+      viewType:
         type: string
     type: object
   model.MenuTreeNode:
@@ -1173,6 +1185,8 @@ definitions:
         type: array
       displayName:
         type: string
+      frameworkService:
+        type: string
       id:
         type: string
       isAction:
@@ -1181,9 +1195,13 @@ definitions:
         type: integer
       parentId:
         type: string
+      path:
+        type: string
       priority:
         type: integer
       resType:
+        type: string
+      viewType:
         type: string
     type: object
   model.MoveOrganizationRequest:
@@ -1542,6 +1560,53 @@ definitions:
         type: integer
       updated_at:
         type: string
+    type: object
+  model.RolePermissionBackup:
+    properties:
+      backupAt:
+        type: string
+      kind:
+        type: string
+      permissions:
+        items:
+          $ref: '#/definitions/model.RolePermissionEntry'
+        type: array
+      sections:
+        items:
+          type: string
+        type: array
+      source:
+        type: string
+    type: object
+  model.RolePermissionEntry:
+    properties:
+      csps:
+        items:
+          type: string
+        type: array
+      menus:
+        items:
+          type: string
+        type: array
+      operations:
+        items:
+          type: string
+        type: array
+      role:
+        type: string
+    type: object
+  model.RolePermissionRestoreResult:
+    properties:
+      menusAdded:
+        type: integer
+      menusRemoved:
+        type: integer
+      message:
+        type: string
+      mode:
+        type: string
+      rolesProcessed:
+        type: integer
     type: object
   model.RoleSub:
     properties:
@@ -7734,6 +7799,49 @@ paths:
       summary: Get workspace role by Name
       tags:
       - roles
+  /api/setup/backup-role-permissions:
+    get:
+      description: 플랫폼 역할의 현재 메뉴(및 reserved ops/csp) 권한을 role-permission-backup 문서로
+        내보냅니다
+      operationId: backupRolePermissions
+      parameters:
+      - description: 'Comma-separated role names (default: all platform roles)'
+        in: query
+        name: roles
+        type: string
+      - description: 'Comma-separated sections (menus,operations,csps). Default: menus'
+        in: query
+        name: sections
+        type: string
+      - description: yaml or json (default yaml)
+        in: query
+        name: format
+        type: string
+      - description: If true, also write under asset/menu/backups/
+        in: query
+        name: save
+        type: boolean
+      produces:
+      - application/json
+      - application/yaml
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.RolePermissionBackup'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/model.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/model.Response'
+      security:
+      - BearerAuth: []
+      summary: Backup current role permissions from DB
+      tags:
+      - admin
   /api/setup/check-user-roles:
     get:
       consumes:
@@ -7879,6 +7987,52 @@ paths:
       summary: mc-infra-manager와 프로젝트 동기화 차이 조회
       tags:
       - projects
+  /api/setup/restore-role-permissions:
+    post:
+      consumes:
+      - application/json
+      - application/yaml
+      description: role-permission-backup YAML/JSON(또는 filePath)으로 역할 메뉴 권한을 복구합니다.
+        mode=additive|replace-role
+      operationId: restoreRolePermissions
+      parameters:
+      - description: additive (default) or replace-role
+        in: query
+        name: mode
+        type: string
+      - description: 'Comma-separated sections. Default: menus'
+        in: query
+        name: sections
+        type: string
+      - description: Local backup file path (if body empty)
+        in: query
+        name: filePath
+        type: string
+      - description: Backup document
+        in: body
+        name: body
+        schema:
+          $ref: '#/definitions/model.RolePermissionBackup'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.RolePermissionRestoreResult'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/model.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/model.Response'
+      security:
+      - BearerAuth: []
+      summary: Restore role permissions from backup document
+      tags:
+      - admin
   /api/setup/sync-projects:
     post:
       consumes:

--- a/src/handler/admin_handler.go
+++ b/src/handler/admin_handler.go
@@ -1,7 +1,10 @@
 package handler
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -12,6 +15,7 @@ import (
 	"github.com/m-cmp/mc-iam-manager/constants"
 	"github.com/m-cmp/mc-iam-manager/model"
 	"github.com/m-cmp/mc-iam-manager/service"
+	"gopkg.in/yaml.v3"
 	"gorm.io/gorm"
 )
 
@@ -276,4 +280,174 @@ func (h *AdminHandler) InitializeMenuPermissions(c echo.Context) error {
 		Error:   false,
 		Message: "Menu permissions initialized successfully",
 	})
+}
+
+// BackupRolePermissions godoc
+// @Summary Backup current role permissions from DB
+// @Description 플랫폼 역할의 현재 메뉴(및 reserved ops/csp) 권한을 role-permission-backup 문서로 내보냅니다
+// @Tags admin
+// @Produce json
+// @Produce application/yaml
+// @Param roles query string false "Comma-separated role names (default: all platform roles)"
+// @Param sections query string false "Comma-separated sections (menus,operations,csps). Default: menus"
+// @Param format query string false "yaml or json (default yaml)"
+// @Param save query bool false "If true, also write under asset/menu/backups/"
+// @Success 200 {object} model.RolePermissionBackup
+// @Failure 400 {object} model.Response
+// @Failure 500 {object} model.Response
+// @Security BearerAuth
+// @Router /api/setup/backup-role-permissions [get]
+// @Id backupRolePermissions
+func (h *AdminHandler) BackupRolePermissions(c echo.Context) error {
+	roleNames := splitCSVQuery(c.QueryParam("roles"))
+	sections := splitCSVQuery(c.QueryParam("sections"))
+	format := strings.ToLower(strings.TrimSpace(c.QueryParam("format")))
+	if format == "" {
+		format = "yaml"
+	}
+	save := strings.EqualFold(c.QueryParam("save"), "true") || c.QueryParam("save") == "1"
+
+	backup, err := h.menuService.BackupRolePermissions(roleNames, sections)
+	if err != nil {
+		log.Printf("[ERROR] BackupRolePermissions failed: %v", err)
+		return c.JSON(http.StatusInternalServerError, model.Response{
+			Error:   true,
+			Message: fmt.Sprintf("Failed to backup role permissions: %v", err),
+		})
+	}
+
+	savedPath := ""
+	if save {
+		savedPath, err = h.menuService.SaveRolePermissionBackupFile(backup, "")
+		if err != nil {
+			log.Printf("[ERROR] SaveRolePermissionBackupFile failed: %v", err)
+			return c.JSON(http.StatusInternalServerError, model.Response{
+				Error:   true,
+				Message: fmt.Sprintf("Failed to save role permission backup file: %v", err),
+			})
+		}
+		log.Printf("[INFO] Role permission backup saved: %s", savedPath)
+	}
+
+	if format == "json" {
+		if savedPath != "" {
+			c.Response().Header().Set("X-Role-Permission-Backup-Path", savedPath)
+		}
+		return c.JSON(http.StatusOK, backup)
+	}
+
+	body, err := yaml.Marshal(backup)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, model.Response{
+			Error:   true,
+			Message: fmt.Sprintf("Failed to marshal backup yaml: %v", err),
+		})
+	}
+	if savedPath != "" {
+		c.Response().Header().Set("X-Role-Permission-Backup-Path", savedPath)
+	}
+	c.Response().Header().Set(
+		"Content-Disposition",
+		`attachment; filename="role-permission-backup.yaml"`,
+	)
+	return c.Blob(http.StatusOK, "application/yaml", body)
+}
+
+// RestoreRolePermissions godoc
+// @Summary Restore role permissions from backup document
+// @Description role-permission-backup YAML/JSON(또는 filePath)으로 역할 메뉴 권한을 복구합니다. mode=additive|replace-role
+// @Tags admin
+// @Accept json
+// @Accept application/yaml
+// @Produce json
+// @Param mode query string false "additive (default) or replace-role"
+// @Param sections query string false "Comma-separated sections. Default: menus"
+// @Param filePath query string false "Local backup file path (if body empty)"
+// @Param body body model.RolePermissionBackup false "Backup document"
+// @Success 200 {object} model.RolePermissionRestoreResult
+// @Failure 400 {object} model.Response
+// @Failure 500 {object} model.Response
+// @Security BearerAuth
+// @Router /api/setup/restore-role-permissions [post]
+// @Id restoreRolePermissions
+func (h *AdminHandler) RestoreRolePermissions(c echo.Context) error {
+	mode := c.QueryParam("mode")
+	sections := splitCSVQuery(c.QueryParam("sections"))
+	filePath := strings.TrimSpace(c.QueryParam("filePath"))
+
+	var backup *model.RolePermissionBackup
+	var err error
+
+	if filePath != "" {
+		backup, err = h.menuService.LoadRolePermissionBackupFile(filePath)
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, model.Response{
+				Error:   true,
+				Message: fmt.Sprintf("Failed to load backup file: %v", err),
+			})
+		}
+	} else {
+		bodyBytes, readErr := io.ReadAll(c.Request().Body)
+		if readErr != nil {
+			return c.JSON(http.StatusBadRequest, model.Response{
+				Error:   true,
+				Message: fmt.Sprintf("Failed to read request body: %v", readErr),
+			})
+		}
+		if len(bytes.TrimSpace(bodyBytes)) == 0 {
+			return c.JSON(http.StatusBadRequest, model.Response{
+				Error:   true,
+				Message: "request body or filePath is required",
+			})
+		}
+		ct := strings.ToLower(c.Request().Header.Get(echo.HeaderContentType))
+		if strings.Contains(ct, "json") {
+			backup = &model.RolePermissionBackup{}
+			if err := json.Unmarshal(bodyBytes, backup); err != nil {
+				return c.JSON(http.StatusBadRequest, model.Response{
+					Error:   true,
+					Message: fmt.Sprintf("Invalid backup JSON: %v", err),
+				})
+			}
+		} else {
+			backup, err = service.ParseRolePermissionBackupYAML(bodyBytes)
+			if err != nil {
+				return c.JSON(http.StatusBadRequest, model.Response{
+					Error:   true,
+					Message: err.Error(),
+				})
+			}
+		}
+	}
+
+	result, err := h.menuService.RestoreRolePermissions(backup, mode, sections)
+	if err != nil {
+		log.Printf("[ERROR] RestoreRolePermissions failed: %v", err)
+		return c.JSON(http.StatusInternalServerError, model.Response{
+			Error:   true,
+			Message: fmt.Sprintf("Failed to restore role permissions: %v", err),
+		})
+	}
+
+	log.Printf(
+		"[INFO] Role permissions restored: mode=%s roles=%d added=%d removed=%d",
+		result.Mode, result.RolesProcessed, result.MenusAdded, result.MenusRemoved,
+	)
+	return c.JSON(http.StatusOK, result)
+}
+
+func splitCSVQuery(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }

--- a/src/main.go
+++ b/src/main.go
@@ -233,6 +233,8 @@ func main() {
 		setup.POST("/initial-menus", menuHandler.RegisterMenusFromYAML, middleware.PlatformAdminMiddleware)
 		setup.POST("/initial-menus2", menuHandler.RegisterMenusFromBody, middleware.PlatformAdminMiddleware)
 		setup.GET("/initial-role-menu-permission", adminHandler.InitializeMenuPermissions, middleware.PlatformAdminMiddleware)
+		setup.GET("/backup-role-permissions", adminHandler.BackupRolePermissions, middleware.PlatformAdminMiddleware)
+		setup.POST("/restore-role-permissions", adminHandler.RestoreRolePermissions, middleware.PlatformAdminMiddleware)
 		setup.POST("/initial-organizations", organizationHandler.SetupInitialOrganizations, middleware.PlatformAdminMiddleware)
 	}
 

--- a/src/model/menu.go
+++ b/src/model/menu.go
@@ -55,3 +55,29 @@ type CreateMenuResponse struct {
 	Menu         *Menu              `json:"menu"`
 	RoleMappings []*RoleMenuMapping `json:"roleMappings"`
 }
+
+// RolePermissionEntry 역할 단위 권한 (permission.yaml / role-permission-backup 공통)
+type RolePermissionEntry struct {
+	Role       string   `json:"role" yaml:"role"`
+	Menus      []string `json:"menus" yaml:"menus"`
+	Operations []string `json:"operations" yaml:"operations"`
+	Csps       []string `json:"csps" yaml:"csps"`
+}
+
+// RolePermissionBackup DB 역할 권한 백업 문서 (kind: role-permission-backup)
+type RolePermissionBackup struct {
+	Kind        string                `json:"kind" yaml:"kind"`
+	BackupAt    string                `json:"backupAt" yaml:"backupAt"`
+	Source      string                `json:"source" yaml:"source"`
+	Sections    []string              `json:"sections" yaml:"sections"`
+	Permissions []RolePermissionEntry `json:"permissions" yaml:"permissions"`
+}
+
+// RolePermissionRestoreResult restore 결과 요약
+type RolePermissionRestoreResult struct {
+	Mode           string `json:"mode"`
+	RolesProcessed int    `json:"rolesProcessed"`
+	MenusAdded     int    `json:"menusAdded"`
+	MenusRemoved   int    `json:"menusRemoved"`
+	Message        string `json:"message"`
+}

--- a/src/service/csp_account_service_test.go
+++ b/src/service/csp_account_service_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -52,7 +53,7 @@ func TestCspAccountValidate_AWS_Valid(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = svc.ValidateCspAccount(created.ID)
+	_, err = svc.ValidateCspAccount(context.Background(), created.ID)
 	assert.NoError(t, err)
 }
 
@@ -67,7 +68,7 @@ func TestCspAccountValidate_AWS_MissingAccountID(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = svc.ValidateCspAccount(created.ID)
+	_, err = svc.ValidateCspAccount(context.Background(), created.ID)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "AWS account_id is required")
 }
@@ -85,7 +86,7 @@ func TestCspAccountValidate_GCP_Valid(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = svc.ValidateCspAccount(created.ID)
+	_, err = svc.ValidateCspAccount(context.Background(), created.ID)
 	assert.NoError(t, err)
 }
 
@@ -100,7 +101,7 @@ func TestCspAccountValidate_GCP_MissingProjectID(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = svc.ValidateCspAccount(created.ID)
+	_, err = svc.ValidateCspAccount(context.Background(), created.ID)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "GCP project_id is required")
 }
@@ -119,7 +120,7 @@ func TestCspAccountValidate_Azure_Valid(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = svc.ValidateCspAccount(created.ID)
+	_, err = svc.ValidateCspAccount(context.Background(), created.ID)
 	assert.NoError(t, err)
 }
 
@@ -136,7 +137,7 @@ func TestCspAccountValidate_Azure_MissingSubscriptionID(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = svc.ValidateCspAccount(created.ID)
+	_, err = svc.ValidateCspAccount(context.Background(), created.ID)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Azure subscription_id is required")
 }
@@ -154,7 +155,7 @@ func TestCspAccountValidate_Azure_MissingTenantID(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = svc.ValidateCspAccount(created.ID)
+	_, err = svc.ValidateCspAccount(context.Background(), created.ID)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Azure tenant_id is required")
 }
@@ -175,7 +176,7 @@ func TestCspAccountValidate_UnsupportedType(t *testing.T) {
 	err := db.Create(account).Error
 	require.NoError(t, err)
 
-	err = svc.ValidateCspAccount(account.ID)
+	_, err = svc.ValidateCspAccount(context.Background(), account.ID)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported CSP type")
 }
@@ -184,7 +185,7 @@ func TestCspAccountValidate_UnsupportedType(t *testing.T) {
 func TestCspAccountValidate_NotFound(t *testing.T) {
 	svc, _ := newTestService(t)
 
-	err := svc.ValidateCspAccount(9999)
+	_, err := svc.ValidateCspAccount(context.Background(), 9999)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "CSP account not found with ID: 9999")
 }
@@ -272,7 +273,7 @@ func TestCspAccountDelete_Success(t *testing.T) {
 	assert.NoError(t, err)
 
 	// 삭제 후 조회 시 에러 확인
-	err = svc.ValidateCspAccount(created.ID)
+	_, err = svc.ValidateCspAccount(context.Background(), created.ID)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), fmt.Sprintf("CSP account not found with ID: %d", created.ID))
 }

--- a/src/service/menu_service.go
+++ b/src/service/menu_service.go
@@ -11,6 +11,7 @@ import (
 	"sort" // Added
 	"strconv"
 	"strings"
+	"time"
 
 	"encoding/csv"
 
@@ -838,4 +839,309 @@ func (s *MenuService) DeleteRoleMenuMappingByRoleAndMenu(roleID uint, menuID str
 // 해당 role 과 매핑된 메뉴 삭제
 func (s *MenuService) DeleteRoleMenuMappingsByRoleID(roleID uint) error {
 	return s.menuRepo.DeleteRoleMenuMappingsByRoleID(roleID)
+}
+
+const (
+	rolePermissionBackupKind     = "role-permission-backup"
+	rolePermissionSectionMenus   = "menus"
+	rolePermissionSectionOps     = "operations"
+	rolePermissionSectionCsps    = "csps"
+	rolePermissionRestoreAdd     = "additive"
+	rolePermissionRestoreReplace = "replace-role"
+)
+
+// BackupRolePermissions 현재 DB의 플랫폼 역할 권한을 백업 문서로 내보냅니다.
+// roleNames가 비어 있으면 플랫폼 역할 전체. sections 기본값은 menus.
+// role_masters.name 기준으로 직렬화합니다 (numeric role_id 미사용).
+func (s *MenuService) BackupRolePermissions(
+	roleNames []string, sections []string,
+) (*model.RolePermissionBackup, error) {
+	sections = normalizeRolePermissionSections(sections)
+	roles, err := s.resolvePlatformRolesForBackup(roleNames)
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(roles, func(i, j int) bool {
+		return roles[i].Name < roles[j].Name
+	})
+
+	entries := make([]model.RolePermissionEntry, 0, len(roles))
+	for _, role := range roles {
+		entry := model.RolePermissionEntry{
+			Role:       role.Name,
+			Menus:      []string{},
+			Operations: []string{},
+			Csps:       []string{},
+		}
+		if containsSection(sections, rolePermissionSectionMenus) {
+			menuIDs, err := s.menuMappingRepo.GetMappedMenuIDs(role.ID)
+			if err != nil {
+				return nil, fmt.Errorf("failed to list menus for role %s: %w", role.Name, err)
+			}
+			sort.Strings(menuIDs)
+			entry.Menus = menuIDs
+		}
+		if containsSection(sections, rolePermissionSectionOps) ||
+			containsSection(sections, rolePermissionSectionCsps) {
+			// reserved: 스키마 자리만 유지 (1단계는 menus)
+			fmt.Printf(
+				"Note: backup role %s — operations/csps sections reserved (empty)\n",
+				role.Name,
+			)
+		}
+		entries = append(entries, entry)
+	}
+
+	return &model.RolePermissionBackup{
+		Kind:        rolePermissionBackupKind,
+		BackupAt:    time.Now().Format(time.RFC3339),
+		Source:      "db",
+		Sections:    sections,
+		Permissions: entries,
+	}, nil
+}
+
+// SaveRolePermissionBackupFile 백업 문서를 asset/menu/backups/ 에 저장합니다.
+func (s *MenuService) SaveRolePermissionBackupFile(
+	backup *model.RolePermissionBackup, fileName string,
+) (string, error) {
+	if backup == nil {
+		return "", fmt.Errorf("backup is nil")
+	}
+	assetPath := util.GetAssetPath()
+	dir := filepath.Join(assetPath, "menu", "backups")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("failed to create backup dir: %w", err)
+	}
+	if fileName == "" {
+		fileName = fmt.Sprintf(
+			"role-permission-backup-%s.yaml",
+			time.Now().Format("20060102-150405"),
+		)
+	}
+	path := filepath.Join(dir, fileName)
+	body, err := yaml.Marshal(backup)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal backup: %w", err)
+	}
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		return "", fmt.Errorf("failed to write backup file: %w", err)
+	}
+	return path, nil
+}
+
+// RestoreRolePermissions 역할 권한 백업 문서를 DB에 복구합니다.
+// mode: additive | replace-role
+func (s *MenuService) RestoreRolePermissions(
+	backup *model.RolePermissionBackup, mode string, sections []string,
+) (*model.RolePermissionRestoreResult, error) {
+	if backup == nil {
+		return nil, fmt.Errorf("backup is nil")
+	}
+	if len(backup.Permissions) == 0 {
+		return nil, fmt.Errorf("backup has no permissions entries")
+	}
+	mode = strings.TrimSpace(strings.ToLower(mode))
+	if mode == "" {
+		mode = rolePermissionRestoreAdd
+	}
+	if mode != rolePermissionRestoreAdd && mode != rolePermissionRestoreReplace {
+		return nil, fmt.Errorf(
+			"invalid mode %q (use %s or %s)",
+			mode, rolePermissionRestoreAdd, rolePermissionRestoreReplace,
+		)
+	}
+	sections = normalizeRolePermissionSections(sections)
+	if backup.Kind != "" && backup.Kind != rolePermissionBackupKind {
+		fmt.Printf(
+			"Warning: backup kind=%q (expected %q); proceeding\n",
+			backup.Kind, rolePermissionBackupKind,
+		)
+	}
+
+	result := &model.RolePermissionRestoreResult{
+		Mode:    mode,
+		Message: "role permission restore completed",
+	}
+
+	for _, entry := range backup.Permissions {
+		roleName := strings.TrimSpace(entry.Role)
+		if roleName == "" {
+			return nil, fmt.Errorf("permission entry missing role")
+		}
+		role, err := s.roleRepo.FindRoleByRoleName(roleName, constants.RoleTypePlatform)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find role %s: %w", roleName, err)
+		}
+		if role == nil {
+			return nil, fmt.Errorf("role not found: %s", roleName)
+		}
+		result.RolesProcessed++
+
+		if !containsSection(sections, rolePermissionSectionMenus) {
+			continue
+		}
+
+		desired := uniqueNonEmpty(entry.Menus)
+		if mode == rolePermissionRestoreReplace {
+			removed, err := s.replaceRoleMenuMappings(role.ID, desired)
+			if err != nil {
+				return nil, fmt.Errorf("replace-role failed for %s: %w", roleName, err)
+			}
+			result.MenusRemoved += removed
+			result.MenusAdded += len(desired)
+			continue
+		}
+
+		added, err := s.addMissingRoleMenuMappings(role.ID, desired)
+		if err != nil {
+			return nil, fmt.Errorf("additive restore failed for %s: %w", roleName, err)
+		}
+		result.MenusAdded += added
+	}
+
+	return result, nil
+}
+
+// ParseRolePermissionBackupYAML YAML 바이트를 RolePermissionBackup으로 파싱합니다.
+func ParseRolePermissionBackupYAML(body []byte) (*model.RolePermissionBackup, error) {
+	var backup model.RolePermissionBackup
+	if err := yaml.Unmarshal(body, &backup); err != nil {
+		return nil, fmt.Errorf("failed to parse role permission backup: %w", err)
+	}
+	return &backup, nil
+}
+
+// LoadRolePermissionBackupFile 파일에서 백업 문서를 로드합니다.
+func (s *MenuService) LoadRolePermissionBackupFile(filePath string) (*model.RolePermissionBackup, error) {
+	body, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read backup file: %w", err)
+	}
+	return ParseRolePermissionBackupYAML(body)
+}
+
+func (s *MenuService) resolvePlatformRolesForBackup(
+	roleNames []string,
+) ([]*model.RoleMaster, error) {
+	if len(roleNames) > 0 {
+		out := make([]*model.RoleMaster, 0, len(roleNames))
+		for _, name := range roleNames {
+			name = strings.TrimSpace(name)
+			if name == "" {
+				continue
+			}
+			role, err := s.roleRepo.FindRoleByRoleName(name, constants.RoleTypePlatform)
+			if err != nil {
+				return nil, fmt.Errorf("failed to find role %s: %w", name, err)
+			}
+			if role == nil {
+				return nil, fmt.Errorf("role not found: %s", name)
+			}
+			out = append(out, role)
+		}
+		return out, nil
+	}
+
+	roles, err := s.roleRepo.FindRoles(&model.RoleFilterRequest{
+		RoleTypes: []constants.IAMRoleType{constants.RoleTypePlatform},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list platform roles: %w", err)
+	}
+	return roles, nil
+}
+
+func (s *MenuService) addMissingRoleMenuMappings(roleID uint, menuIDs []string) (int, error) {
+	existing, err := s.menuMappingRepo.GetMappedMenuIDs(roleID)
+	if err != nil {
+		return 0, err
+	}
+	have := make(map[string]bool, len(existing))
+	for _, id := range existing {
+		have[id] = true
+	}
+	added := 0
+	for _, menuID := range menuIDs {
+		if have[menuID] {
+			continue
+		}
+		mapping := &model.RoleMenuMapping{RoleID: roleID, MenuID: menuID}
+		if err := s.menuRepo.CreateRoleMenuMappings([]*model.RoleMenuMapping{mapping}); err != nil {
+			return added, err
+		}
+		added++
+		have[menuID] = true
+	}
+	return added, nil
+}
+
+func (s *MenuService) replaceRoleMenuMappings(roleID uint, menuIDs []string) (int, error) {
+	existing, err := s.menuMappingRepo.GetMappedMenuIDs(roleID)
+	if err != nil {
+		return 0, err
+	}
+	if err := s.menuRepo.DeleteRoleMenuMappingsByRoleID(roleID); err != nil {
+		return 0, err
+	}
+	if len(menuIDs) > 0 {
+		mappings := make([]*model.RoleMenuMapping, 0, len(menuIDs))
+		for _, menuID := range menuIDs {
+			mappings = append(mappings, &model.RoleMenuMapping{
+				RoleID: roleID,
+				MenuID: menuID,
+			})
+		}
+		if err := s.menuRepo.CreateRoleMenuMappings(mappings); err != nil {
+			return 0, err
+		}
+	}
+	return len(existing), nil
+}
+
+func normalizeRolePermissionSections(sections []string) []string {
+	if len(sections) == 0 {
+		return []string{rolePermissionSectionMenus}
+	}
+	seen := map[string]bool{}
+	out := make([]string, 0, len(sections))
+	for _, s := range sections {
+		s = strings.TrimSpace(strings.ToLower(s))
+		if s == "" || seen[s] {
+			continue
+		}
+		switch s {
+		case rolePermissionSectionMenus, rolePermissionSectionOps, rolePermissionSectionCsps:
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 {
+		return []string{rolePermissionSectionMenus}
+	}
+	return out
+}
+
+func containsSection(sections []string, target string) bool {
+	for _, s := range sections {
+		if s == target {
+			return true
+		}
+	}
+	return false
+}
+
+func uniqueNonEmpty(ids []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		out = append(out, id)
+	}
+	return out
 }

--- a/src/service/mock_keycloak_service_test.go
+++ b/src/service/mock_keycloak_service_test.go
@@ -29,6 +29,7 @@ func (m *mockKeycloakService) CreateUser(ctx context.Context, user *model.User) 
 func (m *mockKeycloakService) UpdateUser(ctx context.Context, user *model.User) error { return nil }
 func (m *mockKeycloakService) DeleteUser(ctx context.Context, kcId string) error      { return nil }
 func (m *mockKeycloakService) EnableUser(ctx context.Context, kcUserID string) error  { return nil }
+func (m *mockKeycloakService) DisableUser(ctx context.Context, kcUserID string) error { return nil }
 func (m *mockKeycloakService) CheckAdminLogin(ctx context.Context) (bool, error)      { return false, nil }
 func (m *mockKeycloakService) CheckRealm(ctx context.Context) (bool, error)           { return false, nil }
 func (m *mockKeycloakService) CreateRealm(ctx context.Context, accessToken string) (bool, error) {

--- a/src/service/role_permission_backup_test.go
+++ b/src/service/role_permission_backup_test.go
@@ -1,0 +1,141 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/m-cmp/mc-iam-manager/constants"
+	"github.com/m-cmp/mc-iam-manager/model"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupRolePermissionBackupTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&model.RoleMaster{},
+		&model.RoleSub{},
+		&model.Menu{},
+		&model.RoleMenuMapping{},
+	))
+	return db
+}
+
+func seedPlatformRole(t *testing.T, db *gorm.DB, name string) *model.RoleMaster {
+	t.Helper()
+	role := &model.RoleMaster{Name: name, Description: name, Predefined: true}
+	require.NoError(t, db.Create(role).Error)
+	require.NoError(t, db.Create(&model.RoleSub{
+		RoleID:    role.ID,
+		RoleType:  constants.RoleTypePlatform,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}).Error)
+	return role
+}
+
+func seedMenu(t *testing.T, db *gorm.DB, id, display string) {
+	t.Helper()
+	require.NoError(t, db.Create(&model.Menu{
+		ID:               id,
+		DisplayName:      display,
+		ResType:          "menu",
+		Priority:         1,
+		MenuNumber:       1,
+		ViewType:         "local",
+		FrameworkService: "mc-web-console-front",
+		Path:             "",
+	}).Error)
+}
+
+func TestBackupAndRestoreRolePermissions_Additive(t *testing.T) {
+	db := setupRolePermissionBackupTestDB(t)
+	svc := NewMenuService(db)
+
+	admin := seedPlatformRole(t, db, "admin")
+	seedPlatformRole(t, db, "operator")
+	seedMenu(t, db, "operations", "Operations")
+	seedMenu(t, db, "observability", "Monitorings")
+	seedMenu(t, db, "costanalysis", "Cost Analysis")
+
+	require.NoError(t, svc.CreateRoleMenuMappings([]*model.RoleMenuMapping{
+		{RoleID: admin.ID, MenuID: "operations"},
+		{RoleID: admin.ID, MenuID: "observability"},
+	}))
+
+	backup, err := svc.BackupRolePermissions([]string{"admin"}, []string{"menus"})
+	require.NoError(t, err)
+	require.Equal(t, "role-permission-backup", backup.Kind)
+	require.Equal(t, "db", backup.Source)
+	require.Len(t, backup.Permissions, 1)
+	require.Equal(t, "admin", backup.Permissions[0].Role)
+	require.Equal(t, []string{"observability", "operations"}, backup.Permissions[0].Menus)
+
+	// wipe mapping then additive restore from backup that also adds costanalysis
+	require.NoError(t, svc.DeleteRoleMenuMappingsByRoleID(admin.ID))
+	backup.Permissions[0].Menus = append(backup.Permissions[0].Menus, "costanalysis")
+
+	result, err := svc.RestoreRolePermissions(backup, "additive", []string{"menus"})
+	require.NoError(t, err)
+	require.Equal(t, 1, result.RolesProcessed)
+	require.Equal(t, 3, result.MenusAdded)
+
+	ids, err := svc.menuMappingRepo.GetMappedMenuIDs(admin.ID)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"operations", "observability", "costanalysis"}, ids)
+}
+
+func TestRestoreRolePermissions_ReplaceRole(t *testing.T) {
+	db := setupRolePermissionBackupTestDB(t)
+	svc := NewMenuService(db)
+
+	admin := seedPlatformRole(t, db, "admin")
+	seedMenu(t, db, "operations", "Operations")
+	seedMenu(t, db, "observability", "Monitorings")
+	seedMenu(t, db, "costanalysis", "Cost Analysis")
+
+	require.NoError(t, svc.CreateRoleMenuMappings([]*model.RoleMenuMapping{
+		{RoleID: admin.ID, MenuID: "operations"},
+		{RoleID: admin.ID, MenuID: "observability"},
+		{RoleID: admin.ID, MenuID: "costanalysis"},
+	}))
+
+	backup := &model.RolePermissionBackup{
+		Kind:     "role-permission-backup",
+		Source:   "db",
+		Sections: []string{"menus"},
+		Permissions: []model.RolePermissionEntry{
+			{Role: "admin", Menus: []string{"operations", "observability"}},
+		},
+	}
+
+	result, err := svc.RestoreRolePermissions(backup, "replace-role", []string{"menus"})
+	require.NoError(t, err)
+	require.Equal(t, 3, result.MenusRemoved)
+	require.Equal(t, 2, result.MenusAdded)
+
+	ids, err := svc.menuMappingRepo.GetMappedMenuIDs(admin.ID)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"operations", "observability"}, ids)
+}
+
+func TestParseRolePermissionBackupYAML(t *testing.T) {
+	raw := []byte(`
+kind: role-permission-backup
+backupAt: "2026-07-15T12:00:00+09:00"
+source: db
+sections: [menus]
+permissions:
+  - role: viewer
+    menus: [operations]
+    operations: []
+    csps: []
+`)
+	backup, err := ParseRolePermissionBackupYAML(raw)
+	require.NoError(t, err)
+	require.Equal(t, "viewer", backup.Permissions[0].Role)
+	require.Equal(t, []string{"operations"}, backup.Permissions[0].Menus)
+}


### PR DESCRIPTION
## Summary
- Add `GET /api/setup/backup-role-permissions` to export current platform role–menu permissions as a `role-permission-backup` document (role name based, no numeric role_id).
- Add `POST /api/setup/restore-role-permissions` with `additive` / `replace-role` modes to restore from body or `filePath`.
- Include usage guide, API/unit TCs, and Swagger/service-actions updates. Optional `save=true` writes under `asset/menu/backups/`.

## Test plan
- [ ] `cd src && go test ./service/ -run 'TestBackupAndRestore|TestRestoreRolePermissions_Replace|TestParseRolePermission' -count=1`
- [ ] `go build ./`
- [ ] Platform admin: `GET /api/setup/backup-role-permissions?roles=admin&save=true` returns YAML and creates a backup file
- [ ] `POST /api/setup/restore-role-permissions?mode=additive` with that YAML restores missing mappings only
- [ ] `mode=replace-role` aligns target role menus to the backup set
- [ ] Non-admin token is rejected