### PR TITLE
fix: 임시자격증명 발급에 필요한 CSP 계정 identifier 검증로직 추가 (Alibaba, 1/N)

### DIFF
--- a/src/model/csp_account.go
+++ b/src/model/csp_account.go
@@ -86,6 +86,13 @@ func (c *CspAccount) GetRegion() string {
 	return c.AccountInfo["region"]
 }
 
+// GetAlibabaAccountID Alibaba Cloud Account ID 반환
+// Alibaba는 AWS와 동일하게 "account_id" 키를 사용하므로 GetAccountID()와 동일 동작이지만,
+// CSP별 getter 네이밍 컨벤션(Get<Csp>ID)을 맞추기 위해 별도로 노출한다.
+func (c *CspAccount) GetAlibabaAccountID() string {
+	return c.GetAccountID()
+}
+
 // CspAccountFilter CSP 계정 조회 필터
 type CspAccountFilter struct {
 	CspType  string `json:"csp_type,omitempty"`

--- a/src/service/csp_account_service.go
+++ b/src/service/csp_account_service.go
@@ -181,12 +181,24 @@ func (s *CspAccountService) ValidateCspAccount(ctx context.Context, id uint) (*m
 		return nil, fmt.Errorf("CSP account not found with ID: %d", id)
 	}
 
+	// CSP 타입별 AccountInfo 필수 필드 검증 (역할 조회보다 먼저 수행)
+	if err := validateAccountInfo(account); err != nil {
+		return nil, err
+	}
+
 	roles, err := s.cspRoleRepo.GetByCspAccountID(id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get CSP roles: %w", err)
 	}
 	if len(roles) == 0 {
-		return nil, fmt.Errorf("no CSP roles found for account ID: %d", id)
+		// AccountInfo 검증은 통과했으나 연결된 CspRole이 없는 경우 —
+		// 더 이상 하드 에러가 아니라, 검증할 역할이 없다는 의미로 빈 결과를 반환한다.
+		return &model.CspAccountValidationResponse{
+			AccountID:   account.ID,
+			AccountName: account.Name,
+			CspType:     account.CspType,
+			Results:     []model.CspAccountValidationResult{},
+		}, nil
 	}
 
 	resp := &model.CspAccountValidationResponse{
@@ -203,6 +215,27 @@ func (s *CspAccountService) ValidateCspAccount(ctx context.Context, id uint) (*m
 
 	log.Printf("Validated CSP account: %s (ID: %d), roles: %d", account.Name, account.ID, len(roles))
 	return resp, nil
+}
+
+// validateAccountInfo CSP 타입별 CspAccount.AccountInfo 필수 필드 검증
+//
+// 새로운 CSP 타입을 지원하려면 이 switch 문에 case를 추가하기만 하면 된다
+// (구조 변경 불필요). 아직 필드 검증이 구현되지 않은 CSP 타입은 no-op(nil)으로
+// 통과시키며, 목록에 없는 타입은 unsupported 에러를 반환한다.
+func validateAccountInfo(account *model.CspAccount) error {
+	switch account.CspType {
+	case "alibaba":
+		if account.GetAlibabaAccountID() == "" {
+			return fmt.Errorf("Alibaba account_id is required")
+		}
+		return nil
+	case "aws", "gcp", "azure", "tencent", "ibm", "ncp", "nhn", "kt", "openstack":
+		// TODO: 각 CSP 타입별 필수 필드 검증은 이후 PR에서 순차적으로 추가 예정.
+		// 지금은 no-op으로 통과시킨다 (이번 PR 범위는 Alibaba만).
+		return nil
+	default:
+		return fmt.Errorf("unsupported CSP type: %s", account.CspType)
+	}
 }
 
 // validateCspRole CspRole 단위로 CSP 인프라 검증

--- a/src/service/csp_account_service_test.go
+++ b/src/service/csp_account_service_test.go
@@ -69,8 +69,11 @@ func TestCspAccountValidate_AWS_MissingAccountID(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = svc.ValidateCspAccount(context.Background(), created.ID)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "AWS account_id is required")
+	// NOTE: AWS 필드 검증은 아직 미구현(no-op)이라 이 assertion은 현재 실패한다 (별도 PR에서 구현 예정).
+	// err가 nil일 수 있으므로 err.Error() 호출로 인한 패닉을 막기 위해 assert.Error 결과로 가드한다.
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "AWS account_id is required")
+	}
 }
 
 // TestValidateCspAccount_GCP_Valid: GCP 계정에 project_id가 있으면 검증 통과
@@ -102,8 +105,10 @@ func TestCspAccountValidate_GCP_MissingProjectID(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = svc.ValidateCspAccount(context.Background(), created.ID)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "GCP project_id is required")
+	// NOTE: GCP 필드 검증은 아직 미구현(no-op)이라 이 assertion은 현재 실패한다 (별도 PR에서 구현 예정).
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "GCP project_id is required")
+	}
 }
 
 // TestValidateCspAccount_Azure_Valid: Azure 계정에 subscription_id와 tenant_id가 있으면 통과
@@ -138,8 +143,10 @@ func TestCspAccountValidate_Azure_MissingSubscriptionID(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = svc.ValidateCspAccount(context.Background(), created.ID)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "Azure subscription_id is required")
+	// NOTE: Azure 필드 검증은 아직 미구현(no-op)이라 이 assertion은 현재 실패한다 (별도 PR에서 구현 예정).
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Azure subscription_id is required")
+	}
 }
 
 // TestValidateCspAccount_Azure_MissingTenantID: Azure 계정에 tenant_id가 없으면 에러
@@ -156,8 +163,44 @@ func TestCspAccountValidate_Azure_MissingTenantID(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = svc.ValidateCspAccount(context.Background(), created.ID)
+	// NOTE: Azure 필드 검증은 아직 미구현(no-op)이라 이 assertion은 현재 실패한다 (별도 PR에서 구현 예정).
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Azure tenant_id is required")
+	}
+}
+
+// TestCspAccountValidate_Alibaba_Valid: Alibaba 계정에 account_id가 있으면 검증 통과
+// (연결된 CspRole이 없어도 AccountInfo 검증만 통과하면 빈 결과로 성공한다)
+func TestCspAccountValidate_Alibaba_Valid(t *testing.T) {
+	svc, _ := newTestService(t)
+
+	created, err := svc.CreateCspAccount(&model.CreateCspAccountRequest{
+		Name:    "test-alibaba",
+		CspType: "alibaba",
+		AccountInfo: map[string]string{
+			"account_id": "1234567890123456",
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = svc.ValidateCspAccount(context.Background(), created.ID)
+	assert.NoError(t, err)
+}
+
+// TestCspAccountValidate_Alibaba_MissingAccountID: Alibaba 계정에 account_id가 없으면 에러
+func TestCspAccountValidate_Alibaba_MissingAccountID(t *testing.T) {
+	svc, _ := newTestService(t)
+
+	created, err := svc.CreateCspAccount(&model.CreateCspAccountRequest{
+		Name:        "test-alibaba-missing",
+		CspType:     "alibaba",
+		AccountInfo: map[string]string{},
+	})
+	require.NoError(t, err)
+
+	_, err = svc.ValidateCspAccount(context.Background(), created.ID)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "Azure tenant_id is required")
+	assert.Contains(t, err.Error(), "Alibaba account_id is required")
 }
 
 // TestValidateCspAccount_UnsupportedType: 지원하지 않는 CSP 타입은 에러


### PR DESCRIPTION
## 변경 요약
- `ValidateCspAccount`에 CSP 계정 필드 검증(`validateAccountInfo`) 신설 — CSP 타입별 dispatch 구조로 설계, 이번 PR은 **Alibaba `account_id`만 구현** (GCP/Tencent 등 나머지는 후속 PR에서 하나씩 추가 예정, 현재는 no-op 통과)
- 근본 순서 버그 수정: CspRole 연결 여부부터 확인해 필드가 정상이어도 무조건 "no CSP roles found" 에러가 나던 문제 — 필드 검증 통과 시 역할 미연결이면 빈 `Results`로 성공 반환하도록 변경
- 미지원 CSP 타입은 명확한 "unsupported CSP type" 에러 반환
