### PR TITLE
fix: mcmp-apis call 라우트 권한을 manage에서 read로 완화

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -445,7 +445,7 @@ func main() {
 	{
 		mcmpApis.POST("/list", mcmpApiHandler.ListServicesAndActions, middleware.PlatformRoleMiddleware(middleware.Manage))
 		mcmpApis.PUT("/name/:serviceName/versions/:version/activate", mcmpApiHandler.SetActiveVersion, middleware.PlatformRoleMiddleware(middleware.Manage))
-		mcmpApis.POST("/call", mcmpApiHandler.McmpApiCall, middleware.PlatformRoleMiddleware(middleware.Manage))
+		mcmpApis.POST("/call", mcmpApiHandler.McmpApiCall, middleware.PlatformRoleMiddleware(middleware.Read))
 		mcmpApis.GET("/test/mc-infra-manager/getallns", mcmpApiHandler.TestCallGetAllNs, middleware.PlatformRoleMiddleware(middleware.Manage))
 		mcmpApis.POST("", mcmpApiHandler.CreateFrameworkService, middleware.PlatformRoleMiddleware(middleware.Manage))
 		mcmpApis.PUT("/name/:serviceName", mcmpApiHandler.UpdateFrameworkService, middleware.PlatformRoleMiddleware(middleware.Manage))


### PR DESCRIPTION
## 배경

`POST /api/mcmp-apis/call` 에 대해 기존 Middleware에서 Manage 권한만 통과 -> Read 통과로 변경
