### PR TITLE
test: 조직 계층 테스트를 Postgres 통합테스트로 전환 + go vet 정리

### DIFF
--- a/src/handler/auth_handler.go
+++ b/src/handler/auth_handler.go
@@ -210,7 +210,7 @@ func (h *AuthHandler) WorkspaceTicket(c echo.Context) error {
 	// Convert permissions to scope format
 	scopes := make([]string, 0)
 	for _, role := range workspaceRoles {
-		scopes = append(scopes, fmt.Sprintf("workspace:%s", role))
+		scopes = append(scopes, fmt.Sprintf("workspace:%s", role.RoleName))
 	}
 
 	// 6. Use KeycloakService to issue RPT

--- a/src/handler/role_handler.go
+++ b/src/handler/role_handler.go
@@ -478,7 +478,7 @@ func (h *RoleHandler) AssignRole(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "User ID or username is required"})
 	}
 
-	log.Printf("Role assignment request - UserID: %d, Username: %s, RoleID: %d, RoleType: %s, WorkspaceID: %d",
+	log.Printf("Role assignment request - UserID: %s, Username: %s, RoleID: %s, RoleType: %s, WorkspaceID: %s",
 		req.UserID, req.Username, req.RoleID, reqRoleType, req.WorkspaceID)
 
 	if err := c.Validate(&req); err != nil {
@@ -508,7 +508,7 @@ func (h *RoleHandler) AssignRole(c echo.Context) error {
 		}
 		userID = user.ID
 	} else {
-		log.Printf("User identifier missing - UserID: %d, Username: %s", req.UserID, req.Username)
+		log.Printf("User identifier missing - UserID: %s, Username: %s", req.UserID, req.Username)
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "User ID or username is required"})
 	}
 
@@ -523,11 +523,11 @@ func (h *RoleHandler) AssignRole(c echo.Context) error {
 	// Check if role exists
 	role, err := h.roleService.GetRoleByID(roleID, reqRoleType)
 	if err != nil {
-		log.Printf("Failed to retrieve role - roleID: %d, error: %v", req.RoleID, err)
+		log.Printf("Failed to retrieve role - roleID: %s, error: %v", req.RoleID, err)
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("Failed to retrieve role: %v", err)})
 	}
 	if role == nil {
-		log.Printf("Role not found - roleID: %d", req.RoleID)
+		log.Printf("Role not found - roleID: %s", req.RoleID)
 		return c.JSON(http.StatusNotFound, map[string]string{"error": "Role with the specified ID not found"})
 	}
 
@@ -540,7 +540,7 @@ func (h *RoleHandler) AssignRole(c echo.Context) error {
 		}
 	}
 	if !hasRoleType {
-		log.Printf("Unsupported role type - roleID: %d, requested type: %s", req.RoleID, reqRoleType)
+		log.Printf("Unsupported role type - roleID: %s, requested type: %s", req.RoleID, reqRoleType)
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("This role does not support %s type", reqRoleType)})
 	}
 
@@ -556,22 +556,22 @@ func (h *RoleHandler) AssignRole(c echo.Context) error {
 	// Assign role
 	if reqRoleType == constants.RoleTypePlatform {
 		if err := h.roleService.AssignPlatformRole(userID, roleID); err != nil {
-			log.Printf("Failed to assign platform role - userID: %d, roleID: %d, error: %v", userID, req.RoleID, err)
+			log.Printf("Failed to assign platform role - userID: %d, roleID: %s, error: %v", userID, req.RoleID, err)
 			return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("Failed to assign platform role: %v", err)})
 		}
 	} else if reqRoleType == constants.RoleTypeWorkspace {
 		if workspaceID == 0 {
-			log.Printf("Workspace ID missing - userID: %d, roleID: %d", userID, req.RoleID)
+			log.Printf("Workspace ID missing - userID: %d, roleID: %s", userID, req.RoleID)
 			return c.JSON(http.StatusBadRequest, map[string]string{"error": "Workspace ID is required"})
 		}
 		if err := h.roleService.AssignWorkspaceRole(userID, workspaceID, roleID); err != nil {
-			log.Printf("Failed to assign workspace role - userID: %d, workspaceID: %d, roleID: %d, error: %v",
+			log.Printf("Failed to assign workspace role - userID: %d, workspaceID: %d, roleID: %s, error: %v",
 				userID, workspaceID, req.RoleID, err)
 			return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("Failed to assign workspace role: %v", err)})
 		}
 	}
 
-	log.Printf("Successfully assigned role - userID: %d, roleID: %d, roleType: %s", userID, req.RoleID, reqRoleType)
+	log.Printf("Successfully assigned role - userID: %d, roleID: %s, roleType: %s", userID, req.RoleID, reqRoleType)
 	return c.JSON(http.StatusOK, map[string]string{"message": fmt.Sprintf("%s role assigned successfully", reqRoleType)})
 }
 
@@ -1891,7 +1891,7 @@ func (h *RoleHandler) AddCspRoleMappings(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("역할 할당 실패: %v", err)})
 	}
 
-	log.Printf("Master 역할-CSP 역할 매핑 생성 성공 - ID: %d")
+	log.Printf("Master 역할-CSP 역할 매핑 생성 성공 - ID: %d", roleIDInt)
 	return c.JSON(http.StatusCreated, map[string]string{"message": "Master 역할-CSP 역할 매핑 생성 성공"})
 }
 

--- a/src/model/request.go
+++ b/src/model/request.go
@@ -69,8 +69,8 @@ type CreateRoleRequest struct {
 // RoleRequest 역할 조회 요청 구조체
 type RoleFilterRequest struct {
 	RoleID    string                  `json:"roleId,omitempty"`
-	RoleName  string                  `json:"roleName",omitempty"`
-	RoleTypes []constants.IAMRoleType `json:"roleTypes",omitempty"`
+	RoleName  string                  `json:"roleName,omitempty"`
+	RoleTypes []constants.IAMRoleType `json:"roleTypes,omitempty"`
 }
 
 // 워크스페이스와 프로젝트 매핑 추가 또는 해제
@@ -135,8 +135,8 @@ type CreateMenuRequests struct {
 }
 
 type MenuFilterRequest struct {
-	MenuIDs   []*string `json:"menuIds",omitempty"`
-	MenuNames []*string `json:"menuNames",omitempty"`
+	MenuIDs   []*string `json:"menuIds,omitempty"`
+	MenuNames []*string `json:"menuNames,omitempty"`
 }
 
 // CreateMenuMappingRequest 메뉴 매핑 생성을 위한 요청 구조체
@@ -146,8 +146,8 @@ type CreateMenuMappingRequest struct {
 }
 
 type MenuMappingFilterRequest struct {
-	RoleIDs []string `json:"roleId",omitempty"`
-	MenuID  string   `json:"menuIds",omitempty"`
+	RoleIDs []string `json:"roleId,omitempty"`
+	MenuID  string   `json:"menuIds,omitempty"`
 }
 
 // AssignWorkspaceRoleRequest 워크스페이스 역할 할당 요청 구조체

--- a/src/repository/organization_repository_integration_test.go
+++ b/src/repository/organization_repository_integration_test.go
@@ -1,0 +1,319 @@
+package repository
+
+// organization_repository_integration_test.go
+//
+// OrganizationRepository 중 PostgreSQL 전용 SQL(CTE, ::text 캐스팅,
+// SUBSTRING ... FROM, ILIKE)을 사용하는 메서드들에 대한 실제 PostgreSQL
+// 통합 테스트입니다. 아래 메서드들은 SQLite에서 실행할 수 없어 그동안
+// 테스트 커버리지가 전혀 없었습니다:
+//   - FindTreeFlat
+//   - FindSubtreeFlat
+//   - GetSubtreeDepth
+//   - GetAncestorDepth
+//   - UpdateDescendantCodes
+//   - FindByFilter (ILIKE)
+//
+// 실행 방법 (service 패키지의 csp_credential_integration_test.go 와 동일한 패턴):
+//   INTEGRATION_TEST=1 \
+//   MC_IAM_MANAGER_DATABASE_HOST=... MC_IAM_MANAGER_DATABASE_PORT=... \
+//   MC_IAM_MANAGER_DATABASE_USER=... MC_IAM_MANAGER_DATABASE_PASSWORD=... \
+//   MC_IAM_MANAGER_DATABASE_NAME=... MC_IAM_MANAGER_DATABASE_SSLMODE=... \
+//   go test github.com/m-cmp/mc-iam-manager/repository -run "TestOrgRepoPG" -v -count=1
+//
+// DB 접속 정보는 config.NewDatabaseConfig() (프로덕션과 동일한 코드 경로)로 읽으며,
+// DB에 연결할 수 없으면 skip 됩니다 (SQLite로 폴백하지 않습니다).
+//
+// 각 테스트는 트랜잭션을 시작하고 종료 시 롤백하여, 실제(영속) PostgreSQL DB를
+// 사용하면서도 테스트 간 독립성과 재실행 가능성을 보장합니다.
+
+import (
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/m-cmp/mc-iam-manager/config"
+	"github.com/m-cmp/mc-iam-manager/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+var orgRepoPGMigrateOnce sync.Once
+
+// skipIfNotIntegrationOrgRepo 통합 테스트 환경이 아니면 skip
+// (service 패키지의 skipIfNotIntegration 과 동일한 게이팅 규칙)
+func skipIfNotIntegrationOrgRepo(t *testing.T) {
+	t.Helper()
+	if os.Getenv("INTEGRATION_TEST") != "1" {
+		t.Skip("INTEGRATION_TEST=1 이 설정되지 않아 통합 테스트를 건너뜁니다")
+	}
+}
+
+// setupOrgRepoPGTestDB 실제 PostgreSQL에 연결하고, 테스트에 필요한 테이블을
+// (최초 1회) AutoMigrate 한 뒤, 트랜잭션을 열어 반환합니다.
+// 트랜잭션은 테스트 종료 시 자동 롤백되어 DB 상태를 원복합니다.
+func setupOrgRepoPGTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	skipIfNotIntegrationOrgRepo(t)
+
+	dbConfig := config.NewDatabaseConfig()
+	db, err := gorm.Open(postgres.Open(dbConfig.GetDSN()), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Skipf("DB 연결 실패 — DB 미연결로 테스트를 건너뜁니다: %v", err)
+	}
+
+	orgRepoPGMigrateOnce.Do(func() {
+		require.NoError(t, db.AutoMigrate(
+			&model.Organization{},
+			&model.User{},
+			&model.UserOrganization{},
+		))
+	})
+
+	tx := db.Begin()
+	require.NoError(t, tx.Error)
+	t.Cleanup(func() {
+		tx.Rollback()
+	})
+	return tx
+}
+
+func newOrgRepoPGTest(t *testing.T) (*OrganizationRepository, *gorm.DB) {
+	t.Helper()
+	db := setupOrgRepoPGTestDB(t)
+	return NewOrganizationRepository(db), db
+}
+
+func createTestOrg(t *testing.T, db *gorm.DB, code, name string, parentID *uint) *model.Organization {
+	t.Helper()
+	org := &model.Organization{
+		OrganizationCode: code,
+		Name:             name,
+		ParentID:         parentID,
+	}
+	require.NoError(t, db.Create(org).Error)
+	return org
+}
+
+// ── FindTreeFlat ──────────────────────────────────────────────────────────────
+
+// TC-FTF-01: 조직이 하나도 없으면 빈 슬라이스 반환
+func TestOrgRepoPG_FindTreeFlat_Empty(t *testing.T) {
+	repo, _ := newOrgRepoPGTest(t)
+
+	trees, err := repo.FindTreeFlat()
+
+	require.NoError(t, err)
+	assert.Empty(t, trees)
+}
+
+// TC-FTF-02: 3단계 계층 구조 → level/path 정확히 계산
+func TestOrgRepoPG_FindTreeFlat_MultiLevel(t *testing.T) {
+	repo, db := newOrgRepoPGTest(t)
+
+	root := createTestOrg(t, db, "01", "Root", nil)
+	child := createTestOrg(t, db, "0101", "Child", &root.ID)
+	grandchild := createTestOrg(t, db, "010101", "GrandChild", &child.ID)
+
+	trees, err := repo.FindTreeFlat()
+	require.NoError(t, err)
+	require.Len(t, trees, 3)
+
+	byID := make(map[uint]model.OrganizationTree, len(trees))
+	for _, node := range trees {
+		byID[node.ID] = node
+	}
+
+	require.Contains(t, byID, root.ID)
+	require.Contains(t, byID, child.ID)
+	require.Contains(t, byID, grandchild.ID)
+
+	assert.Equal(t, 1, byID[root.ID].Level)
+	assert.Equal(t, "/Root", byID[root.ID].Path)
+
+	assert.Equal(t, 2, byID[child.ID].Level)
+	assert.Equal(t, "/Root/Child", byID[child.ID].Path)
+
+	assert.Equal(t, 3, byID[grandchild.ID].Level)
+	assert.Equal(t, "/Root/Child/GrandChild", byID[grandchild.ID].Path)
+}
+
+// ── FindSubtreeFlat ───────────────────────────────────────────────────────────
+
+// TC-FSF-01: 단일(리프) 조직 → 자신만 포함
+func TestOrgRepoPG_FindSubtreeFlat_SingleLevel(t *testing.T) {
+	repo, db := newOrgRepoPGTest(t)
+
+	org := createTestOrg(t, db, "01", "Leaf", nil)
+
+	trees, err := repo.FindSubtreeFlat(org.ID)
+	require.NoError(t, err)
+	require.Len(t, trees, 1)
+	assert.Equal(t, org.ID, trees[0].ID)
+	assert.Equal(t, 1, trees[0].Level)
+}
+
+// TC-FSF-02: 다단계 계층에서 중간 노드를 루트로 조회 → 자신 + 하위만 포함 (형제/상위 제외)
+func TestOrgRepoPG_FindSubtreeFlat_MultiLevel(t *testing.T) {
+	repo, db := newOrgRepoPGTest(t)
+
+	root := createTestOrg(t, db, "01", "Root", nil)
+	child := createTestOrg(t, db, "0101", "Child", &root.ID)
+	grandchild := createTestOrg(t, db, "010101", "GrandChild", &child.ID)
+	// 형제 조직 (subtree에 포함되면 안 됨)
+	createTestOrg(t, db, "0102", "Sibling", &root.ID)
+
+	trees, err := repo.FindSubtreeFlat(child.ID)
+	require.NoError(t, err)
+	require.Len(t, trees, 2)
+
+	ids := []uint{trees[0].ID, trees[1].ID}
+	assert.Contains(t, ids, child.ID)
+	assert.Contains(t, ids, grandchild.ID)
+	assert.NotContains(t, ids, root.ID)
+}
+
+// ── GetSubtreeDepth ───────────────────────────────────────────────────────────
+
+// TC-GSD-01: 리프 조직(하위 없음) → depth 1
+func TestOrgRepoPG_GetSubtreeDepth_Leaf(t *testing.T) {
+	repo, db := newOrgRepoPGTest(t)
+
+	org := createTestOrg(t, db, "01", "Leaf", nil)
+
+	depth, err := repo.GetSubtreeDepth(org.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, depth)
+}
+
+// TC-GSD-02: 3단계 하위 트리 → depth 3
+func TestOrgRepoPG_GetSubtreeDepth_MultiLevel(t *testing.T) {
+	repo, db := newOrgRepoPGTest(t)
+
+	root := createTestOrg(t, db, "01", "Root", nil)
+	child := createTestOrg(t, db, "0101", "Child", &root.ID)
+	createTestOrg(t, db, "010101", "GrandChild", &child.ID)
+
+	depth, err := repo.GetSubtreeDepth(root.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 3, depth)
+}
+
+// ── GetAncestorDepth ──────────────────────────────────────────────────────────
+
+// TC-GAD-01: 최상위 조직 → depth 1
+func TestOrgRepoPG_GetAncestorDepth_Root(t *testing.T) {
+	repo, db := newOrgRepoPGTest(t)
+
+	org := createTestOrg(t, db, "01", "Root", nil)
+
+	depth, err := repo.GetAncestorDepth(org.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, depth)
+}
+
+// TC-GAD-02: 3단계 깊이의 자손 조직 → depth 3
+func TestOrgRepoPG_GetAncestorDepth_MultiLevel(t *testing.T) {
+	repo, db := newOrgRepoPGTest(t)
+
+	root := createTestOrg(t, db, "01", "Root", nil)
+	child := createTestOrg(t, db, "0101", "Child", &root.ID)
+	grandchild := createTestOrg(t, db, "010101", "GrandChild", &child.ID)
+
+	depth, err := repo.GetAncestorDepth(grandchild.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 3, depth)
+}
+
+// ── UpdateDescendantCodes ─────────────────────────────────────────────────────
+
+// TC-UDC-01: prefix 변경 시 하위 조직들의 코드만 변경, 자신의 코드는 변경되지 않음
+func TestOrgRepoPG_UpdateDescendantCodes_PrefixRename(t *testing.T) {
+	repo, db := newOrgRepoPGTest(t)
+
+	root := createTestOrg(t, db, "01", "Root", nil)
+	child := createTestOrg(t, db, "0101", "Child", &root.ID)
+	grandchild := createTestOrg(t, db, "010102", "GrandChild", &child.ID)
+
+	err := repo.UpdateDescendantCodes("01", "09")
+	require.NoError(t, err)
+
+	var reloadedRoot, reloadedChild, reloadedGrandchild model.Organization
+	require.NoError(t, db.First(&reloadedRoot, root.ID).Error)
+	require.NoError(t, db.First(&reloadedChild, child.ID).Error)
+	require.NoError(t, db.First(&reloadedGrandchild, grandchild.ID).Error)
+
+	// UpdateDescendantCodes는 자신(oldPrefix와 완전히 일치하는 코드)은 건드리지 않음
+	assert.Equal(t, "01", reloadedRoot.OrganizationCode)
+	assert.Equal(t, "0901", reloadedChild.OrganizationCode)
+	assert.Equal(t, "090102", reloadedGrandchild.OrganizationCode)
+}
+
+// TC-UDC-02: 대상 prefix를 가진 하위 조직이 없으면 아무 것도 변경되지 않고 오류도 없음
+func TestOrgRepoPG_UpdateDescendantCodes_NoMatch(t *testing.T) {
+	repo, db := newOrgRepoPGTest(t)
+
+	org := createTestOrg(t, db, "01", "Solo", nil)
+
+	err := repo.UpdateDescendantCodes("99", "88")
+	require.NoError(t, err)
+
+	var reloaded model.Organization
+	require.NoError(t, db.First(&reloaded, org.ID).Error)
+	assert.Equal(t, "01", reloaded.OrganizationCode)
+}
+
+// ── FindByFilter ──────────────────────────────────────────────────────────────
+
+// TC-FBF-01: name 대소문자 무관 부분일치 검색 (ILIKE)
+func TestOrgRepoPG_FindByFilter_NameCaseInsensitivePartial(t *testing.T) {
+	repo, db := newOrgRepoPGTest(t)
+
+	createTestOrg(t, db, "01", "Engineering", nil)
+	createTestOrg(t, db, "02", "Marketing", nil)
+
+	results, err := repo.FindByFilter("engine", "")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "Engineering", results[0].Name)
+}
+
+// TC-FBF-02: code 부분일치 검색
+func TestOrgRepoPG_FindByFilter_CodePartial(t *testing.T) {
+	repo, db := newOrgRepoPGTest(t)
+
+	createTestOrg(t, db, "0101", "Backend", nil)
+	createTestOrg(t, db, "0202", "Frontend", nil)
+
+	results, err := repo.FindByFilter("", "01")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "Backend", results[0].Name)
+}
+
+// TC-FBF-03: 조건에 맞는 조직이 없으면 빈 슬라이스 반환
+func TestOrgRepoPG_FindByFilter_NoMatch(t *testing.T) {
+	repo, db := newOrgRepoPGTest(t)
+
+	createTestOrg(t, db, "01", "Sales", nil)
+
+	results, err := repo.FindByFilter("nonexistent", "")
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+// TC-FBF-04: name/code 모두 빈 값이면 전체 목록 반환
+func TestOrgRepoPG_FindByFilter_EmptyFilterReturnsAll(t *testing.T) {
+	repo, db := newOrgRepoPGTest(t)
+
+	createTestOrg(t, db, "01", "Alpha", nil)
+	createTestOrg(t, db, "02", "Beta", nil)
+
+	results, err := repo.FindByFilter("", "")
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+}

--- a/src/service/organization_service_integration_test.go
+++ b/src/service/organization_service_integration_test.go
@@ -1,0 +1,140 @@
+package service
+
+// organization_service_integration_test.go
+//
+// 조직 계층 구조(Organization Hierarchy) OrganizationService 메서드 중
+// PostgreSQL 전용 SQL(CTE, ::text 캐스팅 등)을 사용하는 FindUserOrganizations
+// 경로를 실제 PostgreSQL 에 대해 검증하는 통합 테스트.
+//
+// organization_service_test.go 의 SQLite 기반 단위 테스트에서는 실행할 수 없어
+// 이 파일로 이동되었습니다 (GetUserOrganizations, ReplaceUserGroups 의 정상 경로).
+//
+// 실행 방법 (csp_credential_integration_test.go 와 동일한 패턴/게이팅):
+//   INTEGRATION_TEST=1 \
+//   MC_IAM_MANAGER_DATABASE_HOST=... MC_IAM_MANAGER_DATABASE_PORT=... \
+//   MC_IAM_MANAGER_DATABASE_USER=... MC_IAM_MANAGER_DATABASE_PASSWORD=... \
+//   MC_IAM_MANAGER_DATABASE_NAME=... MC_IAM_MANAGER_DATABASE_SSLMODE=... \
+//   go test github.com/m-cmp/mc-iam-manager/service -run "TestOrgServicePG" -v -count=1
+//
+// DB 접속 정보는 config.NewDatabaseConfig() (프로덕션과 동일한 코드 경로)로 읽습니다.
+// DB에 연결할 수 없으면 skip 됩니다 (SQLite로 폴백하지 않습니다).
+//
+// 각 테스트는 트랜잭션을 시작하고 종료 시 롤백하여, 실제(영속) PostgreSQL DB를
+// 사용하면서도 테스트 간 독립성과 재실행 가능성을 보장합니다.
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/m-cmp/mc-iam-manager/config"
+	"github.com/m-cmp/mc-iam-manager/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+var orgServicePGMigrateOnce sync.Once
+
+// setupOrgServicePGTestDB 실제 PostgreSQL에 연결하고, 테스트에 필요한 테이블을
+// (최초 1회) AutoMigrate 한 뒤, 트랜잭션을 열어 반환합니다.
+// 트랜잭션은 테스트 종료 시 자동 롤백되어 DB 상태를 원복합니다.
+func setupOrgServicePGTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	skipIfNotIntegration(t)
+
+	dbConfig := config.NewDatabaseConfig()
+	db, err := gorm.Open(postgres.Open(dbConfig.GetDSN()), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Skipf("DB 연결 실패 — DB 미연결로 테스트를 건너뜁니다: %v", err)
+	}
+
+	orgServicePGMigrateOnce.Do(func() {
+		require.NoError(t, db.AutoMigrate(
+			&model.Organization{},
+			&model.User{},
+			&model.UserOrganization{},
+		))
+	})
+
+	tx := db.Begin()
+	require.NoError(t, tx.Error)
+	t.Cleanup(func() {
+		tx.Rollback()
+	})
+	return tx
+}
+
+func newOrgServicePGTest(t *testing.T) (*OrganizationService, *gorm.DB) {
+	t.Helper()
+	db := setupOrgServicePGTestDB(t)
+	svc := NewOrganizationService(db)
+	return svc, db
+}
+
+// ── GetUserOrganizations 테스트 (PostgreSQL) ─────────────────────────────────
+
+// TC-GU-01: 소속 조직 없는 사용자 → 빈 슬라이스
+func TestOrgServicePG_GetUserOrganizations_Empty(t *testing.T) {
+	svc, _ := newOrgServicePGTest(t)
+
+	orgs, err := svc.GetUserOrganizations(99999)
+
+	require.NoError(t, err)
+	assert.Empty(t, orgs)
+}
+
+// TC-GU-02: 소속 조직 목록 정상 반환
+func TestOrgServicePG_GetUserOrganizations_WithOrgs(t *testing.T) {
+	svc, db := newOrgServicePGTest(t)
+	org1 := createOrg(t, db, "01", "Alpha", nil)
+	org2 := createOrg(t, db, "02", "Beta", nil)
+	user := createOrgUser(t, db, "frank", "kc-frank-01")
+
+	require.NoError(t, db.Create(&model.UserOrganization{UserID: user.ID, OrganizationID: org1.ID}).Error)
+	require.NoError(t, db.Create(&model.UserOrganization{UserID: user.ID, OrganizationID: org2.ID}).Error)
+
+	orgs, err := svc.GetUserOrganizations(user.ID)
+
+	require.NoError(t, err)
+	assert.Len(t, orgs, 2)
+}
+
+// ── ReplaceUserGroups 테스트 (PostgreSQL) ────────────────────────────────────
+
+// TC-RG-02: 기존 그룹 전부 제거 후 신규 할당 (빈 배열)
+func TestOrgServicePG_ReplaceUserGroups_RemoveAll(t *testing.T) {
+	svc, db := newOrgServicePGTest(t)
+	org := createOrg(t, db, "01", "Old", nil)
+	user := createOrgUser(t, db, "grace", "kc-grace-01")
+	require.NoError(t, db.Create(&model.UserOrganization{UserID: user.ID, OrganizationID: org.ID}).Error)
+
+	err := svc.ReplaceUserGroups(user.ID, []uint{})
+
+	require.NoError(t, err)
+
+	var count int64
+	db.Model(&model.UserOrganization{}).Where("user_id = ?", user.ID).Count(&count)
+	assert.Equal(t, int64(0), count)
+}
+
+// TC-RG-03: 기존 그룹 교체 성공
+func TestOrgServicePG_ReplaceUserGroups_Replace(t *testing.T) {
+	svc, db := newOrgServicePGTest(t)
+	org1 := createOrg(t, db, "01", "OldGroup", nil)
+	org2 := createOrg(t, db, "02", "NewGroup", nil)
+	user := createOrgUser(t, db, "henry", "kc-henry-01")
+	require.NoError(t, db.Create(&model.UserOrganization{UserID: user.ID, OrganizationID: org1.ID}).Error)
+
+	err := svc.ReplaceUserGroups(user.ID, []uint{org2.ID})
+
+	require.NoError(t, err)
+
+	orgs, err := svc.GetUserOrganizations(user.ID)
+	require.NoError(t, err)
+	require.Len(t, orgs, 1)
+	assert.Equal(t, "NewGroup", orgs[0].Name)
+}

--- a/src/service/organization_service_test.go
+++ b/src/service/organization_service_test.go
@@ -13,18 +13,21 @@ package service
 //   - DeleteOrganizationCascade:      존재하지 않는 ID → not found
 //   - AssignUserToOrganizations:      조직 미존재 → 오류, 정상 할당
 //   - RemoveUserFromOrganization:     매핑 없음 → ErrUserOrganizationNotFound
-//   - GetUserOrganizations:           정상 조회 (빈 목록)
 //   - ReplaceUserGroups:              그룹 미존재 → 오류
 //   - GetOrganizationSubtree:         존재하지 않는 조직 → not found
 //   - MoveOrganization:               존재하지 않는 조직, 자기 자신으로 이동 → 순환 참조
 //   - UpdateOrganization:             존재하지 않는 조직 → not found
 //
-// NOTE: FindTreeFlat, FindSubtreeFlat, GetSubtreeDepth, GetAncestorDepth,
-//       UpdateDescendantCodes 는 PostgreSQL CTE / SUBSTRING FROM 구문을 사용하므로
-//       SQLite in-memory DB 에서는 실행할 수 없습니다.
-//       해당 경로를 거치는 MoveOrganization 의 정상 경로와
-//       GetOrganizationTree / GetOrganizationSubtree 의 정상 경로는
-//       통합 테스트(PostgreSQL)로 별도 검증합니다.
+// NOTE: FindUserOrganizations(GetUserOrganizations/ReplaceUserGroups 정상 경로),
+//       FindTreeFlat, FindSubtreeFlat, GetSubtreeDepth, GetAncestorDepth,
+//       UpdateDescendantCodes 는 PostgreSQL CTE / `::text` 캐스팅 / SUBSTRING FROM
+//       구문을 사용하므로 SQLite in-memory DB 에서는 실행할 수 없습니다.
+//       해당 경로를 거치는 GetUserOrganizations, ReplaceUserGroups 정상 경로,
+//       MoveOrganization 정상 경로, GetOrganizationTree / GetOrganizationSubtree
+//       정상 경로, 그리고 OrganizationRepository 의 위 메서드들은
+//       organization_service_integration_test.go / organization_repository_integration_test.go
+//       에서 실제 PostgreSQL 을 사용한 통합 테스트로 검증합니다.
+//       (INTEGRATION_TEST=1 로 게이팅, DB 미연결 시 skip)
 
 import (
 	"errors"
@@ -477,32 +480,10 @@ func TestRemoveUserFromOrganization_Success(t *testing.T) {
 }
 
 // ── GetUserOrganizations 테스트 ───────────────────────────────────────────────
-
-// TC-GU-01: 소속 조직 없는 사용자 → 빈 슬라이스
-func TestGetUserOrganizations_Empty(t *testing.T) {
-	svc, _ := newTestOrgService(t)
-
-	orgs, err := svc.GetUserOrganizations(99999)
-
-	require.NoError(t, err)
-	assert.Empty(t, orgs)
-}
-
-// TC-GU-02: 소속 조직 목록 정상 반환
-func TestGetUserOrganizations_WithOrgs(t *testing.T) {
-	svc, db := newTestOrgService(t)
-	org1 := createOrg(t, db, "01", "Alpha", nil)
-	org2 := createOrg(t, db, "02", "Beta", nil)
-	user := createOrgUser(t, db, "frank", "kc-frank-01")
-
-	require.NoError(t, db.Create(&model.UserOrganization{UserID: user.ID, OrganizationID: org1.ID}).Error)
-	require.NoError(t, db.Create(&model.UserOrganization{UserID: user.ID, OrganizationID: org2.ID}).Error)
-
-	orgs, err := svc.GetUserOrganizations(user.ID)
-
-	require.NoError(t, err)
-	assert.Len(t, orgs, 2)
-}
+//
+// NOTE: TestGetUserOrganizations_Empty / TestGetUserOrganizations_WithOrgs 는
+//       FindUserOrganizations(PostgreSQL CTE + ::text 캐스팅)를 거치므로
+//       organization_service_integration_test.go 로 이동했습니다.
 
 // ── ReplaceUserGroups 테스트 ──────────────────────────────────────────────────
 
@@ -516,39 +497,9 @@ func TestReplaceUserGroups_GroupNotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "group not found")
 }
 
-// TC-RG-02: 기존 그룹 전부 제거 후 신규 할당 (빈 배열)
-func TestReplaceUserGroups_RemoveAll(t *testing.T) {
-	svc, db := newTestOrgService(t)
-	org := createOrg(t, db, "01", "Old", nil)
-	user := createOrgUser(t, db, "grace", "kc-grace-01")
-	require.NoError(t, db.Create(&model.UserOrganization{UserID: user.ID, OrganizationID: org.ID}).Error)
-
-	err := svc.ReplaceUserGroups(user.ID, []uint{})
-
-	require.NoError(t, err)
-
-	var count int64
-	db.Model(&model.UserOrganization{}).Where("user_id = ?", user.ID).Count(&count)
-	assert.Equal(t, int64(0), count)
-}
-
-// TC-RG-03: 기존 그룹 교체 성공
-func TestReplaceUserGroups_Replace(t *testing.T) {
-	svc, db := newTestOrgService(t)
-	org1 := createOrg(t, db, "01", "OldGroup", nil)
-	org2 := createOrg(t, db, "02", "NewGroup", nil)
-	user := createOrgUser(t, db, "henry", "kc-henry-01")
-	require.NoError(t, db.Create(&model.UserOrganization{UserID: user.ID, OrganizationID: org1.ID}).Error)
-
-	err := svc.ReplaceUserGroups(user.ID, []uint{org2.ID})
-
-	require.NoError(t, err)
-
-	orgs, err := svc.GetUserOrganizations(user.ID)
-	require.NoError(t, err)
-	require.Len(t, orgs, 1)
-	assert.Equal(t, "NewGroup", orgs[0].Name)
-}
+// NOTE: TestReplaceUserGroups_RemoveAll / TestReplaceUserGroups_Replace 는
+//       내부적으로 FindUserOrganizations(PostgreSQL CTE + ::text 캐스팅)를 거치므로
+//       organization_service_integration_test.go 로 이동했습니다.
 
 // ── GetOrganizationSubtree 테스트 ─────────────────────────────────────────────
 


### PR DESCRIPTION
## 변경 요약
- go vet 경고(malformed struct tag, printf 포맷 불일치) 정리
- 조직 계층 조회 테스트를 SQLite 인메모리 → 실제 Postgres 통합테스트로 전환. Postgres 전용 SQL(`::text`, `SUBSTRING FROM`, `ILIKE`)을 쓰는 프로덕션 쿼리는 그대로 두고, 테스트 쪽을 실제 DB에 맞춤 (`INTEGRATION_TEST=1` 게이트, 기존 `csp_credential_integration_test.go` 패턴 재사용)
- 그동안 커버리지 없던 `FindTreeFlat`/`FindSubtreeFlat`/`GetSubtreeDepth`/`GetAncestorDepth`/`UpdateDescendantCodes`/`FindByFilter` 6개 메서드에 Postgres 통합테스트 신규 추가

