### PR TITLE
fix : GCP 임시자격 증명 발급 로직 보완

### DIFF
--- a/src/service/csp_credential_service.go
+++ b/src/service/csp_credential_service.go
@@ -244,7 +244,9 @@ func (s *CspCredentialService) GetTemporaryCredentials(ctx context.Context, user
 				return nil, fmt.Errorf("failed to get impersonation token: %w", err)
 			}
 			log.Printf("[CSP_CREDENTIAL] Calling GCP WIF ExchangeTokenAndImpersonate (OIDC)...")
-			return s.gcpCredService.ExchangeTokenAndImpersonate(ctx, idpArn, roleArn, impersonationToken.AccessToken, "jwt")
+			// GCP WIF STS는 단일 문자열 aud를 요구하므로 Access Token(aud가 "account")이 아니라
+			// ID Token(aud=OIDC 클라이언트 ID)을 사용해야 한다 — Alibaba OIDC(OI-1)와 동일한 이유.
+			return s.gcpCredService.ExchangeTokenAndImpersonate(ctx, idpArn, roleArn, impersonationToken.IDToken, "jwt")
 		case model.AuthMethodSAML:
 			samlClientAudience := idpArn
 			if extConfig, ok := targetCspRole.ExtendedConfig["saml_client_id"].(string); ok && extConfig != "" {


### PR DESCRIPTION
## Summary

- GCP Workload Identity Federation STS 토큰 교환은 단일 문자열 `aud`를 요구하는데, `GetTemporaryCredentials`의 GCP OIDC 분기가 `GetImpersonationTokenByServiceAccount()`의 Access Token(`aud="account"`, 배열 형태)을 계속 전달하고 있었음
- GCP 계정(WIF Pool/Provider가 issuer=`mciam-oidc-Client` audience로 구성된 환경) 대상으로 검증 중 `invalid_grant: The audience in ID Token [account] does not match the expected audience`로 발견

## Fix
`impersonationToken.AccessToken` → `impersonationToken.IDToken`
