### PR TITLE
fix: 임시자격증명 발급에 필요한 CSP 계정 identifier 검증로직 추가 (Tencent, 3/N)

### DIFF
--- a/src/model/csp_account.go
+++ b/src/model/csp_account.go
@@ -93,6 +93,14 @@ func (c *CspAccount) GetAlibabaAccountID() string {
 	return c.GetAccountID()
 }
 
+// GetTencentAppID Tencent Cloud APPID 반환
+func (c *CspAccount) GetTencentAppID() string {
+	if c.AccountInfo == nil {
+		return ""
+	}
+	return c.AccountInfo["app_id"]
+}
+
 // CspAccountFilter CSP 계정 조회 필터
 type CspAccountFilter struct {
 	CspType  string `json:"csp_type,omitempty"`

--- a/src/service/csp_account_service.go
+++ b/src/service/csp_account_service.go
@@ -234,9 +234,14 @@ func validateAccountInfo(account *model.CspAccount) error {
 			return fmt.Errorf("GCP project_id is required")
 		}
 		return nil
-	case "aws", "azure", "tencent", "ibm", "ncp", "nhn", "kt", "openstack":
+	case "tencent":
+		if account.GetTencentAppID() == "" {
+			return fmt.Errorf("Tencent app_id is required")
+		}
+		return nil
+	case "aws", "azure", "ibm", "ncp", "nhn", "kt", "openstack":
 		// TODO: 각 CSP 타입별 필수 필드 검증은 이후 PR에서 순차적으로 추가 예정.
-		// 지금은 no-op으로 통과시킨다 (이번 PR 범위는 Alibaba, GCP만).
+		// 지금은 no-op으로 통과시킨다 (이번 PR 범위는 Alibaba, GCP, Tencent만).
 		return nil
 	default:
 		return fmt.Errorf("unsupported CSP type: %s", account.CspType)

--- a/src/service/csp_account_service_test.go
+++ b/src/service/csp_account_service_test.go
@@ -201,6 +201,39 @@ func TestCspAccountValidate_Alibaba_MissingAccountID(t *testing.T) {
 	assert.Contains(t, err.Error(), "Alibaba account_id is required")
 }
 
+// TestCspAccountValidate_Tencent_Valid: Tencent 계정에 app_id가 있으면 검증 통과
+func TestCspAccountValidate_Tencent_Valid(t *testing.T) {
+	svc, _ := newTestService(t)
+
+	created, err := svc.CreateCspAccount(&model.CreateCspAccountRequest{
+		Name:    "test-tencent",
+		CspType: "tencent",
+		AccountInfo: map[string]string{
+			"app_id": "1234567890",
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = svc.ValidateCspAccount(context.Background(), created.ID)
+	assert.NoError(t, err)
+}
+
+// TestCspAccountValidate_Tencent_MissingAppID: Tencent 계정에 app_id가 없으면 에러
+func TestCspAccountValidate_Tencent_MissingAppID(t *testing.T) {
+	svc, _ := newTestService(t)
+
+	created, err := svc.CreateCspAccount(&model.CreateCspAccountRequest{
+		Name:        "test-tencent-missing",
+		CspType:     "tencent",
+		AccountInfo: map[string]string{},
+	})
+	require.NoError(t, err)
+
+	_, err = svc.ValidateCspAccount(context.Background(), created.ID)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Tencent app_id is required")
+}
+
 // TestValidateCspAccount_UnsupportedType: 지원하지 않는 CSP 타입은 에러
 func TestCspAccountValidate_UnsupportedType(t *testing.T) {
 	svc, db := newTestService(t)


### PR DESCRIPTION
## 변경 요약
- CSP 계정 identifier 검증(1/N Alibaba #131, 2/N GCP #132)에 이어 **Tencent `app_id` 검증 추가** — 임시자격증명 발급(`GetTemporaryCredentials`) 시 실제로 쓰이는 식별자(Tencent Cloud APPID)
- `GetTencentAppID()` 게터 신설
