### PR TITLE
fix: 프로젝트 삭제 시 mc-infra-manager 네임스페이스 삭제 operationId 수정

### DIFF
--- a/src/service/project_service.go
+++ b/src/service/project_service.go
@@ -243,7 +243,7 @@ func (s *ProjectService) DeleteProject(id uint) error {
 		ctx := context.Background()
 		callReq := &model.McmpApiCallRequest{
 			ServiceName: "mc-infra-manager",
-			ActionName:  "DeleteNs",
+			ActionName:  "DelNs",
 			RequestParams: model.McmpApiRequestParams{
 				PathParams: map[string]string{
 					"nsId": project.NsId,
@@ -256,7 +256,7 @@ func (s *ProjectService) DeleteProject(id uint) error {
 			log.Printf("Warning: failed to delete namespace %s from mc-infra-manager: %v", project.NsId, err)
 			// 계속 진행 (DB 정리는 수행)
 		} else if statusCode < 200 || statusCode >= 300 {
-			log.Printf("Warning: mc-infra-manager DeleteNs failed (status %d): %s", statusCode, string(respBody))
+			log.Printf("Warning: mc-infra-manager DelNs failed (status %d): %s", statusCode, string(respBody))
 			// 계속 진행 (DB 정리는 수행)
 		} else {
 			log.Printf("Successfully deleted namespace %s from mc-infra-manager", project.NsId)


### PR DESCRIPTION
## 배경

프로젝트 삭제 시 `DeleteProject`
- `src/service/project_service.go`: `ActionName: "DeleteNs"` → `"DelNs"`
- 동일 파일의 관련 로그 메시지도 `DelNs` 기준으로 수정
