### PR TITLE
fix: Tencent/AWS/Azure CSP 계정 identifier 검증 복구 (스택 PR 유실분, 3-5/N)

### DIFF
--- a/src/model/csp_account.go
+++ b/src/model/csp_account.go
@@ -93,6 +93,14 @@ func (c *CspAccount) GetAlibabaAccountID() string {
 	return c.GetAccountID()
 }
 
+// GetTencentAppID Tencent Cloud APPID 반환
+func (c *CspAccount) GetTencentAppID() string {
+	if c.AccountInfo == nil {
+		return ""
+	}
+	return c.AccountInfo["app_id"]
+}
+
 // CspAccountFilter CSP 계정 조회 필터
 type CspAccountFilter struct {
 	CspType  string `json:"csp_type,omitempty"`

--- a/src/service/csp_account_service.go
+++ b/src/service/csp_account_service.go
@@ -239,9 +239,22 @@ func validateAccountInfo(account *model.CspAccount) error {
 			return fmt.Errorf("Tencent app_id is required")
 		}
 		return nil
-	case "aws", "azure", "ibm", "ncp", "nhn", "kt", "openstack":
+	case "aws":
+		if account.GetAccountID() == "" {
+			return fmt.Errorf("AWS account_id is required")
+		}
+		return nil
+	case "azure":
+		if account.GetSubscriptionID() == "" {
+			return fmt.Errorf("Azure subscription_id is required")
+		}
+		if account.GetTenantID() == "" {
+			return fmt.Errorf("Azure tenant_id is required")
+		}
+		return nil
+	case "ibm", "ncp", "nhn", "kt", "openstack":
 		// TODO: 각 CSP 타입별 필수 필드 검증은 이후 PR에서 순차적으로 추가 예정.
-		// 지금은 no-op으로 통과시킨다 (이번 PR 범위는 Alibaba, GCP, Tencent만).
+		// 지금은 no-op으로 통과시킨다 (이번 PR 범위는 Alibaba, GCP, Tencent, AWS, Azure만).
 		return nil
 	default:
 		return fmt.Errorf("unsupported CSP type: %s", account.CspType)

--- a/src/service/csp_account_service.go
+++ b/src/service/csp_account_service.go
@@ -234,9 +234,14 @@ func validateAccountInfo(account *model.CspAccount) error {
 			return fmt.Errorf("GCP project_id is required")
 		}
 		return nil
-	case "aws", "azure", "tencent", "ibm", "ncp", "nhn", "kt", "openstack":
+	case "tencent":
+		if account.GetTencentAppID() == "" {
+			return fmt.Errorf("Tencent app_id is required")
+		}
+		return nil
+	case "aws", "azure", "ibm", "ncp", "nhn", "kt", "openstack":
 		// TODO: 각 CSP 타입별 필수 필드 검증은 이후 PR에서 순차적으로 추가 예정.
-		// 지금은 no-op으로 통과시킨다 (이번 PR 범위는 Alibaba, GCP만).
+		// 지금은 no-op으로 통과시킨다 (이번 PR 범위는 Alibaba, GCP, Tencent만).
 		return nil
 	default:
 		return fmt.Errorf("unsupported CSP type: %s", account.CspType)

--- a/src/service/csp_account_service_test.go
+++ b/src/service/csp_account_service_test.go
@@ -69,11 +69,8 @@ func TestCspAccountValidate_AWS_MissingAccountID(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = svc.ValidateCspAccount(context.Background(), created.ID)
-	// NOTE: AWS 필드 검증은 아직 미구현(no-op)이라 이 assertion은 현재 실패한다 (별도 PR에서 구현 예정).
-	// err가 nil일 수 있으므로 err.Error() 호출로 인한 패닉을 막기 위해 assert.Error 결과로 가드한다.
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "AWS account_id is required")
-	}
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "AWS account_id is required")
 }
 
 // TestValidateCspAccount_GCP_Valid: GCP 계정에 project_id가 있으면 검증 통과
@@ -141,10 +138,8 @@ func TestCspAccountValidate_Azure_MissingSubscriptionID(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = svc.ValidateCspAccount(context.Background(), created.ID)
-	// NOTE: Azure 필드 검증은 아직 미구현(no-op)이라 이 assertion은 현재 실패한다 (별도 PR에서 구현 예정).
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "Azure subscription_id is required")
-	}
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Azure subscription_id is required")
 }
 
 // TestValidateCspAccount_Azure_MissingTenantID: Azure 계정에 tenant_id가 없으면 에러
@@ -161,10 +156,8 @@ func TestCspAccountValidate_Azure_MissingTenantID(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = svc.ValidateCspAccount(context.Background(), created.ID)
-	// NOTE: Azure 필드 검증은 아직 미구현(no-op)이라 이 assertion은 현재 실패한다 (별도 PR에서 구현 예정).
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "Azure tenant_id is required")
-	}
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Azure tenant_id is required")
 }
 
 // TestCspAccountValidate_Alibaba_Valid: Alibaba 계정에 account_id가 있으면 검증 통과

--- a/src/service/csp_account_service_test.go
+++ b/src/service/csp_account_service_test.go
@@ -201,6 +201,39 @@ func TestCspAccountValidate_Alibaba_MissingAccountID(t *testing.T) {
 	assert.Contains(t, err.Error(), "Alibaba account_id is required")
 }
 
+// TestCspAccountValidate_Tencent_Valid: Tencent 계정에 app_id가 있으면 검증 통과
+func TestCspAccountValidate_Tencent_Valid(t *testing.T) {
+	svc, _ := newTestService(t)
+
+	created, err := svc.CreateCspAccount(&model.CreateCspAccountRequest{
+		Name:    "test-tencent",
+		CspType: "tencent",
+		AccountInfo: map[string]string{
+			"app_id": "1234567890",
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = svc.ValidateCspAccount(context.Background(), created.ID)
+	assert.NoError(t, err)
+}
+
+// TestCspAccountValidate_Tencent_MissingAppID: Tencent 계정에 app_id가 없으면 에러
+func TestCspAccountValidate_Tencent_MissingAppID(t *testing.T) {
+	svc, _ := newTestService(t)
+
+	created, err := svc.CreateCspAccount(&model.CreateCspAccountRequest{
+		Name:        "test-tencent-missing",
+		CspType:     "tencent",
+		AccountInfo: map[string]string{},
+	})
+	require.NoError(t, err)
+
+	_, err = svc.ValidateCspAccount(context.Background(), created.ID)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Tencent app_id is required")
+}
+
 // TestValidateCspAccount_UnsupportedType: 지원하지 않는 CSP 타입은 에러
 func TestCspAccountValidate_UnsupportedType(t *testing.T) {
 	svc, db := newTestService(t)


### PR DESCRIPTION
## 변경 요약
Tencent(3/N, #133)와 AWS/Azure(4-5/N, #134)가 스택 PR 구조 때문에 develop이 아닌 중간 브랜치(`fix-iam-csp-validate-gcp`/`fix-iam-csp-validate-tencent`)로 머지됐고, 그 브랜치들이 이후 정리 과정에서 삭제되어 develop에 반영되지 않은 상태였습니다. 실제 커밋 2건(#133, #134)을 cherry-pick으로 복구해 develop 기준으로 다시 올립니다. 코드 변경 내용은 #133/#134와 100% 동일합니다.

- Tencent `app_id` 검증 (`GetTencentAppID()`)
- AWS `account_id`, Azure `subscription_id`+`tenant_id` 검증
- IAM-BUG-013 원래 범위(`TestCspAccountValidate_*` 8건) 전부 PASS 재확인
