### PR TITLE
fix: 임시자격증명 발급에 필요한 CSP 계정 identifier 검증로직 추가 (GCP, 2/N)

### DIFF
--- a/src/service/csp_account_service.go
+++ b/src/service/csp_account_service.go
@@ -229,9 +229,14 @@ func validateAccountInfo(account *model.CspAccount) error {
 			return fmt.Errorf("Alibaba account_id is required")
 		}
 		return nil
-	case "aws", "gcp", "azure", "tencent", "ibm", "ncp", "nhn", "kt", "openstack":
+	case "gcp":
+		if account.GetProjectID() == "" {
+			return fmt.Errorf("GCP project_id is required")
+		}
+		return nil
+	case "aws", "azure", "tencent", "ibm", "ncp", "nhn", "kt", "openstack":
 		// TODO: 각 CSP 타입별 필수 필드 검증은 이후 PR에서 순차적으로 추가 예정.
-		// 지금은 no-op으로 통과시킨다 (이번 PR 범위는 Alibaba만).
+		// 지금은 no-op으로 통과시킨다 (이번 PR 범위는 Alibaba, GCP만).
 		return nil
 	default:
 		return fmt.Errorf("unsupported CSP type: %s", account.CspType)

--- a/src/service/csp_account_service_test.go
+++ b/src/service/csp_account_service_test.go
@@ -105,10 +105,8 @@ func TestCspAccountValidate_GCP_MissingProjectID(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = svc.ValidateCspAccount(context.Background(), created.ID)
-	// NOTE: GCP 필드 검증은 아직 미구현(no-op)이라 이 assertion은 현재 실패한다 (별도 PR에서 구현 예정).
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "GCP project_id is required")
-	}
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "GCP project_id is required")
 }
 
 // TestValidateCspAccount_Azure_Valid: Azure 계정에 subscription_id와 tenant_id가 있으면 통과


### PR DESCRIPTION
## 변경 요약
- CSP 계정 identifier 검증(1/N Alibaba, #131)에 이어 **GCP `project_id` 검증 추가** — 임시자격증명 발급(`GetTemporaryCredentials`) 시 실제로 쓰이는 식별자
- `TestCspAccountValidate_GCP_MissingProjectID`가 이제 정상적으로 에러를 검증
