### PR TITLE
fix: 임시자격증명 발급에 필요한 CSP 계정 identifier 검증로직 추가 (AWS/Azure, 4-5/N)

### DIFF
--- a/src/service/csp_account_service.go
+++ b/src/service/csp_account_service.go
@@ -239,9 +239,22 @@ func validateAccountInfo(account *model.CspAccount) error {
 			return fmt.Errorf("Tencent app_id is required")
 		}
 		return nil
-	case "aws", "azure", "ibm", "ncp", "nhn", "kt", "openstack":
+	case "aws":
+		if account.GetAccountID() == "" {
+			return fmt.Errorf("AWS account_id is required")
+		}
+		return nil
+	case "azure":
+		if account.GetSubscriptionID() == "" {
+			return fmt.Errorf("Azure subscription_id is required")
+		}
+		if account.GetTenantID() == "" {
+			return fmt.Errorf("Azure tenant_id is required")
+		}
+		return nil
+	case "ibm", "ncp", "nhn", "kt", "openstack":
 		// TODO: 각 CSP 타입별 필수 필드 검증은 이후 PR에서 순차적으로 추가 예정.
-		// 지금은 no-op으로 통과시킨다 (이번 PR 범위는 Alibaba, GCP, Tencent만).
+		// 지금은 no-op으로 통과시킨다 (이번 PR 범위는 Alibaba, GCP, Tencent, AWS, Azure만).
 		return nil
 	default:
 		return fmt.Errorf("unsupported CSP type: %s", account.CspType)

--- a/src/service/csp_account_service_test.go
+++ b/src/service/csp_account_service_test.go
@@ -69,11 +69,8 @@ func TestCspAccountValidate_AWS_MissingAccountID(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = svc.ValidateCspAccount(context.Background(), created.ID)
-	// NOTE: AWS 필드 검증은 아직 미구현(no-op)이라 이 assertion은 현재 실패한다 (별도 PR에서 구현 예정).
-	// err가 nil일 수 있으므로 err.Error() 호출로 인한 패닉을 막기 위해 assert.Error 결과로 가드한다.
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "AWS account_id is required")
-	}
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "AWS account_id is required")
 }
 
 // TestValidateCspAccount_GCP_Valid: GCP 계정에 project_id가 있으면 검증 통과
@@ -141,10 +138,8 @@ func TestCspAccountValidate_Azure_MissingSubscriptionID(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = svc.ValidateCspAccount(context.Background(), created.ID)
-	// NOTE: Azure 필드 검증은 아직 미구현(no-op)이라 이 assertion은 현재 실패한다 (별도 PR에서 구현 예정).
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "Azure subscription_id is required")
-	}
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Azure subscription_id is required")
 }
 
 // TestValidateCspAccount_Azure_MissingTenantID: Azure 계정에 tenant_id가 없으면 에러
@@ -161,10 +156,8 @@ func TestCspAccountValidate_Azure_MissingTenantID(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = svc.ValidateCspAccount(context.Background(), created.ID)
-	// NOTE: Azure 필드 검증은 아직 미구현(no-op)이라 이 assertion은 현재 실패한다 (별도 PR에서 구현 예정).
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "Azure tenant_id is required")
-	}
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Azure tenant_id is required")
 }
 
 // TestCspAccountValidate_Alibaba_Valid: Alibaba 계정에 account_id가 있으면 검증 통과


### PR DESCRIPTION
## 변경 요약
- CSP 계정 identifier 검증(1/N Alibaba #131, 2/N GCP #132, 3/N Tencent #133)에 이어 **AWS `account_id`, Azure `subscription_id`+`tenant_id` 검증 추가**