### PR TITLE
fix: 워크스페이스/프로젝트 목록 API 접근범위 검증 추가

### DIFF
--- a/src/handler/user_handler.go
+++ b/src/handler/user_handler.go
@@ -906,13 +906,24 @@ func (h *UserHandler) ListUserProjectsByWorkspace(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "Retrieved invalid local user database ID (0)"})
 	}
 
-	// Get user's workspace
-	//ListWorkspacesProjects
-	//workspaces, err := h.workspaceService.ListWorkspaces(&model.WorkspaceFilterRequest{
+	// 1. 사용자가 실제로 해당 workspace에 소속되어 있는지 먼저 검증한다.
+	//    (WorkspaceID + UserID 조건을 함께 걸어야 하므로 project 정보가 없는 ListWorkspaces를 사용한다.
+	//     FindWorkspacesProjects는 WorkspaceID가 있으면 UserID를 확인하기 전에 바로 return해버려서 사용할 수 없다.)
+	memberWorkspaces, err := h.workspaceService.ListWorkspaces(&model.WorkspaceFilterRequest{
+		WorkspaceID: fmt.Sprintf("%d", workspaceIdInt),
+		UserID:      fmt.Sprintf("%d", localUserID),
+	})
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("Failed to verify workspace membership: %v", err)})
+	}
+	if len(memberWorkspaces) == 0 {
+		return c.JSON(http.StatusForbidden, map[string]string{"error": "user does not belong to the requested workspace"})
+	}
+
+	// 2. 소속이 확인된 workspace에 한해 project 목록(NsId 포함)을 조회한다.
 	workspaces, err := h.workspaceService.ListWorkspacesProjects(&model.WorkspaceFilterRequest{
 		WorkspaceID: fmt.Sprintf("%d", workspaceIdInt),
 	})
-	//workspace, err := h.workspaceService.GetWorkspaceByID(workspaceIdInt)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("Failed to get user workspace roles: %v", err)})
 	}

--- a/src/main.go
+++ b/src/main.go
@@ -167,8 +167,8 @@ func main() {
 		basePath + "/auth/login",
 		basePath + "/auth/logout",
 		basePath + "/auth/refresh",
-		basePath + "/auth/certs",   // 인증서 조회 경로 추가
-		basePath + "/auth/signup",  // 사용자 가입 신청 경로 추가
+		basePath + "/auth/certs",  // 인증서 조회 경로 추가
+		basePath + "/auth/signup", // 사용자 가입 신청 경로 추가
 
 	}
 
@@ -243,7 +243,7 @@ func main() {
 	// 워크스페이스 라우트
 	workspaces := api.Group("/workspaces")
 	{
-		workspaces.POST("/list", workspaceHandler.ListWorkspaces) // workspace 목록만 조회. 전체조회 권한이 있으면 모든 workspaces, 그 외에는 세션의 유저에 해당하는 workspaces 조회
+		workspaces.POST("/list", workspaceHandler.ListWorkspaces, middleware.PlatformRoleMiddleware(middleware.Write)) // workspace 목록만 조회. 전체조회 권한이 있으면 모든 workspaces, 그 외에는 세션의 유저에 해당하는 workspaces 조회
 		workspaces.POST("", workspaceHandler.CreateWorkspace)
 		workspaces.GET("/id/:workspaceId", workspaceHandler.GetWorkspaceByID)
 		workspaces.GET("/name/:workspaceName", workspaceHandler.GetWorkspaceByName)
@@ -254,16 +254,16 @@ func main() {
 		workspaces.POST("/temporary-credentials", cspCredentialHandler.GetTemporaryCredentials)
 		workspaces.POST("/credentials/validate", cspValidationHandler.ValidateCredentials)
 
-		workspaces.POST("/users/list", workspaceHandler.ListWorkspaceUsers)                                                                    // workspace의 사용자 목록 조회
+		workspaces.POST("/users/list", workspaceHandler.ListWorkspaceUsers, middleware.PlatformRoleMiddleware(middleware.Write))               // workspace의 사용자 목록 조회
 		workspaces.POST("/users-roles/list", workspaceHandler.ListWorkspaceUsersAndRoles, middleware.PlatformRoleMiddleware(middleware.Write)) // workspace와 사용자 및 role 조회
-		workspaces.POST("/roles/list", workspaceHandler.ListWorkspaceRoles) // workspace 역할 목록 조회
+		workspaces.POST("/roles/list", workspaceHandler.ListWorkspaceRoles, middleware.PlatformRoleMiddleware(middleware.Write))               // workspace 역할 목록 조회
 
-		workspaces.POST("/projects/list", workspaceHandler.ListWorkspaceProjects)
-		workspaces.GET("/id/:workspaceId/projects/list", workspaceHandler.GetWorkspaceProjectsByWorkspaceId)
+		workspaces.POST("/projects/list", workspaceHandler.ListWorkspaceProjects, middleware.PlatformRoleMiddleware(middleware.Write))
+		workspaces.GET("/id/:workspaceId/projects/list", workspaceHandler.GetWorkspaceProjectsByWorkspaceId, middleware.PlatformRoleMiddleware(middleware.Write))
 		workspaces.POST("/id/:workspaceId/users/list", workspaceHandler.ListUsersAndRolesByWorkspaces)                                              // TODO ListAllWorkspaceUsersAndRoles으로 대체 또는 통합 가능하지 않나?
 		workspaces.GET("/id/:workspaceId/users/id/:userId", roleHandler.GetUserWorkspaceRoles, middleware.PlatformRoleMiddleware(middleware.Write)) // 특정 사용자에게 할당된 워크스페이스 역할 조회 ( 관리자가 사용자의 workspace role 조회) --> get을 post로 바꿀까?
 
-		workspaces.POST("/id/:id/users", workspaceHandler.AddUserToWorkspace, middleware.PlatformRoleMiddleware(middleware.Write)) // workspace에 사용자 추가
+		workspaces.POST("/id/:id/users", workspaceHandler.AddUserToWorkspace, middleware.PlatformRoleMiddleware(middleware.Write))                // workspace에 사용자 추가
 		workspaces.DELETE("/id/:id/users/:userId", workspaceHandler.RemoveUserFromWorkspace, middleware.PlatformRoleMiddleware(middleware.Write)) // workspace에서 사용자 제거
 		workspaces.POST("/assign/projects", workspaceHandler.AddProjectToWorkspace, middleware.PlatformAdminMiddleware)
 		workspaces.DELETE("/unassign/projects", workspaceHandler.RemoveProjectFromWorkspace, middleware.PlatformAdminMiddleware)
@@ -277,14 +277,14 @@ func main() {
 	// 프로젝트 라우트 : workspace ticket과 workspaceId가 있으면 됨.
 	projects := api.Group("/projects")
 	{
-		projects.POST("/list", projectHandler.ListProjects)
+		projects.POST("/list", projectHandler.ListProjects, middleware.PlatformRoleMiddleware(middleware.Write))
 		projects.POST("", projectHandler.CreateProject, middleware.PlatformRoleMiddleware(middleware.Manage)) // platformRole에서 관리자
-		projects.GET("/id/:projectId", projectHandler.GetProjectByID)
+		projects.GET("/id/:projectId", projectHandler.GetProjectByID, middleware.PlatformRoleMiddleware(middleware.Write))
 		projects.GET("/name/:projectName", projectHandler.GetProjectByName)
 		projects.PUT("/id/:projectId", projectHandler.UpdateProject, middleware.PlatformRoleMiddleware(middleware.Manage))
 		projects.DELETE("/id/:projectId", projectHandler.DeleteProject, middleware.PlatformRoleMiddleware(middleware.Manage))
 
-		projects.GET("/id/:projectId/workspaces", projectHandler.GetProjectWorkspaces) // Get workspaces assigned to project
+		projects.GET("/id/:projectId/workspaces", projectHandler.GetProjectWorkspaces, middleware.PlatformRoleMiddleware(middleware.Write)) // Get workspaces assigned to project
 
 		projects.POST("/assign/workspaces", projectHandler.AddWorkspaceToProject, middleware.PlatformAdminMiddleware)
 		projects.DELETE("/unassign/workspaces", projectHandler.RemoveWorkspaceFromProject, middleware.PlatformAdminMiddleware)
@@ -362,13 +362,13 @@ func main() {
 		users.DELETE("/id/:userId", userHandler.DeleteUser, middleware.PlatformRoleMiddleware(middleware.Write))
 		users.POST("/id/:userId/status", userHandler.UpdateUserStatus, middleware.PlatformRoleMiddleware(middleware.Write))
 		users.PUT("/id/:userId/password", userHandler.ResetUserPassword, middleware.PlatformRoleMiddleware(middleware.Write))
-		users.GET("/me", userHandler.GetMyInfo)                                                            // 사용자 본인 정보 조회
-		users.PUT("/me/password", userHandler.ChangeMyPassword)                                            // 사용자 본인 패스워드 변경
-		users.GET("/me/platform-roles", userHandler.GetMyPlatformRoles)                                    // 내 유효 플랫폼 역할 목록
-		users.GET("/me/workspace-roles", userHandler.GetMyWorkspaceRoles)                                  // 내 유효 워크스페이스 역할 목록
-		users.PUT("/id/:userId/deactivate", userHandler.DeactivateUser, middleware.PlatformAdminMiddleware) // 사용자 계정 비활성화
-		users.PUT("/id/:userId/activate", userHandler.ActivateUser, middleware.PlatformAdminMiddleware)     // 사용자 계정 재활성화
-		users.POST("/me/withdrawal", userHandler.RequestWithdrawal)                                        // 탈퇴 신청
+		users.GET("/me", userHandler.GetMyInfo)                                                              // 사용자 본인 정보 조회
+		users.PUT("/me/password", userHandler.ChangeMyPassword)                                              // 사용자 본인 패스워드 변경
+		users.GET("/me/platform-roles", userHandler.GetMyPlatformRoles)                                      // 내 유효 플랫폼 역할 목록
+		users.GET("/me/workspace-roles", userHandler.GetMyWorkspaceRoles)                                    // 내 유효 워크스페이스 역할 목록
+		users.PUT("/id/:userId/deactivate", userHandler.DeactivateUser, middleware.PlatformAdminMiddleware)  // 사용자 계정 비활성화
+		users.PUT("/id/:userId/activate", userHandler.ActivateUser, middleware.PlatformAdminMiddleware)      // 사용자 계정 재활성화
+		users.POST("/me/withdrawal", userHandler.RequestWithdrawal)                                          // 탈퇴 신청
 		users.PUT("/id/:userId/withdraw", userHandler.ProcessWithdrawal, middleware.PlatformAdminMiddleware) // 탈퇴 처리
 
 		users.POST("/menus-tree/list", menuHandler.ListUserMenuTree)


### PR DESCRIPTION
## 배경
관리자 전용 API 에 대하여 middleware에서 1차 필터링

### 1. 미들웨어 추가 (`src/main.go`)

아래 8개 라우트에 `PlatformRoleMiddleware(Write)`(admin/platformAdmin만 통과) 추가:

- `POST /api/workspaces/list` — 전체 워크스페이스 목록
- `POST /api/workspaces/projects/list` — 워크스페이스별 프로젝트 목록
- `GET /api/workspaces/id/:workspaceId/projects/list` — 1개 워크스페이스의 프로젝트 목록
- `POST /api/workspaces/users/list` — 워크스페이스별 사용자 목록
- `POST /api/workspaces/roles/list` — 워크스페이스 할당가능 역할 목록
- `POST /api/projects/list` — 전체 프로젝트 목록
- `GET /api/projects/id/:projectId` — 특정 프로젝트
- `GET /api/projects/id/:projectId/workspaces` — 프로젝트의 할당 워크스페이스 목록

