### PR TITLE
[refactor]: use MC_WEB_CONSOLE_MENU_PERMISSIONS for permission.yaml seed

### DIFF
--- a/.env.setup
+++ b/.env.setup
@@ -50,7 +50,9 @@ MC_IAM_MANAGER_USE_TICKET_VALID=true # [true|false]
 
 MC_ADMIN_CLI_APIYAML=https://raw.githubusercontent.com/m-cmp/mc-admin-cli/refs/heads/main/conf/api.yaml
 MC_WEB_CONSOLE_MENUYAML=https://raw.githubusercontent.com/m-cmp/mc-web-console/refs/heads/main/conf/webconsole_menu_resources.yaml
-MC_WEB_CONSOLE_MENU_PERMISSIONS=https://raw.githubusercontent.com/m-cmp/mc-web-console/refs/heads/main/conf/webconsole_menu_permissions.csv
+# YAML role-menu permission seed (path or remote URL). Deprecated CSV API falls back to local
+# asset/menu/permission.csv when this value's extension is not .csv.
+MC_WEB_CONSOLE_MENU_PERMISSIONS=asset/menu/permission.yaml
 
 
 MC_IAM_MANAGER_PLATFORMADMIN_ID=mcmp

--- a/.env_sample
+++ b/.env_sample
@@ -42,10 +42,9 @@ MC_IAM_MANAGER_USE_TICKET_VALID=true # [true|false]
 
 MC_ADMIN_CLI_APIYAML=https://raw.githubusercontent.com/m-cmp/mc-admin-cli/refs/heads/main/conf/api.yaml
 MC_WEB_CONSOLE_MENUYAML=https://raw.githubusercontent.com/m-cmp/mc-web-console/refs/heads/main/conf/webconsole_menu_resources.yaml
-# CSV role-menu permission seed (legacy / CSV init path)
-MC_WEB_CONSOLE_MENU_PERMISSIONS=https://raw.githubusercontent.com/m-cmp/mc-web-console/refs/heads/main/conf/webconsole_menu_permissions.csv
-# YAML role-menu permission seed (preferred for InitializeMenuPermissionsFromYAML / initial-role-menu-permission-yaml)
-# MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML=https://example.com/path/to/permission.yaml
+# YAML role-menu permission seed (path or remote URL). Deprecated CSV API falls back to local
+# asset/menu/permission.csv when this value's extension is not .csv.
+MC_WEB_CONSOLE_MENU_PERMISSIONS=asset/menu/permission.yaml
 
 
 MC_IAM_MANAGER_PLATFORMADMIN_ID=mcmp

--- a/conf/mc-iam-manager/1_setup_auto.sh
+++ b/conf/mc-iam-manager/1_setup_auto.sh
@@ -326,17 +326,17 @@ init_menu_permissions() {
     # Prefer: query filePath only when a local path is known
     # Default call without filePath (server resolvePermissionSeedPath)
     file_path=""
-    yaml_src="${MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML:-}"
+    yaml_src="${MC_WEB_CONSOLE_MENU_PERMISSIONS:-}"
     if [ -n "$yaml_src" ]; then
         case "$yaml_src" in
             http://*|https://*)
-                # Rely on server-side MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML (no filePath query)
+                # Rely on server-side MC_WEB_CONSOLE_MENU_PERMISSIONS (no filePath query)
                 ;;
             *)
                 if [ -f "$yaml_src" ]; then
                     file_path="$yaml_src"
                 else
-                    echo "WARNING: MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML is set but local file not found: $yaml_src"
+                    echo "WARNING: MC_WEB_CONSOLE_MENU_PERMISSIONS is set but local file not found: $yaml_src"
                     echo "Falling back to server-side path resolution"
                 fi
                 ;;

--- a/conf/mc-iam-manager/1_setup_manual.sh
+++ b/conf/mc-iam-manager/1_setup_manual.sh
@@ -102,17 +102,17 @@ init_menu_permissions() {
     # Prefer: query filePath only when a local path is known
     # Default call without filePath (server resolvePermissionSeedPath)
     file_path=""
-    yaml_src="${MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML:-}"
+    yaml_src="${MC_WEB_CONSOLE_MENU_PERMISSIONS:-}"
     if [ -n "$yaml_src" ]; then
         case "$yaml_src" in
             http://*|https://*)
-                # Rely on server-side MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML (no filePath query)
+                # Rely on server-side MC_WEB_CONSOLE_MENU_PERMISSIONS (no filePath query)
                 ;;
             *)
                 if [ -f "$yaml_src" ]; then
                     file_path="$yaml_src"
                 else
-                    echo "WARNING: MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML is set but local file not found: $yaml_src"
+                    echo "WARNING: MC_WEB_CONSOLE_MENU_PERMISSIONS is set but local file not found: $yaml_src"
                     echo "Falling back to server-side path resolution"
                 fi
                 ;;

--- a/src/service/menu_service.go
+++ b/src/service/menu_service.go
@@ -691,8 +691,8 @@ func (s *MenuService) InitializeMenuPermissionsFromCSV(filePath string) error {
 }
 
 // InitializeMenuPermissionsFromYAML 역할 중심 permission.yaml으로 권한을 시드합니다.
-// filePath가 비어 있으면 MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML,
-// 확장자가 .yaml/.yml인 MC_WEB_CONSOLE_MENU_PERMISSIONS, 또는 asset/menu/permission.yaml을 사용합니다.
+// filePath가 비어 있으면 확장자가 맞는 MC_WEB_CONSOLE_MENU_PERMISSIONS,
+// 또는 asset/menu/permission.yaml을 사용합니다.
 // 스키마: permissions → role → menus | operations | csps
 func (s *MenuService) InitializeMenuPermissionsFromYAML(filePath string) error {
 	effectiveFilePath, cleanup, err := s.resolvePermissionSeedPath(
@@ -719,14 +719,9 @@ func permissionSeedSourceMatchesExt(source, defaultExt string) bool {
 	return ext == want
 }
 
-func isYAMLPermissionSeedExt(defaultExt string) bool {
-	ext := strings.ToLower(defaultExt)
-	return ext == ".yaml" || ext == ".yml"
-}
-
 // resolvePermissionSeedPath 시드 파일 경로를 결정합니다.
-// 우선순위: query filePath → (YAML) MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML →
-// 확장자가 맞는 MC_WEB_CONSOLE_MENU_PERMISSIONS → asset/menu/{defaultFileName}
+// 우선순위: query filePath → 확장자가 맞는 MC_WEB_CONSOLE_MENU_PERMISSIONS →
+// asset/menu/{defaultFileName}
 // 공유 env의 확장자가 기대 포맷과 다르면 다운로드하지 않고 로컬 기본 파일로 fallback합니다.
 func (s *MenuService) resolvePermissionSeedPath(
 	filePath, defaultFileName, defaultExt string,
@@ -740,34 +735,16 @@ func (s *MenuService) resolvePermissionSeedPath(
 	defaultLocalPath := filepath.Join(assetPath, "menu", defaultFileName)
 
 	permissionSource := ""
-	if isYAMLPermissionSeedExt(defaultExt) {
-		permissionSource = strings.TrimSpace(os.Getenv("MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML"))
-		if permissionSource == "" {
-			shared := strings.TrimSpace(os.Getenv("MC_WEB_CONSOLE_MENU_PERMISSIONS"))
-			if shared != "" {
-				if permissionSeedSourceMatchesExt(shared, defaultExt) {
-					permissionSource = shared
-				} else {
-					fmt.Printf(
-						"Warning: MC_WEB_CONSOLE_MENU_PERMISSIONS (%s) is not a YAML source; "+
-							"falling back to local %s. Set MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML for remote YAML.\n",
-						shared, defaultLocalPath,
-					)
-				}
-			}
-		}
-	} else {
-		shared := strings.TrimSpace(os.Getenv("MC_WEB_CONSOLE_MENU_PERMISSIONS"))
-		if shared != "" {
-			if permissionSeedSourceMatchesExt(shared, defaultExt) {
-				permissionSource = shared
-			} else {
-				fmt.Printf(
-					"Warning: MC_WEB_CONSOLE_MENU_PERMISSIONS (%s) is not a %s source; "+
-						"falling back to local %s.\n",
-					shared, defaultExt, defaultLocalPath,
-				)
-			}
+	shared := strings.TrimSpace(os.Getenv("MC_WEB_CONSOLE_MENU_PERMISSIONS"))
+	if shared != "" {
+		if permissionSeedSourceMatchesExt(shared, defaultExt) {
+			permissionSource = shared
+		} else {
+			fmt.Printf(
+				"Warning: MC_WEB_CONSOLE_MENU_PERMISSIONS (%s) is not a %s source; "+
+					"falling back to local %s.\n",
+				shared, defaultExt, defaultLocalPath,
+			)
 		}
 	}
 

--- a/src/service/menu_service_permission_seed_path_test.go
+++ b/src/service/menu_service_permission_seed_path_test.go
@@ -30,12 +30,28 @@ func TestPermissionSeedSourceMatchesExt(t *testing.T) {
 	}
 }
 
-func TestResolvePermissionSeedPathCSVEnvNotUsedForYAML(t *testing.T) {
+func TestResolvePermissionSeedPathSharedEnvYAMLPreferred(t *testing.T) {
+	yamlPath := filepath.Join(t.TempDir(), "custom-permission.yaml")
+	t.Setenv("MC_WEB_CONSOLE_MENU_PERMISSIONS", yamlPath)
+
+	svc := &MenuService{}
+	got, cleanup, err := svc.resolvePermissionSeedPath("", "permission.yaml", ".yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cleanup != "" {
+		t.Fatalf("cleanup=%q, want empty", cleanup)
+	}
+	if got != yamlPath {
+		t.Fatalf("got %q, want shared YAML path %q", got, yamlPath)
+	}
+}
+
+func TestResolvePermissionSeedPathCSVEnvIgnoredForYAML(t *testing.T) {
 	t.Setenv(
 		"MC_WEB_CONSOLE_MENU_PERMISSIONS",
 		"https://example.com/webconsole_menu_permissions.csv",
 	)
-	t.Setenv("MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML", "")
 
 	svc := &MenuService{}
 	got, cleanup, err := svc.resolvePermissionSeedPath("", "permission.yaml", ".yaml")
@@ -50,31 +66,9 @@ func TestResolvePermissionSeedPathCSVEnvNotUsedForYAML(t *testing.T) {
 	}
 }
 
-func TestResolvePermissionSeedPathYAMLEnvPreferred(t *testing.T) {
-	yamlPath := filepath.Join(t.TempDir(), "custom-permission.yaml")
-	t.Setenv(
-		"MC_WEB_CONSOLE_MENU_PERMISSIONS",
-		"https://example.com/webconsole_menu_permissions.csv",
-	)
-	t.Setenv("MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML", yamlPath)
-
-	svc := &MenuService{}
-	got, cleanup, err := svc.resolvePermissionSeedPath("", "permission.yaml", ".yaml")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cleanup != "" {
-		t.Fatalf("cleanup=%q, want empty", cleanup)
-	}
-	if got != yamlPath {
-		t.Fatalf("got %q, want YAML-specific path %q", got, yamlPath)
-	}
-}
-
 func TestResolvePermissionSeedPathCSVEnvUsedForCSV(t *testing.T) {
 	csvPath := filepath.Join(t.TempDir(), "custom-permission.csv")
 	t.Setenv("MC_WEB_CONSOLE_MENU_PERMISSIONS", csvPath)
-	t.Setenv("MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML", "")
 
 	svc := &MenuService{}
 	got, cleanup, err := svc.resolvePermissionSeedPath("", "permission.csv", ".csv")
@@ -92,11 +86,7 @@ func TestResolvePermissionSeedPathCSVEnvUsedForCSV(t *testing.T) {
 func TestResolvePermissionSeedPathExplicitFilePathWins(t *testing.T) {
 	t.Setenv(
 		"MC_WEB_CONSOLE_MENU_PERMISSIONS",
-		"https://example.com/webconsole_menu_permissions.csv",
-	)
-	t.Setenv(
-		"MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML",
-		"/should/not/use/permission.yaml",
+		"/env/should/not/use/permission.yaml",
 	)
 
 	explicit := "/explicit/permission.yaml"


### PR DESCRIPTION
## Summary
- Unify YAML and CSV permission seed path resolution on `MC_WEB_CONSOLE_MENU_PERMISSIONS` only
- Remove `MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML`; ext mismatch still warns and falls back to local `asset/menu/{defaultFileName}`
- Point `.env_sample` / `.env.setup` at `asset/menu/permission.yaml` and update local setup scripts accordingly
