### PR TITLE
fix(menu): specs/images/securitys/disks 이름 불일치 정리 및 permission.yaml 동기화

### DIFF
--- a/asset/menu/menu.yaml
+++ b/asset/menu/menu.yaml
@@ -90,6 +90,14 @@ menus:
     priority: 2
     menunumber: 1790
 
+  - id: infratemplates
+    parentid: workloads
+    displayname: Infra Templates
+    restype: menu
+    isaction: true
+    priority: 2
+    menunumber: 1780
+
   - id: workflows
     parentid: manage
     displayname: Workflows
@@ -338,22 +346,6 @@ menus:
     priority: 2
     menunumber: 1410
 
-  - id: specs
-    parentid: cloudresources
-    displayname: Specs
-    restype: menu
-    isaction: false
-    priority: 2
-    menunumber: 1410
-
-  - id: images
-    parentid: cloudresources
-    displayname: Images
-    restype: menu
-    isaction: false
-    priority: 2
-    menunumber: 1420
-
   - id: serverimages
     parentid: cloudresources
     displayname: Images
@@ -378,14 +370,6 @@ menus:
     priority: 2
     menunumber: 1520
 
-  - id: securitys
-    parentid: cloudresources
-    displayname: Securitys
-    restype: menu
-    isaction: false
-    priority: 2
-    menunumber: 1520
-
   - id: myimages
     parentid: cloudresources
     displayname: MyImages
@@ -394,7 +378,7 @@ menus:
     priority: 2
     menunumber: 1530
 
-  - id: disks
+  - id: datadisk
     parentid: cloudresources
     displayname: Disks
     restype: menu
@@ -433,6 +417,14 @@ menus:
     isaction: true
     priority: 3
     menunumber: 1595
+
+  - id: networktemplates
+    parentid: cloudresources
+    displayname: Network Templates
+    restype: menu
+    isaction: true
+    priority: 2
+    menunumber: 1598
 
   - id: cloudrescatalogs
     parentid: environment

--- a/asset/menu/permission.yaml
+++ b/asset/menu/permission.yaml
@@ -18,6 +18,7 @@ permissions:
       - workloads
       - mciworkloads
       - pmkworkloads
+      - infratemplates
       - workflows
       - swcatalogs
       - mcdatamanager
@@ -46,18 +47,16 @@ permissions:
       - cspaccounts
       - cloudresources
       - serverspecs
-      - specs
-      - images
       - serverimages
       - networks
       - securitygroups
-      - securitys
       - myimages
-      - disks
+      - datadisk
       - sshkeys
       - csp
       - cspschedule
       - resourcesync
+      - networktemplates
       - cloudrescatalogs
       - workspacessettings
       - allocatedprojects
@@ -106,12 +105,9 @@ permissions:
       - cloudoverview
       - regions
       - cloudresources
-      - specs
-      - images
       - networks
-      - securitys
       - myimages
-      - disks
+      - datadisk
       - sshkeys
       - cloudrescatalogs
     operations: []

--- a/conf/mc-iam-manager/menu.yaml
+++ b/conf/mc-iam-manager/menu.yaml
@@ -90,6 +90,14 @@ menus:
     priority: 2
     menunumber: 1790
 
+  - id: infratemplates
+    parentid: workloads
+    displayname: Infra Templates
+    restype: menu
+    isaction: true
+    priority: 2
+    menunumber: 1780
+
   - id: workflows
     parentid: manage
     displayname: Workflows
@@ -338,22 +346,6 @@ menus:
     priority: 2
     menunumber: 1410
 
-  - id: specs
-    parentid: cloudresources
-    displayname: Specs
-    restype: menu
-    isaction: false
-    priority: 2
-    menunumber: 1410
-
-  - id: images
-    parentid: cloudresources
-    displayname: Images
-    restype: menu
-    isaction: false
-    priority: 2
-    menunumber: 1420
-
   - id: serverimages
     parentid: cloudresources
     displayname: Images
@@ -378,14 +370,6 @@ menus:
     priority: 2
     menunumber: 1520
 
-  - id: securitys
-    parentid: cloudresources
-    displayname: Securitys
-    restype: menu
-    isaction: false
-    priority: 2
-    menunumber: 1520
-
   - id: myimages
     parentid: cloudresources
     displayname: MyImages
@@ -394,7 +378,7 @@ menus:
     priority: 2
     menunumber: 1530
 
-  - id: disks
+  - id: datadisk
     parentid: cloudresources
     displayname: Disks
     restype: menu
@@ -433,6 +417,14 @@ menus:
     isaction: true
     priority: 3
     menunumber: 1595
+
+  - id: networktemplates
+    parentid: cloudresources
+    displayname: Network Templates
+    restype: menu
+    isaction: true
+    priority: 2
+    menunumber: 1598
 
   - id: cloudrescatalogs
     parentid: environment


### PR DESCRIPTION
## Summary
- `specs`/`images`/`securitys`/`disks` id를 제거하고 실제 템플릿 파일명과 일치하는 `serverspecs`/`serverimages`/`securitygroups`/`datadisk`로 대체 (이 중 3개는 이미 develop에 존재, `datadisk`만 이번에 신규 추가)
- 고아 템플릿(menu.yaml에 등록되지 않은 mc-web-console 화면) 중 남아있던 `networktemplates`, `infratemplates` 등록
- `asset/menu/menu.yaml` / `conf/mc-iam-manager/menu.yaml` 동일하게 반영 (배포용 사본 동기화)
- `asset/menu/permission.yaml`을 위 변경사항과 동기화: admin/operator 롤에서 제거된 id 정리, `datadisk`는 admin+operator, `networktemplates`/`infratemplates`는 admin 전용으로 추가 (기존 csproles/cspaccounts 등과 동일한 패턴)
