### PR TITLE
[fix]: do not use CSV MENU_PERMISSIONS URL for YAML permission seed

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -42,7 +42,10 @@ MC_IAM_MANAGER_USE_TICKET_VALID=true # [true|false]
 
 MC_ADMIN_CLI_APIYAML=https://raw.githubusercontent.com/m-cmp/mc-admin-cli/refs/heads/main/conf/api.yaml
 MC_WEB_CONSOLE_MENUYAML=https://raw.githubusercontent.com/m-cmp/mc-web-console/refs/heads/main/conf/webconsole_menu_resources.yaml
+# CSV role-menu permission seed (legacy / CSV init path)
 MC_WEB_CONSOLE_MENU_PERMISSIONS=https://raw.githubusercontent.com/m-cmp/mc-web-console/refs/heads/main/conf/webconsole_menu_permissions.csv
+# YAML role-menu permission seed (preferred for InitializeMenuPermissionsFromYAML / initial-role-menu-permission-yaml)
+# MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML=https://example.com/path/to/permission.yaml
 
 
 MC_IAM_MANAGER_PLATFORMADMIN_ID=mcmp

--- a/conf/mc-iam-manager/1_setup_auto.sh
+++ b/conf/mc-iam-manager/1_setup_auto.sh
@@ -42,6 +42,15 @@ auto_setup() {
         return 1
     fi
     echo "✓ Menu data initialized successfully"
+
+    # 4-1. 역할-메뉴 권한 (YAML) 시드 — init_menu 이후 재시드
+    echo "Step 4-1: Initializing role-menu permissions from YAML..."
+    init_menu_permissions
+    if [ $? -ne 0 ]; then
+        echo "ERROR: Role-menu permission (YAML) initialization failed"
+        return 1
+    fi
+    echo "✓ Role-menu permissions initialized successfully"
     
     # 5. API 리소스 데이터 초기화
     echo "Step 5: Initializing API resources..."
@@ -308,6 +317,73 @@ init_menu() {
     fi
     
     echo "Menu data initialized"
+    return 0
+}
+
+init_menu_permissions() {
+    echo "Initializing role-menu permissions from YAML..."
+
+    # Prefer: query filePath only when a local path is known
+    # Default call without filePath (server resolvePermissionSeedPath)
+    file_path=""
+    yaml_src="${MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML:-}"
+    if [ -n "$yaml_src" ]; then
+        case "$yaml_src" in
+            http://*|https://*)
+                # Rely on server-side MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML (no filePath query)
+                ;;
+            *)
+                if [ -f "$yaml_src" ]; then
+                    file_path="$yaml_src"
+                else
+                    echo "WARNING: MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML is set but local file not found: $yaml_src"
+                    echo "Falling back to server-side path resolution"
+                fi
+                ;;
+        esac
+    elif [ -f "asset/menu/permission.yaml" ]; then
+        file_path="asset/menu/permission.yaml"
+    elif [ -f "./permission.yaml" ]; then
+        file_path="./permission.yaml"
+    fi
+
+    url="$MC_IAM_MANAGER_HOST/api/setup/initial-role-menu-permission-yaml"
+    if [ -n "$file_path" ]; then
+        echo "Using local permission YAML filePath=$file_path"
+        http_and_body=$(curl -s -w "\n%{http_code}" -G \
+            --header "Authorization: Bearer $MC_IAM_MANAGER_PLATFORMADMIN_ACCESSTOKEN" \
+            --header 'Content-Type: application/json' \
+            --data-urlencode "filePath=$file_path" \
+            "$url")
+    else
+        echo "Calling YAML permission seed without filePath (server resolvePermissionSeedPath)"
+        http_and_body=$(curl -s -w "\n%{http_code}" -X GET \
+            --header "Authorization: Bearer $MC_IAM_MANAGER_PLATFORMADMIN_ACCESSTOKEN" \
+            --header 'Content-Type: application/json' \
+            "$url")
+    fi
+
+    if [ $? -ne 0 ]; then
+        echo "ERROR: Failed to call initial-role-menu-permission-yaml"
+        return 1
+    fi
+
+    http_code=$(printf '%s\n' "$http_and_body" | tail -n1)
+    response=$(printf '%s\n' "$http_and_body" | sed '$d')
+
+    echo "Menu permission (YAML) initialization response (HTTP $http_code): $response"
+
+    if [ "$http_code" != "200" ]; then
+        echo "ERROR: Menu permission (YAML) initialization failed (HTTP $http_code)"
+        return 1
+    fi
+
+    if echo "$response" | jq -e '.error' > /dev/null 2>&1; then
+        echo "ERROR: Menu permission (YAML) initialization failed"
+        return 1
+    fi
+
+    echo "Role-menu permissions initialized from YAML"
     return 0
 }
 

--- a/conf/mc-iam-manager/1_setup_manual.sh
+++ b/conf/mc-iam-manager/1_setup_manual.sh
@@ -90,6 +90,77 @@ init_menu() {
         "$MC_IAM_MANAGER_HOST/api/setup/initial-menus")
     echo "Menu initialization response: $response"
     echo "Menu data initialized"
+
+    # Also seed role-menu permissions from YAML after menus are loaded
+    init_menu_permissions
+}
+
+
+init_menu_permissions() {
+    echo "Initializing role-menu permissions from YAML..."
+
+    # Prefer: query filePath only when a local path is known
+    # Default call without filePath (server resolvePermissionSeedPath)
+    file_path=""
+    yaml_src="${MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML:-}"
+    if [ -n "$yaml_src" ]; then
+        case "$yaml_src" in
+            http://*|https://*)
+                # Rely on server-side MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML (no filePath query)
+                ;;
+            *)
+                if [ -f "$yaml_src" ]; then
+                    file_path="$yaml_src"
+                else
+                    echo "WARNING: MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML is set but local file not found: $yaml_src"
+                    echo "Falling back to server-side path resolution"
+                fi
+                ;;
+        esac
+    elif [ -f "asset/menu/permission.yaml" ]; then
+        file_path="asset/menu/permission.yaml"
+    elif [ -f "./permission.yaml" ]; then
+        file_path="./permission.yaml"
+    fi
+
+    url="$MC_IAM_MANAGER_HOST/api/setup/initial-role-menu-permission-yaml"
+    if [ -n "$file_path" ]; then
+        echo "Using local permission YAML filePath=$file_path"
+        http_and_body=$(curl -s -w "\n%{http_code}" -G \
+            --header "Authorization: Bearer $MC_IAM_MANAGER_PLATFORMADMIN_ACCESSTOKEN" \
+            --header 'Content-Type: application/json' \
+            --data-urlencode "filePath=$file_path" \
+            "$url")
+    else
+        echo "Calling YAML permission seed without filePath (server resolvePermissionSeedPath)"
+        http_and_body=$(curl -s -w "\n%{http_code}" -X GET \
+            --header "Authorization: Bearer $MC_IAM_MANAGER_PLATFORMADMIN_ACCESSTOKEN" \
+            --header 'Content-Type: application/json' \
+            "$url")
+    fi
+
+    if [ $? -ne 0 ]; then
+        echo "ERROR: Failed to call initial-role-menu-permission-yaml"
+        return 1
+    fi
+
+    http_code=$(printf '%s\n' "$http_and_body" | tail -n1)
+    response=$(printf '%s\n' "$http_and_body" | sed '$d')
+
+    echo "Menu permission (YAML) initialization response (HTTP $http_code): $response"
+
+    if [ "$http_code" != "200" ]; then
+        echo "ERROR: Menu permission (YAML) initialization failed (HTTP $http_code)"
+        return 1
+    fi
+
+    if echo "$response" | jq -e '.error' > /dev/null 2>&1; then
+        echo "ERROR: Menu permission (YAML) initialization failed"
+        return 1
+    fi
+
+    echo "Role-menu permissions initialized from YAML"
+    return 0
 }
 
 init_api_resources() {
@@ -223,7 +294,8 @@ while true; do
     echo "1. Init Platform And PlatformAdmin"
     echo "2. PlatformAdmin Login"
     echo "3. Init Role Data"
-    echo "4. Init Menu Data"
+    echo "4. Init Menu Data (includes YAML role-menu permissions)"
+    echo "4a. Init Menu Role Permissions (YAML) (re-seed only)"
     echo "5. Init API Resource Data"
     echo "6. Init Cloud Resource Data"
     echo "7. Map API-Cloud Resources"
@@ -259,6 +331,14 @@ while true; do
                 echo "Current token value: '$MC_IAM_MANAGER_PLATFORMADMIN_ACCESSTOKEN'"
             else
                 init_menu
+            fi
+            ;;
+        4a)
+            if [ -z "$MC_IAM_MANAGER_PLATFORMADMIN_ACCESSTOKEN" ]; then
+                echo "Please login first (option 2)"
+                echo "Current token value: '$MC_IAM_MANAGER_PLATFORMADMIN_ACCESSTOKEN'"
+            else
+                init_menu_permissions
             fi
             ;;
         5)

--- a/src/service/menu_service.go
+++ b/src/service/menu_service.go
@@ -691,7 +691,8 @@ func (s *MenuService) InitializeMenuPermissionsFromCSV(filePath string) error {
 }
 
 // InitializeMenuPermissionsFromYAML 역할 중심 permission.yaml으로 권한을 시드합니다.
-// filePath가 비어 있으면 asset/menu/permission.yaml (또는 MC_WEB_CONSOLE_MENU_PERMISSIONS)을 사용합니다.
+// filePath가 비어 있으면 MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML,
+// 확장자가 .yaml/.yml인 MC_WEB_CONSOLE_MENU_PERMISSIONS, 또는 asset/menu/permission.yaml을 사용합니다.
 // 스키마: permissions → role → menus | operations | csps
 func (s *MenuService) InitializeMenuPermissionsFromYAML(filePath string) error {
 	effectiveFilePath, cleanup, err := s.resolvePermissionSeedPath(
@@ -706,8 +707,27 @@ func (s *MenuService) InitializeMenuPermissionsFromYAML(filePath string) error {
 	return s.loadAndApplyMenuPermissionsFromYAML(effectiveFilePath)
 }
 
+// permissionSeedSourceMatchesExt는 source 경로/URL 확장자가 defaultExt와 맞는지 확인합니다.
+// YAML(.yaml/.yml)은 서로 호환으로 취급하며, 쿼리스트링은 확장자 검사 전에 제거합니다.
+func permissionSeedSourceMatchesExt(source, defaultExt string) bool {
+	pathPart := strings.SplitN(source, "?", 2)[0]
+	ext := strings.ToLower(filepath.Ext(pathPart))
+	want := strings.ToLower(defaultExt)
+	if want == ".yaml" || want == ".yml" {
+		return ext == ".yaml" || ext == ".yml"
+	}
+	return ext == want
+}
+
+func isYAMLPermissionSeedExt(defaultExt string) bool {
+	ext := strings.ToLower(defaultExt)
+	return ext == ".yaml" || ext == ".yml"
+}
+
 // resolvePermissionSeedPath 시드 파일 경로를 결정합니다.
-// 우선순위: query filePath → env URL/path → asset/menu/{defaultFileName}
+// 우선순위: query filePath → (YAML) MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML →
+// 확장자가 맞는 MC_WEB_CONSOLE_MENU_PERMISSIONS → asset/menu/{defaultFileName}
+// 공유 env의 확장자가 기대 포맷과 다르면 다운로드하지 않고 로컬 기본 파일로 fallback합니다.
 func (s *MenuService) resolvePermissionSeedPath(
 	filePath, defaultFileName, defaultExt string,
 ) (string, string, error) {
@@ -716,65 +736,97 @@ func (s *MenuService) resolvePermissionSeedPath(
 	}
 
 	util.LoadEnvFiles()
-	permissionURL := os.Getenv("MC_WEB_CONSOLE_MENU_PERMISSIONS")
 	assetPath := util.GetAssetPath()
 	defaultLocalPath := filepath.Join(assetPath, "menu", defaultFileName)
 
-	if permissionURL != "" &&
-		(strings.HasPrefix(permissionURL, "http://") ||
-			strings.HasPrefix(permissionURL, "https://")) {
-		fmt.Printf("Attempting to download permission seed from URL: %s\n", permissionURL)
-		resp, err := http.Get(permissionURL)
-		if err != nil {
-			fmt.Printf(
-				"Warning: Failed to download permission seed from %s: %v. Falling back to local file.\n",
-				permissionURL, err,
-			)
-		} else {
-			defer resp.Body.Close()
-			if resp.StatusCode != http.StatusOK {
-				fmt.Printf(
-					"Warning: Failed to download permission seed from %s (Status: %s). Falling back to local file.\n",
-					permissionURL, resp.Status,
-				)
-			} else {
-				bodyBytes, err := io.ReadAll(resp.Body)
-				if err != nil {
-					fmt.Printf(
-						"Warning: Failed to read permission seed from %s: %v. Falling back to local file.\n",
-						permissionURL, err,
-					)
+	permissionSource := ""
+	if isYAMLPermissionSeedExt(defaultExt) {
+		permissionSource = strings.TrimSpace(os.Getenv("MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML"))
+		if permissionSource == "" {
+			shared := strings.TrimSpace(os.Getenv("MC_WEB_CONSOLE_MENU_PERMISSIONS"))
+			if shared != "" {
+				if permissionSeedSourceMatchesExt(shared, defaultExt) {
+					permissionSource = shared
 				} else {
-					ext := filepath.Ext(strings.Split(permissionURL, "?")[0])
-					if ext == "" {
-						ext = defaultExt
-					}
-					tempFile, err := os.CreateTemp("", "permission-*"+ext)
-					if err != nil {
-						fmt.Printf(
-							"Warning: Failed to create temp file: %v. Falling back to local file.\n", err,
-						)
-					} else {
-						if _, err := tempFile.Write(bodyBytes); err != nil {
-							tempFile.Close()
-							os.Remove(tempFile.Name())
-							fmt.Printf(
-								"Warning: Failed to write temp permission file: %v. Falling back to local file.\n",
-								err,
-							)
-						} else {
-							tempFile.Close()
-							return tempFile.Name(), tempFile.Name(), nil
-						}
-					}
+					fmt.Printf(
+						"Warning: MC_WEB_CONSOLE_MENU_PERMISSIONS (%s) is not a YAML source; "+
+							"falling back to local %s. Set MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML for remote YAML.\n",
+						shared, defaultLocalPath,
+					)
 				}
 			}
 		}
-	} else if permissionURL != "" {
-		return permissionURL, "", nil
+	} else {
+		shared := strings.TrimSpace(os.Getenv("MC_WEB_CONSOLE_MENU_PERMISSIONS"))
+		if shared != "" {
+			if permissionSeedSourceMatchesExt(shared, defaultExt) {
+				permissionSource = shared
+			} else {
+				fmt.Printf(
+					"Warning: MC_WEB_CONSOLE_MENU_PERMISSIONS (%s) is not a %s source; "+
+						"falling back to local %s.\n",
+					shared, defaultExt, defaultLocalPath,
+				)
+			}
+		}
 	}
 
-	return defaultLocalPath, "", nil
+	if permissionSource == "" {
+		return defaultLocalPath, "", nil
+	}
+
+	if strings.HasPrefix(permissionSource, "http://") ||
+		strings.HasPrefix(permissionSource, "https://") {
+		fmt.Printf("Attempting to download permission seed from URL: %s\n", permissionSource)
+		resp, err := http.Get(permissionSource)
+		if err != nil {
+			fmt.Printf(
+				"Warning: Failed to download permission seed from %s: %v. Falling back to local file.\n",
+				permissionSource, err,
+			)
+			return defaultLocalPath, "", nil
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			fmt.Printf(
+				"Warning: Failed to download permission seed from %s (Status: %s). Falling back to local file.\n",
+				permissionSource, resp.Status,
+			)
+			return defaultLocalPath, "", nil
+		}
+		bodyBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			fmt.Printf(
+				"Warning: Failed to read permission seed from %s: %v. Falling back to local file.\n",
+				permissionSource, err,
+			)
+			return defaultLocalPath, "", nil
+		}
+		ext := filepath.Ext(strings.SplitN(permissionSource, "?", 2)[0])
+		if ext == "" {
+			ext = defaultExt
+		}
+		tempFile, err := os.CreateTemp("", "permission-*"+ext)
+		if err != nil {
+			fmt.Printf(
+				"Warning: Failed to create temp file: %v. Falling back to local file.\n", err,
+			)
+			return defaultLocalPath, "", nil
+		}
+		if _, err := tempFile.Write(bodyBytes); err != nil {
+			tempFile.Close()
+			os.Remove(tempFile.Name())
+			fmt.Printf(
+				"Warning: Failed to write temp permission file: %v. Falling back to local file.\n",
+				err,
+			)
+			return defaultLocalPath, "", nil
+		}
+		tempFile.Close()
+		return tempFile.Name(), tempFile.Name(), nil
+	}
+
+	return permissionSource, "", nil
 }
 
 // loadAndApplyMenuPermissionsFromYAML 역할 중심 permission.yaml을 적용합니다.

--- a/src/service/menu_service_permission_seed_path_test.go
+++ b/src/service/menu_service_permission_seed_path_test.go
@@ -1,0 +1,114 @@
+package service
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPermissionSeedSourceMatchesExt(t *testing.T) {
+	cases := []struct {
+		source     string
+		defaultExt string
+		want       bool
+	}{
+		{"https://example.com/perm.csv", ".yaml", false},
+		{"https://example.com/perm.csv?token=1", ".csv", true},
+		{"/tmp/permission.yaml", ".yml", true},
+		{"/tmp/permission.yml", ".yaml", true},
+		{"/tmp/permission.csv", ".csv", true},
+		{"/tmp/permission.yaml", ".csv", false},
+	}
+	for _, tc := range cases {
+		got := permissionSeedSourceMatchesExt(tc.source, tc.defaultExt)
+		if got != tc.want {
+			t.Fatalf(
+				"permissionSeedSourceMatchesExt(%q, %q)=%v, want %v",
+				tc.source, tc.defaultExt, got, tc.want,
+			)
+		}
+	}
+}
+
+func TestResolvePermissionSeedPathCSVEnvNotUsedForYAML(t *testing.T) {
+	t.Setenv(
+		"MC_WEB_CONSOLE_MENU_PERMISSIONS",
+		"https://example.com/webconsole_menu_permissions.csv",
+	)
+	t.Setenv("MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML", "")
+
+	svc := &MenuService{}
+	got, cleanup, err := svc.resolvePermissionSeedPath("", "permission.yaml", ".yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cleanup != "" {
+		t.Fatalf("cleanup=%q, want empty (no download)", cleanup)
+	}
+	if !strings.HasSuffix(got, filepath.Join("menu", "permission.yaml")) {
+		t.Fatalf("got %q, want path ending with menu/permission.yaml", got)
+	}
+}
+
+func TestResolvePermissionSeedPathYAMLEnvPreferred(t *testing.T) {
+	yamlPath := filepath.Join(t.TempDir(), "custom-permission.yaml")
+	t.Setenv(
+		"MC_WEB_CONSOLE_MENU_PERMISSIONS",
+		"https://example.com/webconsole_menu_permissions.csv",
+	)
+	t.Setenv("MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML", yamlPath)
+
+	svc := &MenuService{}
+	got, cleanup, err := svc.resolvePermissionSeedPath("", "permission.yaml", ".yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cleanup != "" {
+		t.Fatalf("cleanup=%q, want empty", cleanup)
+	}
+	if got != yamlPath {
+		t.Fatalf("got %q, want YAML-specific path %q", got, yamlPath)
+	}
+}
+
+func TestResolvePermissionSeedPathCSVEnvUsedForCSV(t *testing.T) {
+	csvPath := filepath.Join(t.TempDir(), "custom-permission.csv")
+	t.Setenv("MC_WEB_CONSOLE_MENU_PERMISSIONS", csvPath)
+	t.Setenv("MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML", "")
+
+	svc := &MenuService{}
+	got, cleanup, err := svc.resolvePermissionSeedPath("", "permission.csv", ".csv")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cleanup != "" {
+		t.Fatalf("cleanup=%q, want empty", cleanup)
+	}
+	if got != csvPath {
+		t.Fatalf("got %q, want CSV path %q", got, csvPath)
+	}
+}
+
+func TestResolvePermissionSeedPathExplicitFilePathWins(t *testing.T) {
+	t.Setenv(
+		"MC_WEB_CONSOLE_MENU_PERMISSIONS",
+		"https://example.com/webconsole_menu_permissions.csv",
+	)
+	t.Setenv(
+		"MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML",
+		"/should/not/use/permission.yaml",
+	)
+
+	explicit := "/explicit/permission.yaml"
+	svc := &MenuService{}
+	got, cleanup, err := svc.resolvePermissionSeedPath(explicit, "permission.yaml", ".yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cleanup != "" {
+		t.Fatalf("cleanup=%q, want empty", cleanup)
+	}
+	if got != explicit {
+		t.Fatalf("got %q, want explicit %q", got, explicit)
+	}
+}


### PR DESCRIPTION
## Summary
- `resolvePermissionSeedPath` no longer treats `MC_WEB_CONSOLE_MENU_PERMISSIONS` as a YAML seed when it points at a `.csv` URL/path (production case).
- YAML seeding prefers `MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML`, then a shared env only if the extension is `.yaml`/`.yml`; mismatched shared sources fall back to `asset/menu/permission.yaml` without download.
- Documented the new env in `.env_sample` and added unit tests for CSV/YAML/explicit-path resolution.

## Test plan
- [x] `cd src && go test ./service/ -run 'PermissionSeed|BackupAndRestore|ParseRolePermission' -count=1`
- [x] `cd src && go build ./...`
- [ ] Call `GET /api/setup/initial-role-menu-permission-yaml` with prod-like `MC_WEB_CONSOLE_MENU_PERMISSIONS=...csv` and no filePath — expect local YAML seed (not 500)
- [ ] With `MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML` set to a YAML path/URL, confirm YAML init uses that source
- [ ] Confirm CSV init (`InitializeMenuPermissionsFromCSV`) still uses `.csv` shared env