### PR TITLE
[feat]: seed role-menu permissions from permission.yaml instead of CSV

### DIFF
--- a/asset/mcmpapi/service-actions.yaml
+++ b/asset/mcmpapi/service-actions.yaml
@@ -833,7 +833,11 @@ serviceActions:
         initializeMenuPermissions:
             method: get
             resourcePath: /api/setup/initial-role-menu-permission
-            description: CSV 파일을 읽어서 메뉴 권한을 초기화합니다
+            description: "(Deprecated) CSV 파일을 읽어서 메뉴 권한을 초기화합니다. Use initializeMenuPermissionsFromYAML."
+        initializeMenuPermissionsFromYAML:
+            method: get
+            resourcePath: /api/setup/initial-role-menu-permission-yaml
+            description: permission.yaml(permissions→role→menus|operations|csps)을 읽어 역할-메뉴 권한을 초기화합니다
         backupRolePermissions:
             method: get
             resourcePath: /api/setup/backup-role-permissions

--- a/asset/menu/menu.yaml
+++ b/asset/menu/menu.yaml
@@ -1,4 +1,190 @@
+# Synchronized from remote mcmp_menus (15.164.139.37) + iframe path fixes — 2026-07-15
+# Removed obsolete monitorings/eventsntraces local trees; use observability iframe.
 menus:
+
+  - id: operations
+    parentid: home
+    displayname: Operations
+    restype: menu
+    isaction: false
+    priority: 2
+    menunumber: 1700
+
+  - id: manage
+    parentid: operations
+    displayname: Manage
+    restype: menu
+    isaction: false
+    priority: 2
+    menunumber: 1701
+
+  - id: workspaces
+    parentid: manage
+    displayname: Workspaces
+    restype: menu
+    isaction: true
+    priority: 2
+    menunumber: 1710
+
+  - id: projects
+    parentid: workspaces
+    displayname: Projects
+    restype: menu
+    isaction: false
+    priority: 2
+    menunumber: 1720
+
+  - id: projectboard
+    parentid: workspaces
+    displayname: Project board
+    restype: menu
+    isaction: false
+    priority: 2
+    menunumber: 1728
+
+  - id: members
+    parentid: workspaces
+    displayname: Members
+    restype: menu
+    isaction: false
+    priority: 2
+    menunumber: 1730
+
+  - id: roles
+    parentid: workspaces
+    displayname: Roles
+    restype: menu
+    isaction: false
+    priority: 2
+    menunumber: 1740
+
+  - id: csproles
+    parentid: workspaces
+    displayname: CSP Roles
+    restype: menu
+    isaction: true
+    priority: 2
+    menunumber: 1741
+
+  - id: workloads
+    parentid: manage
+    displayname: Workloads
+    restype: menu
+    isaction: false
+    priority: 2
+    menunumber: 1750
+
+  - id: mciworkloads
+    parentid: workloads
+    displayname: MCI Workloads
+    restype: menu
+    isaction: true
+    priority: 2
+    menunumber: 1760
+
+  - id: pmkworkloads
+    parentid: workloads
+    displayname: PMK Workloads
+    restype: menu
+    isaction: true
+    priority: 2
+    menunumber: 1790
+
+  - id: workflows
+    parentid: manage
+    displayname: Workflows
+    restype: menu
+    viewtype: iframe
+    frameworkservice: mc-workflow-manager-fe
+    path: /web/workflows/workflow/list
+    isaction: true
+    priority: 2
+    menunumber: 1998
+
+  - id: swcatalogs
+    parentid: manage
+    displayname: SW Catalogs
+    restype: menu
+    viewtype: iframe
+    frameworkservice: mc-application-manager-fe
+    path: /web/softwareCatalog
+    isaction: true
+    priority: 2
+    menunumber: 1998
+
+  - id: mcdatamanager
+    parentid: manage
+    displayname: Data Migrations
+    restype: menu
+    viewtype: iframe
+    frameworkservice: mc-data-manager-fe
+    path: /migrate/objectstorage
+    isaction: false
+    priority: 3
+    menunumber: 1997
+
+  - id: datamigrations
+    parentid: mcdatamanager
+    displayname: Data Migrations
+    restype: menu
+    viewtype: iframe
+    frameworkservice: mc-data-manager-fe
+    path: /
+    isaction: true
+    priority: 1
+    menunumber: 1998
+
+  - id: generateobjectstorage
+    parentid: mcdatamanager
+    displayname: Generate OSS
+    restype: menu
+    viewtype: iframe
+    frameworkservice: mc-data-manager-fe
+    path: /generate/objectstorage
+    isaction: true
+    priority: 2
+    menunumber: 19971
+
+  - id: generaterdb
+    parentid: mcdatamanager
+    displayname: GenerateRDB
+    restype: menu
+    viewtype: iframe
+    frameworkservice: mc-data-manager-fe
+    path: /generate/mysql
+    isaction: true
+    priority: 2
+    menunumber: 19972
+
+  - id: analytics
+    parentid: operations
+    displayname: Analytics
+    restype: menu
+    isaction: false
+    priority: 3
+    menunumber: 1901
+
+  - id: costanalysis
+    parentid: analytics
+    displayname: Cost Analysis
+    restype: menu
+    viewtype: iframe
+    frameworkservice: mc-cost-optimizer-fe
+    path: /
+    isaction: true
+    priority: 2
+    menunumber: 1998
+
+  - id: observability
+    parentid: analytics
+    displayname: Monitorings
+    restype: menu
+    viewtype: iframe
+    frameworkservice: mc-observability-fe
+    path: /
+    isaction: true
+    priority: 3
+    menunumber: 1999
 
   - id: settings
     parentid: home
@@ -39,6 +225,14 @@ menus:
     isaction: false
     priority: 2
     menunumber: 1220
+
+  - id: groups
+    parentid: organizations
+    displayname: Groups
+    restype: menu
+    isaction: true
+    priority: 2
+    menunumber: 1225
 
   - id: approvals
     parentid: organizations
@@ -120,6 +314,14 @@ menus:
     priority: 2
     menunumber: 1350
 
+  - id: cspaccounts
+    parentid: cloudsps
+    displayname: CSP Accounts
+    restype: menu
+    isaction: false
+    priority: 2
+    menunumber: 1360
+
   - id: cloudresources
     parentid: environment
     displayname: Cloud Resources
@@ -127,6 +329,14 @@ menus:
     isaction: false
     priority: 2
     menunumber: 1405
+
+  - id: serverspecs
+    parentid: cloudresources
+    displayname: Specs
+    restype: menu
+    isaction: false
+    priority: 2
+    menunumber: 1410
 
   - id: specs
     parentid: cloudresources
@@ -144,6 +354,14 @@ menus:
     priority: 2
     menunumber: 1420
 
+  - id: serverimages
+    parentid: cloudresources
+    displayname: Images
+    restype: menu
+    isaction: false
+    priority: 2
+    menunumber: 1420
+
   - id: networks
     parentid: cloudresources
     displayname: Networks
@@ -151,6 +369,14 @@ menus:
     isaction: false
     priority: 2
     menunumber: 1510
+
+  - id: securitygroups
+    parentid: cloudresources
+    displayname: Security Groups
+    restype: menu
+    isaction: false
+    priority: 2
+    menunumber: 1520
 
   - id: securitys
     parentid: cloudresources
@@ -183,6 +409,30 @@ menus:
     isaction: false
     priority: 2
     menunumber: 1550
+
+  - id: csp
+    parentid: cloudresources
+    displayname: CSP Overview
+    restype: menu
+    isaction: true
+    priority: 2
+    menunumber: 1580
+
+  - id: cspschedule
+    parentid: cloudresources
+    displayname: CSP Schedule
+    restype: menu
+    isaction: true
+    priority: 2
+    menunumber: 1590
+
+  - id: resourcesync
+    parentid: cloudresources
+    displayname: Resource Sync
+    restype: menu
+    isaction: true
+    priority: 3
+    menunumber: 1595
 
   - id: cloudrescatalogs
     parentid: environment
@@ -223,229 +473,3 @@ menus:
     isaction: false
     priority: 2
     menunumber: 1667
-
-  - id: operations
-    parentid: home
-    displayname: Operations
-    restype: menu
-    isaction: false
-    priority: 2
-    menunumber: 1700
-
-  - id: manage
-    parentid: operations
-    displayname: Manage
-    restype: menu
-    isaction: false
-    priority: 2
-    menunumber: 1701
-
-  - id: workspaces
-    parentid: manage
-    displayname: Workspaces
-    restype: menu
-    isaction: true
-    priority: 2
-    menunumber: 1710
-
-  - id: projects
-    parentid: workspaces
-    displayname: Projects
-    restype: menu
-    isaction: false
-    priority: 2
-    menunumber: 1720
-
-  - id: members
-    parentid: workspaces
-    displayname: Members
-    restype: menu
-    isaction: false
-    priority: 2
-    menunumber: 1730
-
-  - id: roles
-    parentid: workspaces
-    displayname: Roles
-    restype: menu
-    isaction: false
-    priority: 2
-    menunumber: 1740
-
-  - id: projectboard
-    parentid: workspaces
-    displayname: Project board
-    restype: menu
-    isaction: false
-    priority: 2
-    menunumber: 1728
-
-  - id: workloads
-    parentid: manage
-    displayname: Workloads
-    restype: menu
-    isaction: false
-    priority: 2
-    menunumber: 1750
-
-  - id: mciworkloads
-    parentid: workloads
-    displayname: MCI Workloads
-    restype: menu
-    isaction: true
-    priority: 2
-    menunumber: 1760
-
-  - id: pmkworkloads
-    parentid: workloads
-    displayname: PMK Workloads
-    restype: menu
-    isaction: true
-    priority: 2
-    menunumber: 1790
-
-  - id: workflows
-    parentid: manage
-    displayname: Workflows
-    restype: menu
-    viewtype: iframe
-    frameworkservice: mc-workflow-manager-fe
-    path: /web/workflow/list
-    isaction: true
-    priority: 2
-    menunumber: 1998
-
-  - id: swcatalogs
-    parentid: manage
-    displayname: SW Catalogs
-    restype: menu
-    viewtype: iframe
-    frameworkservice: mc-application-manager-fe
-    path: /web/softwareCatalog
-    isaction: true
-    priority: 2
-    menunumber: 1998
-
-  - id: datamigrations
-    parentid: manage
-    displayname: Data Migrations
-    restype: menu
-    viewtype: iframe
-    frameworkservice: mc-data-manager-fe
-    path: /
-    isaction: true
-    priority: 2
-    menunumber: 1998
-
-  - id: analytics
-    parentid: operations
-    displayname: Analytics
-    restype: menu
-    isaction: false
-    priority: 3
-    menunumber: 1901
-
-  - id: monitorings
-    parentid: analytics
-    displayname: Monitorings
-    restype: menu
-    isaction: false
-    priority: 2
-    menunumber: 1905
-
-  - id: mcismonitoring
-    parentid: monitorings
-    displayname: MCIs Monitoring
-    restype: menu
-    isaction: true
-    priority: 2
-    menunumber: 1910
-
-  - id: 3rdpartymonitoring
-    parentid: monitorings
-    displayname: 3rd party Monitoring
-    restype: menu
-    isaction: false
-    priority: 2
-    menunumber: 1930
-
-  - id: monitoringconfig
-    parentid: monitorings
-    displayname: Monitoring Config
-    restype: menu
-    viewtype: local
-    frameworkservice: mc-web-console-front
-    path: /operations/analytics/monitorings/monitoringconfig
-    isaction: true
-    priority: 2
-    menunumber: 1940
-
-  - id: eventsntraces
-    parentid: analytics
-    displayname: Events & Traces
-    restype: menu
-    isaction: false
-    priority: 2
-    menunumber: 1950
-
-  - id: alarmshistory
-    parentid: eventsntraces
-    displayname: Alarms History
-    restype: menu
-    isaction: true
-    priority: 2
-    menunumber: 1960
-
-  - id: thresholdconfig
-    parentid: eventsntraces
-    displayname: Threshold Config
-    restype: menu
-    isaction: true
-    priority: 2
-    menunumber: 1970
-
-  - id: logmanage
-    parentid: eventsntraces
-    displayname: Log Manage
-    restype: menu
-    isaction: true
-    priority: 2
-    menunumber: 1980
-
-  - id: logconfig
-    parentid: eventsntraces
-    displayname: Log Config
-    restype: menu
-    isaction: true
-    priority: 2
-    menunumber: 1990
-
-  - id: eventtrace
-    parentid: eventsntraces
-    displayname: Event Trace
-    restype: menu
-    isaction: false
-    priority: 2
-    menunumber: 1996
-
-  - id: costanalysis
-    parentid: analytics
-    displayname: Cost Analysis
-    restype: menu
-    viewtype: iframe
-    frameworkservice: mc-cost-optimizer-fe
-    path: /
-    isaction: true
-    priority: 2
-    menunumber: 1998
-
-  - id: observability
-    parentid: analytics
-    displayname: Monitorings
-    restype: menu
-    viewtype: iframe
-    frameworkservice: mc-observability-fe
-    path: /
-    isaction: true
-    priority: 3
-    menunumber: 1999

--- a/asset/menu/permission.yaml
+++ b/asset/menu/permission.yaml
@@ -1,0 +1,129 @@
+# asset/menu/permission.yaml
+# Role-centric permissions: permissions → role → menus | operations | csps
+# - menus: mcmp_menus.id 목록 (역할별 접근 가능 메뉴)
+# - operations: (reserved) framework/API operation 권한 ID — 향후 시드
+# - csps: (reserved) CSP 관련 권한/역할 키 — 향후 시드
+# Source: permission.csv invert + remote menu ID remaps (2026-07-15)
+permissions:
+  - role: admin
+    menus:
+      - operations
+      - manage
+      - workspaces
+      - projects
+      - projectboard
+      - members
+      - roles
+      - csproles
+      - workloads
+      - mciworkloads
+      - pmkworkloads
+      - workflows
+      - swcatalogs
+      - mcdatamanager
+      - datamigrations
+      - generateobjectstorage
+      - generaterdb
+      - analytics
+      - costanalysis
+      - observability
+      - settings
+      - accountnaccess
+      - organizations
+      - companyinfo
+      - users
+      - groups
+      - approvals
+      - accesscontrols
+      - menus
+      - environment
+      - cloudsps
+      - cloudoverview
+      - regions
+      - connections
+      - clouddrivers
+      - credentials
+      - cspaccounts
+      - cloudresources
+      - serverspecs
+      - specs
+      - images
+      - serverimages
+      - networks
+      - securitygroups
+      - securitys
+      - myimages
+      - disks
+      - sshkeys
+      - csp
+      - cspschedule
+      - resourcesync
+      - cloudrescatalogs
+      - workspacessettings
+      - allocatedprojects
+      - sharemembers
+      - allocaterolesws
+    operations: []
+    csps: []
+
+  - role: billadmin
+    menus:
+      - operations
+      - manage
+      - workloads
+      - mciworkloads
+      - analytics
+      - costanalysis
+    operations: []
+    csps: []
+
+  - role: billviewer
+    menus:
+      - operations
+      - analytics
+      - costanalysis
+    operations: []
+    csps: []
+
+  - role: operator
+    menus:
+      - operations
+      - manage
+      - workloads
+      - mciworkloads
+      - pmkworkloads
+      - workflows
+      - swcatalogs
+      - mcdatamanager
+      - datamigrations
+      - generateobjectstorage
+      - generaterdb
+      - analytics
+      - observability
+      - settings
+      - environment
+      - cloudsps
+      - cloudoverview
+      - regions
+      - cloudresources
+      - specs
+      - images
+      - networks
+      - securitys
+      - myimages
+      - disks
+      - sshkeys
+      - cloudrescatalogs
+    operations: []
+    csps: []
+
+  - role: viewer
+    menus:
+      - operations
+      - analytics
+      - observability
+      - settings
+      - environment
+      - cloudrescatalogs
+    operations: []
+    csps: []

--- a/conf/mc-iam-manager/menu.yaml
+++ b/conf/mc-iam-manager/menu.yaml
@@ -1,4 +1,190 @@
+# Synchronized from remote mcmp_menus (15.164.139.37) + iframe path fixes — 2026-07-15
+# Removed obsolete monitorings/eventsntraces local trees; use observability iframe.
 menus:
+
+  - id: operations
+    parentid: home
+    displayname: Operations
+    restype: menu
+    isaction: false
+    priority: 2
+    menunumber: 1700
+
+  - id: manage
+    parentid: operations
+    displayname: Manage
+    restype: menu
+    isaction: false
+    priority: 2
+    menunumber: 1701
+
+  - id: workspaces
+    parentid: manage
+    displayname: Workspaces
+    restype: menu
+    isaction: true
+    priority: 2
+    menunumber: 1710
+
+  - id: projects
+    parentid: workspaces
+    displayname: Projects
+    restype: menu
+    isaction: false
+    priority: 2
+    menunumber: 1720
+
+  - id: projectboard
+    parentid: workspaces
+    displayname: Project board
+    restype: menu
+    isaction: false
+    priority: 2
+    menunumber: 1728
+
+  - id: members
+    parentid: workspaces
+    displayname: Members
+    restype: menu
+    isaction: false
+    priority: 2
+    menunumber: 1730
+
+  - id: roles
+    parentid: workspaces
+    displayname: Roles
+    restype: menu
+    isaction: false
+    priority: 2
+    menunumber: 1740
+
+  - id: csproles
+    parentid: workspaces
+    displayname: CSP Roles
+    restype: menu
+    isaction: true
+    priority: 2
+    menunumber: 1741
+
+  - id: workloads
+    parentid: manage
+    displayname: Workloads
+    restype: menu
+    isaction: false
+    priority: 2
+    menunumber: 1750
+
+  - id: mciworkloads
+    parentid: workloads
+    displayname: MCI Workloads
+    restype: menu
+    isaction: true
+    priority: 2
+    menunumber: 1760
+
+  - id: pmkworkloads
+    parentid: workloads
+    displayname: PMK Workloads
+    restype: menu
+    isaction: true
+    priority: 2
+    menunumber: 1790
+
+  - id: workflows
+    parentid: manage
+    displayname: Workflows
+    restype: menu
+    viewtype: iframe
+    frameworkservice: mc-workflow-manager-fe
+    path: /web/workflows/workflow/list
+    isaction: true
+    priority: 2
+    menunumber: 1998
+
+  - id: swcatalogs
+    parentid: manage
+    displayname: SW Catalogs
+    restype: menu
+    viewtype: iframe
+    frameworkservice: mc-application-manager-fe
+    path: /web/softwareCatalog
+    isaction: true
+    priority: 2
+    menunumber: 1998
+
+  - id: mcdatamanager
+    parentid: manage
+    displayname: Data Migrations
+    restype: menu
+    viewtype: iframe
+    frameworkservice: mc-data-manager-fe
+    path: /migrate/objectstorage
+    isaction: false
+    priority: 3
+    menunumber: 1997
+
+  - id: datamigrations
+    parentid: mcdatamanager
+    displayname: Data Migrations
+    restype: menu
+    viewtype: iframe
+    frameworkservice: mc-data-manager-fe
+    path: /
+    isaction: true
+    priority: 1
+    menunumber: 1998
+
+  - id: generateobjectstorage
+    parentid: mcdatamanager
+    displayname: Generate OSS
+    restype: menu
+    viewtype: iframe
+    frameworkservice: mc-data-manager-fe
+    path: /generate/objectstorage
+    isaction: true
+    priority: 2
+    menunumber: 19971
+
+  - id: generaterdb
+    parentid: mcdatamanager
+    displayname: GenerateRDB
+    restype: menu
+    viewtype: iframe
+    frameworkservice: mc-data-manager-fe
+    path: /generate/mysql
+    isaction: true
+    priority: 2
+    menunumber: 19972
+
+  - id: analytics
+    parentid: operations
+    displayname: Analytics
+    restype: menu
+    isaction: false
+    priority: 3
+    menunumber: 1901
+
+  - id: costanalysis
+    parentid: analytics
+    displayname: Cost Analysis
+    restype: menu
+    viewtype: iframe
+    frameworkservice: mc-cost-optimizer-fe
+    path: /
+    isaction: true
+    priority: 2
+    menunumber: 1998
+
+  - id: observability
+    parentid: analytics
+    displayname: Monitorings
+    restype: menu
+    viewtype: iframe
+    frameworkservice: mc-observability-fe
+    path: /
+    isaction: true
+    priority: 3
+    menunumber: 1999
 
   - id: settings
     parentid: home
@@ -36,9 +222,17 @@ menus:
     parentid: organizations
     displayname: Users
     restype: menu
-    isaction: true
+    isaction: false
     priority: 2
     menunumber: 1220
+
+  - id: groups
+    parentid: organizations
+    displayname: Groups
+    restype: menu
+    isaction: true
+    priority: 2
+    menunumber: 1225
 
   - id: approvals
     parentid: organizations
@@ -84,7 +278,7 @@ menus:
     parentid: cloudsps
     displayname: Cloud Overview
     restype: menu
-    isaction: true
+    isaction: false
     priority: 2
     menunumber: 1310
 
@@ -108,7 +302,7 @@ menus:
     parentid: cloudsps
     displayname: Cloud Drivers
     restype: menu
-    isaction: true
+    isaction: false
     priority: 2
     menunumber: 1340
 
@@ -144,6 +338,22 @@ menus:
     priority: 2
     menunumber: 1410
 
+  - id: specs
+    parentid: cloudresources
+    displayname: Specs
+    restype: menu
+    isaction: false
+    priority: 2
+    menunumber: 1410
+
+  - id: images
+    parentid: cloudresources
+    displayname: Images
+    restype: menu
+    isaction: false
+    priority: 2
+    menunumber: 1420
+
   - id: serverimages
     parentid: cloudresources
     displayname: Images
@@ -156,13 +366,21 @@ menus:
     parentid: cloudresources
     displayname: Networks
     restype: menu
-    isaction: true
+    isaction: false
     priority: 2
     menunumber: 1510
 
   - id: securitygroups
     parentid: cloudresources
     displayname: Security Groups
+    restype: menu
+    isaction: false
+    priority: 2
+    menunumber: 1520
+
+  - id: securitys
+    parentid: cloudresources
+    displayname: Securitys
     restype: menu
     isaction: false
     priority: 2
@@ -255,237 +473,3 @@ menus:
     isaction: false
     priority: 2
     menunumber: 1667
-
-  - id: operations
-    parentid: home
-    displayname: Operations
-    restype: menu
-    isaction: false
-    priority: 2
-    menunumber: 1700
-
-  - id: manage
-    parentid: operations
-    displayname: Manage
-    restype: menu
-    isaction: false
-    priority: 2
-    menunumber: 1701
-
-  - id: workspaces
-    parentid: manage
-    displayname: Workspaces
-    restype: menu
-    isaction: true
-    priority: 2
-    menunumber: 1710
-
-  - id: projects
-    parentid: workspaces
-    displayname: Projects
-    restype: menu
-    isaction: false
-    priority: 2
-    menunumber: 1720
-
-  - id: members
-    parentid: workspaces
-    displayname: Members
-    restype: menu
-    isaction: false
-    priority: 2
-    menunumber: 1730
-
-  - id: roles
-    parentid: workspaces
-    displayname: Roles
-    restype: menu
-    isaction: true
-    priority: 2
-    menunumber: 1740
-  
-  - id: csproles
-    parentid: workspaces
-    displayname: CSP Roles
-    restype: menu
-    isaction: true
-    priority: 2
-    menunumber: 1741
-
-  - id: projectboard
-    parentid: workspaces
-    displayname: Project board
-    restype: menu
-    isaction: false
-    priority: 2
-    menunumber: 1728
-
-  - id: workloads
-    parentid: manage
-    displayname: Workloads
-    restype: menu
-    isaction: false
-    priority: 2
-    menunumber: 1750
-
-  - id: mciworkloads
-    parentid: workloads
-    displayname: MCI Workloads
-    restype: menu
-    isaction: true
-    priority: 2
-    menunumber: 1760
-
-  - id: pmkworkloads
-    parentid: workloads
-    displayname: PMK Workloads
-    restype: menu
-    isaction: true
-    priority: 2
-    menunumber: 1790
-
-  - id: workflows
-    parentid: manage
-    displayname: Workflows
-    restype: menu
-    viewtype: iframe
-    frameworkservice: mc-workflow-manager-fe
-    path: /web/workflow/list
-    isaction: true
-    priority: 2
-    menunumber: 1998
-
-  - id: swcatalogs
-    parentid: manage
-    displayname: SW Catalogs
-    restype: menu
-    viewtype: iframe
-    frameworkservice: mc-application-manager-fe
-    path: /web/softwareCatalog
-    isaction: true
-    priority: 2
-    menunumber: 1998
-
-  - id: datamigrations
-    parentid: manage
-    displayname: Data Migrations
-    restype: menu
-    viewtype: iframe
-    frameworkservice: mc-data-manager-fe
-    path: /
-    isaction: true
-    priority: 2
-    menunumber: 1998
-
-  - id: analytics
-    parentid: operations
-    displayname: Analytics
-    restype: menu
-    isaction: false
-    priority: 3
-    menunumber: 1901
-
-  - id: monitorings
-    parentid: analytics
-    displayname: Monitorings
-    restype: menu
-    isaction: false
-    priority: 2
-    menunumber: 1905
-
-  - id: mcismonitoring
-    parentid: monitorings
-    displayname: MCIs Monitoring
-    restype: menu
-    isaction: true
-    priority: 2
-    menunumber: 1910
-
-  - id: 3rdpartymonitoring
-    parentid: monitorings
-    displayname: 3rd party Monitoring
-    restype: menu
-    isaction: false
-    priority: 2
-    menunumber: 1930
-
-  - id: monitoringconfig
-    parentid: monitorings
-    displayname: Monitoring Config
-    restype: menu
-    viewtype: local
-    frameworkservice: mc-web-console-front
-    path: /operations/analytics/monitorings/monitoringconfig
-    isaction: true
-    priority: 2
-    menunumber: 1940
-
-  - id: eventsntraces
-    parentid: analytics
-    displayname: Events & Traces
-    restype: menu
-    isaction: false
-    priority: 2
-    menunumber: 1950
-
-  - id: alarmshistory
-    parentid: eventsntraces
-    displayname: Alarms History
-    restype: menu
-    isaction: true
-    priority: 2
-    menunumber: 1960
-
-  - id: thresholdconfig
-    parentid: eventsntraces
-    displayname: Threshold Config
-    restype: menu
-    isaction: true
-    priority: 2
-    menunumber: 1970
-
-  - id: logmanage
-    parentid: eventsntraces
-    displayname: Log Manage
-    restype: menu
-    isaction: true
-    priority: 2
-    menunumber: 1980
-
-  - id: logconfig
-    parentid: eventsntraces
-    displayname: Log Config
-    restype: menu
-    isaction: true
-    priority: 2
-    menunumber: 1990
-
-  - id: eventtrace
-    parentid: eventsntraces
-    displayname: Event Trace
-    restype: menu
-    isaction: false
-    priority: 2
-    menunumber: 1996
-
-  - id: costanalysis
-    parentid: analytics
-    displayname: Cost Analysis
-    restype: menu
-    viewtype: iframe
-    frameworkservice: mc-cost-optimizer-fe
-    path: /
-    isaction: true
-    priority: 2
-    menunumber: 1998
-
-  - id: observability
-    parentid: analytics
-    displayname: Monitorings
-    restype: menu
-    viewtype: iframe
-    frameworkservice: mc-observability-fe
-    path: /
-    isaction: true
-    priority: 3
-    menunumber: 1999

--- a/conf/mc-iam-manager/service-actions.yaml
+++ b/conf/mc-iam-manager/service-actions.yaml
@@ -833,7 +833,11 @@ serviceActions:
         initializeMenuPermissions:
             method: get
             resourcePath: /api/setup/initial-role-menu-permission
-            description: CSV 파일을 읽어서 메뉴 권한을 초기화합니다
+            description: "(Deprecated) CSV 파일을 읽어서 메뉴 권한을 초기화합니다. Use initializeMenuPermissionsFromYAML."
+        initializeMenuPermissionsFromYAML:
+            method: get
+            resourcePath: /api/setup/initial-role-menu-permission-yaml
+            description: permission.yaml(permissions→role→menus|operations|csps)을 읽어 역할-메뉴 권한을 초기화합니다
         backupRolePermissions:
             method: get
             resourcePath: /api/setup/backup-role-permissions

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -9186,7 +9186,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "CSV 파일을 읽어서 메뉴 권한을 초기화합니다",
+                "description": "Deprecated. permission.csv로 메뉴 권한을 초기화합니다. 제거 예정이니 InitializeMenuPermissionsFromYAML을 사용하세요.",
                 "consumes": [
                     "application/json"
                 ],
@@ -9196,12 +9196,62 @@ const docTemplate = `{
                 "tags": [
                     "admin"
                 ],
-                "summary": "Initialize menu permissions from CSV",
+                "summary": "Initialize menu permissions from CSV (deprecated)",
                 "operationId": "initializeMenuPermissions",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "CSV file path (optional, uses default if not provided)",
+                        "description": "CSV file path (optional, default asset/menu/permission.csv)",
+                        "name": "filePath",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/setup/initial-role-menu-permission-yaml": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "asset/menu/permission.yaml(permissions→role→menus|operations|csps)을 읽어 역할-메뉴 매핑을 DB에 시드합니다",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Initialize role-menu permissions from YAML",
+                "operationId": "initializeMenuPermissionsFromYAML",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "YAML file path (optional, default asset/menu/permission.yaml)",
                         "name": "filePath",
                         "in": "query"
                     }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -9180,7 +9180,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "CSV 파일을 읽어서 메뉴 권한을 초기화합니다",
+                "description": "Deprecated. permission.csv로 메뉴 권한을 초기화합니다. 제거 예정이니 InitializeMenuPermissionsFromYAML을 사용하세요.",
                 "consumes": [
                     "application/json"
                 ],
@@ -9190,12 +9190,62 @@
                 "tags": [
                     "admin"
                 ],
-                "summary": "Initialize menu permissions from CSV",
+                "summary": "Initialize menu permissions from CSV (deprecated)",
                 "operationId": "initializeMenuPermissions",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "CSV file path (optional, uses default if not provided)",
+                        "description": "CSV file path (optional, default asset/menu/permission.csv)",
+                        "name": "filePath",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/setup/initial-role-menu-permission-yaml": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "asset/menu/permission.yaml(permissions→role→menus|operations|csps)을 읽어 역할-메뉴 매핑을 DB에 시드합니다",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Initialize role-menu permissions from YAML",
+                "operationId": "initializeMenuPermissionsFromYAML",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "YAML file path (optional, default asset/menu/permission.yaml)",
                         "name": "filePath",
                         "in": "query"
                     }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -7900,10 +7900,12 @@ paths:
     get:
       consumes:
       - application/json
-      description: CSV 파일을 읽어서 메뉴 권한을 초기화합니다
+      deprecated: true
+      description: Deprecated. permission.csv로 메뉴 권한을 초기화합니다. 제거 예정이니 InitializeMenuPermissionsFromYAML을
+        사용하세요.
       operationId: initializeMenuPermissions
       parameters:
-      - description: CSV file path (optional, uses default if not provided)
+      - description: CSV file path (optional, default asset/menu/permission.csv)
         in: query
         name: filePath
         type: string
@@ -7924,7 +7926,39 @@ paths:
             $ref: '#/definitions/model.Response'
       security:
       - BearerAuth: []
-      summary: Initialize menu permissions from CSV
+      summary: Initialize menu permissions from CSV (deprecated)
+      tags:
+      - admin
+  /api/setup/initial-role-menu-permission-yaml:
+    get:
+      consumes:
+      - application/json
+      description: asset/menu/permission.yaml(permissions→role→menus|operations|csps)을
+        읽어 역할-메뉴 매핑을 DB에 시드합니다
+      operationId: initializeMenuPermissionsFromYAML
+      parameters:
+      - description: YAML file path (optional, default asset/menu/permission.yaml)
+        in: query
+        name: filePath
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.Response'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/model.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/model.Response'
+      security:
+      - BearerAuth: []
+      summary: Initialize role-menu permissions from YAML
       tags:
       - admin
   /api/setup/projects/sync:

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -9186,7 +9186,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "CSV 파일을 읽어서 메뉴 권한을 초기화합니다",
+                "description": "Deprecated. permission.csv로 메뉴 권한을 초기화합니다. 제거 예정이니 InitializeMenuPermissionsFromYAML을 사용하세요.",
                 "consumes": [
                     "application/json"
                 ],
@@ -9196,12 +9196,62 @@ const docTemplate = `{
                 "tags": [
                     "admin"
                 ],
-                "summary": "Initialize menu permissions from CSV",
+                "summary": "Initialize menu permissions from CSV (deprecated)",
                 "operationId": "initializeMenuPermissions",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "CSV file path (optional, uses default if not provided)",
+                        "description": "CSV file path (optional, default asset/menu/permission.csv)",
+                        "name": "filePath",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/setup/initial-role-menu-permission-yaml": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "asset/menu/permission.yaml(permissions→role→menus|operations|csps)을 읽어 역할-메뉴 매핑을 DB에 시드합니다",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Initialize role-menu permissions from YAML",
+                "operationId": "initializeMenuPermissionsFromYAML",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "YAML file path (optional, default asset/menu/permission.yaml)",
                         "name": "filePath",
                         "in": "query"
                     }

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -9180,7 +9180,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "CSV 파일을 읽어서 메뉴 권한을 초기화합니다",
+                "description": "Deprecated. permission.csv로 메뉴 권한을 초기화합니다. 제거 예정이니 InitializeMenuPermissionsFromYAML을 사용하세요.",
                 "consumes": [
                     "application/json"
                 ],
@@ -9190,12 +9190,62 @@
                 "tags": [
                     "admin"
                 ],
-                "summary": "Initialize menu permissions from CSV",
+                "summary": "Initialize menu permissions from CSV (deprecated)",
                 "operationId": "initializeMenuPermissions",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "CSV file path (optional, uses default if not provided)",
+                        "description": "CSV file path (optional, default asset/menu/permission.csv)",
+                        "name": "filePath",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/setup/initial-role-menu-permission-yaml": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "asset/menu/permission.yaml(permissions→role→menus|operations|csps)을 읽어 역할-메뉴 매핑을 DB에 시드합니다",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Initialize role-menu permissions from YAML",
+                "operationId": "initializeMenuPermissionsFromYAML",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "YAML file path (optional, default asset/menu/permission.yaml)",
                         "name": "filePath",
                         "in": "query"
                     }

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -7900,10 +7900,12 @@ paths:
     get:
       consumes:
       - application/json
-      description: CSV 파일을 읽어서 메뉴 권한을 초기화합니다
+      deprecated: true
+      description: Deprecated. permission.csv로 메뉴 권한을 초기화합니다. 제거 예정이니 InitializeMenuPermissionsFromYAML을
+        사용하세요.
       operationId: initializeMenuPermissions
       parameters:
-      - description: CSV file path (optional, uses default if not provided)
+      - description: CSV file path (optional, default asset/menu/permission.csv)
         in: query
         name: filePath
         type: string
@@ -7924,7 +7926,39 @@ paths:
             $ref: '#/definitions/model.Response'
       security:
       - BearerAuth: []
-      summary: Initialize menu permissions from CSV
+      summary: Initialize menu permissions from CSV (deprecated)
+      tags:
+      - admin
+  /api/setup/initial-role-menu-permission-yaml:
+    get:
+      consumes:
+      - application/json
+      description: asset/menu/permission.yaml(permissions→role→menus|operations|csps)을
+        읽어 역할-메뉴 매핑을 DB에 시드합니다
+      operationId: initializeMenuPermissionsFromYAML
+      parameters:
+      - description: YAML file path (optional, default asset/menu/permission.yaml)
+        in: query
+        name: filePath
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.Response'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/model.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/model.Response'
+      security:
+      - BearerAuth: []
+      summary: Initialize role-menu permissions from YAML
       tags:
       - admin
   /api/setup/projects/sync:

--- a/src/handler/admin_handler.go
+++ b/src/handler/admin_handler.go
@@ -180,10 +180,10 @@ func (h *AdminHandler) SetupInitialAdmin(c echo.Context) error {
 		// })
 	}
 
-	// 메뉴와 기본 역할 매핑
-	err = h.menuService.InitializeMenuPermissionsFromCSV("")
+	// 메뉴와 기본 역할 매핑 (permission.yaml)
+	err = h.menuService.InitializeMenuPermissionsFromYAML("")
 	if err != nil {
-		log.Printf("[ERROR] Initialize Menu Permissions failed: %v", err)
+		log.Printf("[ERROR] Initialize Menu Permissions (YAML) failed: %v", err)
 		// return c.JSON(http.StatusInternalServerError, model.Response{
 		// 	Error:   true,
 		// 	Message: "Failed to initialize menu permissions",
@@ -249,36 +249,75 @@ func (h *AdminHandler) CheckUserRoles(c echo.Context) error {
 }
 
 // InitializeMenuPermissions godoc
-// @Summary Initialize menu permissions from CSV
-// @Description CSV 파일을 읽어서 메뉴 권한을 초기화합니다
+// @Summary Initialize menu permissions from CSV (deprecated)
+// @Description Deprecated. permission.csv로 메뉴 권한을 초기화합니다. 제거 예정이니 InitializeMenuPermissionsFromYAML을 사용하세요.
 // @Tags admin
 // @Accept json
 // @Produce json
-// @Param filePath query string false "CSV file path (optional, uses default if not provided)"
+// @Param filePath query string false "CSV file path (optional, default asset/menu/permission.csv)"
 // @Success 200 {object} model.Response
 // @Failure 400 {object} model.Response
 // @Failure 500 {object} model.Response
 // @Security BearerAuth
+// @Deprecated
 // @Router /api/setup/initial-role-menu-permission [get]
 // @Id initializeMenuPermissions
 func (h *AdminHandler) InitializeMenuPermissions(c echo.Context) error {
 	filePath := c.QueryParam("filePath")
 
-	log.Printf("[INFO] Initializing menu permissions from CSV file: %s", filePath)
+	log.Printf(
+		"[WARN] Deprecated API /api/setup/initial-role-menu-permission (CSV). "+
+			"Use /api/setup/initial-role-menu-permission-yaml instead. filePath=%s",
+		filePath,
+	)
 
 	err := h.menuService.InitializeMenuPermissionsFromCSV(filePath)
 	if err != nil {
-		log.Printf("[ERROR] Initialize Menu Permissions failed: %v", err)
+		log.Printf("[ERROR] Initialize Menu Permissions (CSV) failed: %v", err)
 		return c.JSON(http.StatusInternalServerError, model.Response{
 			Error:   true,
-			Message: fmt.Sprintf("Failed to initialize menu permissions: %v", err),
+			Message: fmt.Sprintf("Failed to initialize menu permissions from CSV: %v", err),
 		})
 	}
 
-	log.Printf("[INFO] Menu permissions initialized successfully")
+	log.Printf("[INFO] Menu permissions initialized successfully from CSV (deprecated)")
 	return c.JSON(http.StatusOK, model.Response{
 		Error:   false,
-		Message: "Menu permissions initialized successfully",
+		Message: "Menu permissions initialized successfully from CSV (deprecated; prefer YAML API)",
+	})
+}
+
+// InitializeMenuPermissionsFromYAML godoc
+// @Summary Initialize role-menu permissions from YAML
+// @Description asset/menu/permission.yaml(permissions→role→menus|operations|csps)을 읽어 역할-메뉴 매핑을 DB에 시드합니다
+// @Tags admin
+// @Accept json
+// @Produce json
+// @Param filePath query string false "YAML file path (optional, default asset/menu/permission.yaml)"
+// @Success 200 {object} model.Response
+// @Failure 400 {object} model.Response
+// @Failure 500 {object} model.Response
+// @Security BearerAuth
+// @Router /api/setup/initial-role-menu-permission-yaml [get]
+// @Id initializeMenuPermissionsFromYAML
+func (h *AdminHandler) InitializeMenuPermissionsFromYAML(c echo.Context) error {
+	filePath := c.QueryParam("filePath")
+
+	log.Printf("[INFO] Initializing menu permissions from YAML: %s", filePath)
+
+	err := h.menuService.InitializeMenuPermissionsFromYAML(filePath)
+	if err != nil {
+		log.Printf("[ERROR] Initialize Menu Permissions (YAML) failed: %v", err)
+		return c.JSON(http.StatusInternalServerError, model.Response{
+			Error:   true,
+			Message: fmt.Sprintf("Failed to initialize menu permissions from YAML: %v", err),
+		})
+	}
+
+	log.Printf("[INFO] Menu permissions initialized successfully from YAML")
+	return c.JSON(http.StatusOK, model.Response{
+		Error:   false,
+		Message: "Menu permissions initialized successfully from YAML",
 	})
 }
 

--- a/src/main.go
+++ b/src/main.go
@@ -232,7 +232,9 @@ func main() {
 		setup.POST("/sync-mcmp-apis", mcmpApiHandler.SyncMcmpAPIs)
 		setup.POST("/initial-menus", menuHandler.RegisterMenusFromYAML, middleware.PlatformAdminMiddleware)
 		setup.POST("/initial-menus2", menuHandler.RegisterMenusFromBody, middleware.PlatformAdminMiddleware)
+		// Deprecated: CSV 기반 시드 — 제거 예정. YAML API를 사용하세요.
 		setup.GET("/initial-role-menu-permission", adminHandler.InitializeMenuPermissions, middleware.PlatformAdminMiddleware)
+		setup.GET("/initial-role-menu-permission-yaml", adminHandler.InitializeMenuPermissionsFromYAML, middleware.PlatformAdminMiddleware)
 		setup.GET("/backup-role-permissions", adminHandler.BackupRolePermissions, middleware.PlatformAdminMiddleware)
 		setup.POST("/restore-role-permissions", adminHandler.RestoreRolePermissions, middleware.PlatformAdminMiddleware)
 		setup.POST("/initial-organizations", organizationHandler.SetupInitialOrganizations, middleware.PlatformAdminMiddleware)

--- a/src/service/menu_service.go
+++ b/src/service/menu_service.go
@@ -660,83 +660,225 @@ func (s *MenuService) ListMappedMenusByRole(req *model.MenuMappingFilterRequest)
 	return menus, nil
 }
 
-// InitializeMenuPermissionsFromCSV CSV 파일을 읽어서 메뉴 권한을 초기화합니다.
-// filePath 쿼리 파라미터가 없으면 기본 경로인 asset/menu/permission.csv를 사용
+// rolePermissionEntry permission.yaml 역할 단위 권한 정의
+// permissions → role → menus | operations | csps
+type rolePermissionEntry struct {
+	Role       string   `yaml:"role"`
+	Menus      []string `yaml:"menus"`
+	Operations []string `yaml:"operations"`
+	Csps       []string `yaml:"csps"`
+}
+
+type rolePermissionFile struct {
+	Permissions []rolePermissionEntry `yaml:"permissions"`
+}
+
+// InitializeMenuPermissionsFromCSV CSV 매트릭스로 역할-메뉴 권한을 시드합니다.
+//
+// Deprecated: permission.csv 시드는 제거 예정입니다.
+// 신규/운영 시드는 InitializeMenuPermissionsFromYAML(asset/menu/permission.yaml)을 사용하세요.
 func (s *MenuService) InitializeMenuPermissionsFromCSV(filePath string) error {
-	effectiveFilePath := filePath
+	effectiveFilePath, cleanup, err := s.resolvePermissionSeedPath(
+		filePath, "permission.csv", ".csv",
+	)
+	if err != nil {
+		return err
+	}
+	if cleanup != "" {
+		defer os.Remove(cleanup)
+	}
+	return s.initializeMenuPermissionsFromCSVFile(effectiveFilePath)
+}
 
-	// If filePath is not provided via query param
-	if effectiveFilePath == "" {
-		// Load .env file to get the URL (assuming .env is at project root)
-		util.LoadEnvFiles()
-		permissionURL := os.Getenv("MC_WEB_CONSOLE_MENU_PERMISSIONS")
+// InitializeMenuPermissionsFromYAML 역할 중심 permission.yaml으로 권한을 시드합니다.
+// filePath가 비어 있으면 asset/menu/permission.yaml (또는 MC_WEB_CONSOLE_MENU_PERMISSIONS)을 사용합니다.
+// 스키마: permissions → role → menus | operations | csps
+func (s *MenuService) InitializeMenuPermissionsFromYAML(filePath string) error {
+	effectiveFilePath, cleanup, err := s.resolvePermissionSeedPath(
+		filePath, "permission.yaml", ".yaml",
+	)
+	if err != nil {
+		return err
+	}
+	if cleanup != "" {
+		defer os.Remove(cleanup)
+	}
+	return s.loadAndApplyMenuPermissionsFromYAML(effectiveFilePath)
+}
 
-		// Default local path relative to project root
-		assetPath := util.GetAssetPath()
-		defaultLocalPath := filepath.Join(assetPath, "menu", "permission.csv")
+// resolvePermissionSeedPath 시드 파일 경로를 결정합니다.
+// 우선순위: query filePath → env URL/path → asset/menu/{defaultFileName}
+func (s *MenuService) resolvePermissionSeedPath(
+	filePath, defaultFileName, defaultExt string,
+) (string, string, error) {
+	if filePath != "" {
+		return filePath, "", nil
+	}
 
-		if permissionURL != "" && (strings.HasPrefix(permissionURL, "http://") || strings.HasPrefix(permissionURL, "https://")) {
-			// Attempt to download from URL
-			fmt.Printf("Attempting to download permission CSV from URL: %s\n", permissionURL)
-			resp, err := http.Get(permissionURL)
-			if err != nil {
-				fmt.Printf("Warning: Failed to download permission CSV from %s: %v. Falling back to local path: %s\n", permissionURL, err, defaultLocalPath)
-				effectiveFilePath = defaultLocalPath
+	util.LoadEnvFiles()
+	permissionURL := os.Getenv("MC_WEB_CONSOLE_MENU_PERMISSIONS")
+	assetPath := util.GetAssetPath()
+	defaultLocalPath := filepath.Join(assetPath, "menu", defaultFileName)
+
+	if permissionURL != "" &&
+		(strings.HasPrefix(permissionURL, "http://") ||
+			strings.HasPrefix(permissionURL, "https://")) {
+		fmt.Printf("Attempting to download permission seed from URL: %s\n", permissionURL)
+		resp, err := http.Get(permissionURL)
+		if err != nil {
+			fmt.Printf(
+				"Warning: Failed to download permission seed from %s: %v. Falling back to local file.\n",
+				permissionURL, err,
+			)
+		} else {
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				fmt.Printf(
+					"Warning: Failed to download permission seed from %s (Status: %s). Falling back to local file.\n",
+					permissionURL, resp.Status,
+				)
 			} else {
-				defer resp.Body.Close()
-				if resp.StatusCode != http.StatusOK {
-					fmt.Printf("Warning: Failed to download permission CSV from %s (Status: %s). Falling back to local path: %s\n", permissionURL, resp.Status, defaultLocalPath)
-					effectiveFilePath = defaultLocalPath
+				bodyBytes, err := io.ReadAll(resp.Body)
+				if err != nil {
+					fmt.Printf(
+						"Warning: Failed to read permission seed from %s: %v. Falling back to local file.\n",
+						permissionURL, err,
+					)
 				} else {
-					bodyBytes, err := io.ReadAll(resp.Body)
+					ext := filepath.Ext(strings.Split(permissionURL, "?")[0])
+					if ext == "" {
+						ext = defaultExt
+					}
+					tempFile, err := os.CreateTemp("", "permission-*"+ext)
 					if err != nil {
-						fmt.Printf("Warning: Failed to read response body from %s: %v. Falling back to local path: %s\n", permissionURL, err, defaultLocalPath)
-						effectiveFilePath = defaultLocalPath
+						fmt.Printf(
+							"Warning: Failed to create temp file: %v. Falling back to local file.\n", err,
+						)
 					} else {
-						// Create a temporary file
-						tempFile, err := os.CreateTemp("", "permission-*.csv")
-						if err != nil {
-							fmt.Printf("Warning: Failed to create temp file: %v. Falling back to local path: %s\n", err, defaultLocalPath)
-							effectiveFilePath = defaultLocalPath
+						if _, err := tempFile.Write(bodyBytes); err != nil {
+							tempFile.Close()
+							os.Remove(tempFile.Name())
+							fmt.Printf(
+								"Warning: Failed to write temp permission file: %v. Falling back to local file.\n",
+								err,
+							)
 						} else {
-							defer os.Remove(tempFile.Name()) // Clean up temp file when done
-							if _, err := tempFile.Write(bodyBytes); err != nil {
-								fmt.Printf("Warning: Failed to write to temp file: %v. Falling back to local path: %s\n", err, defaultLocalPath)
-								effectiveFilePath = defaultLocalPath
-							} else {
-								effectiveFilePath = tempFile.Name()
-							}
+							tempFile.Close()
+							return tempFile.Name(), tempFile.Name(), nil
 						}
 					}
 				}
 			}
-		} else {
-			effectiveFilePath = defaultLocalPath
 		}
+	} else if permissionURL != "" {
+		return permissionURL, "", nil
 	}
 
-	// CSV 파일 열기
-	file, err := os.Open(effectiveFilePath)
+	return defaultLocalPath, "", nil
+}
+
+// loadAndApplyMenuPermissionsFromYAML 역할 중심 permission.yaml을 적용합니다.
+func (s *MenuService) loadAndApplyMenuPermissionsFromYAML(filePath string) error {
+	body, err := os.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to read permission YAML: %w", err)
+	}
+
+	var data rolePermissionFile
+	if err := yaml.Unmarshal(body, &data); err != nil {
+		return fmt.Errorf("failed to parse permission YAML: %w", err)
+	}
+	if len(data.Permissions) == 0 {
+		return fmt.Errorf("no permissions entries found in %s", filePath)
+	}
+
+	roleMenus := make(map[string][]string)
+	for _, entry := range data.Permissions {
+		roleName := strings.TrimSpace(entry.Role)
+		if roleName == "" {
+			return fmt.Errorf("permission entry missing role in %s", filePath)
+		}
+		if len(entry.Operations) > 0 {
+			fmt.Printf(
+				"Note: role %s operations(%d) reserved — menu seed only in this pass\n",
+				roleName, len(entry.Operations),
+			)
+		}
+		if len(entry.Csps) > 0 {
+			fmt.Printf(
+				"Note: role %s csps(%d) reserved — menu seed only in this pass\n",
+				roleName, len(entry.Csps),
+			)
+		}
+		menus := make([]string, 0, len(entry.Menus))
+		for _, menuID := range entry.Menus {
+			menuID = strings.TrimSpace(menuID)
+			if menuID != "" {
+				menus = append(menus, menuID)
+			}
+		}
+		roleMenus[roleName] = menus
+	}
+
+	return s.applyRoleMenuPermissionSeed(roleMenus)
+}
+
+// initializeMenuPermissionsFromCSVFile 기존 CSV 매트릭스를 적용합니다.
+// Deprecated path helper — CSV API 제거 시 함께 삭제 예정.
+func (s *MenuService) initializeMenuPermissionsFromCSVFile(filePath string) error {
+	file, err := os.Open(filePath)
 	if err != nil {
 		return fmt.Errorf("failed to open CSV file: %w", err)
 	}
 	defer file.Close()
 
-	// CSV 리더 생성
 	reader := csv.NewReader(file)
-
-	// 첫 번째 행 읽기 (헤더)
 	headers, err := reader.Read()
 	if err != nil {
 		return fmt.Errorf("failed to read CSV headers: %w", err)
 	}
+	if len(headers) < 3 {
+		return fmt.Errorf("invalid CSV headers in %s", filePath)
+	}
 
-	// 역할 이름 목록 추출 (framework, resource 이후의 컬럼들)
 	roleNames := headers[2:]
-
-	// DB에서 역할 ID 조회
-	roleIDs := make(map[string]uint)
+	roleMenus := make(map[string][]string, len(roleNames))
 	for _, roleName := range roleNames {
+		roleMenus[roleName] = []string{}
+	}
+
+	for {
+		record, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to read CSV record: %w", err)
+		}
+		if len(record) < 3 {
+			continue
+		}
+		menuID := strings.TrimSpace(record[1])
+		if menuID == "" {
+			continue
+		}
+		for i, roleName := range roleNames {
+			if i+2 >= len(record) {
+				continue
+			}
+			if strings.EqualFold(strings.TrimSpace(record[i+2]), "TRUE") {
+				roleMenus[roleName] = append(roleMenus[roleName], menuID)
+			}
+		}
+	}
+
+	return s.applyRoleMenuPermissionSeed(roleMenus)
+}
+
+// applyRoleMenuPermissionSeed 역할→메뉴 목록을 DB 매핑으로 upsert(존재 시 skip)합니다.
+func (s *MenuService) applyRoleMenuPermissionSeed(roleMenus map[string][]string) error {
+	roleIDs := make(map[string]uint, len(roleMenus))
+	for roleName := range roleMenus {
 		role, err := s.roleRepo.FindRoleByRoleName(roleName, constants.RoleTypePlatform)
 		if err != nil {
 			return fmt.Errorf("failed to find role %s: %w", roleName, err)
@@ -747,8 +889,7 @@ func (s *MenuService) InitializeMenuPermissionsFromCSV(filePath string) error {
 		roleIDs[roleName] = role.ID
 	}
 
-	// 기존 매핑 조회
-	existingMappings := make(map[string]map[uint]bool) // menuID -> roleID -> exists
+	existingMappings := make(map[string]map[uint]bool)
 	for _, roleID := range roleIDs {
 		req := &model.MenuMappingFilterRequest{
 			RoleIDs: []string{strconv.FormatUint(uint64(roleID), 10)},
@@ -765,56 +906,25 @@ func (s *MenuService) InitializeMenuPermissionsFromCSV(filePath string) error {
 		}
 	}
 
-	// 나머지 행 읽기
-	for {
-		record, err := reader.Read()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return fmt.Errorf("failed to read CSV record: %w", err)
-		}
-
-		// framework와 resource 추출
-		// framework := record[0]
-		// resource := record[1]
-		// 메뉴 ID 생성 (framework:resource 형식)
-		//menuID := fmt.Sprintf("%s:%s", framework, resource)
-		menuID := record[1] // menuId 그대로 넣도록 한다.
-
-		// 각 역할별 권한 확인
-		for i, roleName := range roleNames {
-			hasPermission := record[i+2] == "TRUE" // +2 because first two columns are framework and resource
-
-			if hasPermission {
-				roleID := roleIDs[roleName]
-
-				// 중복 매핑 체크
-				if roleMappings, exists := existingMappings[menuID]; exists {
-					if roleMappings[roleID] {
-						// 이미 매핑이 존재하면 스킵
-						continue
-					}
-				}
-
-				// 새 매핑 생성
-				mappings := []*model.RoleMenuMapping{
-					{
-						RoleID: roleID,
-						MenuID: menuID,
-					},
-				}
-				err := s.menuRepo.CreateRoleMenuMappings(mappings)
-				if err != nil {
-					return fmt.Errorf("failed to create menu mapping for %s with role %s: %w", menuID, roleName, err)
-				}
-
-				// 매핑 정보 업데이트
-				if _, exists := existingMappings[menuID]; !exists {
-					existingMappings[menuID] = make(map[uint]bool)
-				}
-				existingMappings[menuID][roleID] = true
+	for roleName, menus := range roleMenus {
+		roleID := roleIDs[roleName]
+		for _, menuID := range menus {
+			if roleMappings, exists := existingMappings[menuID]; exists && roleMappings[roleID] {
+				continue
 			}
+			mappings := []*model.RoleMenuMapping{
+				{RoleID: roleID, MenuID: menuID},
+			}
+			if err := s.menuRepo.CreateRoleMenuMappings(mappings); err != nil {
+				return fmt.Errorf(
+					"failed to create menu mapping for %s with role %s: %w",
+					menuID, roleName, err,
+				)
+			}
+			if _, exists := existingMappings[menuID]; !exists {
+				existingMappings[menuID] = make(map[uint]bool)
+			}
+			existingMappings[menuID][roleID] = true
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Add role-centric `asset/menu/permission.yaml` (`permissions` → `role` → `menus` | `operations` | `csps`) and seed via `InitializeMenuPermissionsFromYAML`.
- Switch `initial-admin` menu-permission seed from CSV to YAML; mark CSV `/api/setup/initial-role-menu-permission` as deprecated.
- Add `/api/setup/initial-role-menu-permission-yaml`; update `menu.yaml` (remote menu tree / iframe paths) and service-actions/swagger.
- Built on `develop` including already-merged backup/restore (#117).

## Test plan
- [ ] `cd src && go build ./...`
- [ ] `go test ./service/ -run 'TestBackupAndRestore|TestRestoreRolePermissions_Replace|TestParseRolePermission' -count=1`
- [ ] Platform admin: `GET /api/setup/initial-role-menu-permission-yaml` seeds from `permission.yaml`
- [ ] `initial-admin` uses YAML seed (not CSV)
- [ ] CSV endpoint still works but logs deprecation warning
- [ ] Backup/restore APIs from #117 still registered after merge