### PR TITLE
fix(M4-CSP): persist idp/iam identifier for non-AWS CSP role creation

### DIFF
--- a/src/service/csp_role_service.go
+++ b/src/service/csp_role_service.go
@@ -97,11 +97,15 @@ func (s *CspRoleService) CreateCspRole(req *model.CreateCspRoleRequest) (*model.
 		cspRole, err = s.createAwsIamRole(req)
 	default:
 		// AWS 이외 CSP: DB 등록만 수행 (클라우드 역할 생성은 향후 확장)
+		// idp/iam identifier는 admin이 CSP 콘솔에서 수동 생성한 리소스의 ARN/이메일을 그대로 등록하는 값이므로
+		// 요청에서 받은 값을 반드시 저장해야 한다 (OI-24: 이전에는 여기서 누락되어 항상 빈 값으로 저장됐음).
 		cspRole = &model.CspRole{
-			Name:        req.CspRoleName,
-			Description: req.Description,
-			CspType:     req.CspType,
-			Status:      "created",
+			Name:          req.CspRoleName,
+			Description:   req.Description,
+			CspType:       req.CspType,
+			Status:        "created",
+			IdpIdentifier: req.IdpIdentifier,
+			IamIdentifier: req.IamIdentifier,
 		}
 		if err := s.cspRoleRepo.CreateCspRoleRecord(cspRole); err != nil {
 			return nil, fmt.Errorf("failed to create CSP role record: %w", err)

--- a/src/service/csp_role_service_test.go
+++ b/src/service/csp_role_service_test.go
@@ -1,0 +1,58 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/m-cmp/mc-iam-manager/constants"
+	"github.com/m-cmp/mc-iam-manager/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestCspRoleService(t *testing.T) *CspRoleService {
+	db := setupTestDB(t)
+	return NewCspRoleService(db, &mockKeycloakService{})
+}
+
+// TestCreateCspRole_GCP_PersistsIdentifiers: 비-AWS CSP(default 분기)도 요청의
+// idpIdentifier/iamIdentifier를 그대로 저장해야 한다 (OI-24 회귀 방지).
+func TestCreateCspRole_GCP_PersistsIdentifiers(t *testing.T) {
+	svc := newTestCspRoleService(t)
+
+	req := &model.CreateCspRoleRequest{
+		CspRoleName:   "mcmp-admin",
+		CspType:       "gcp",
+		AuthMethod:    constants.AuthMethodOIDC,
+		IdpIdentifier: "//iam.googleapis.com/projects/295058475885/locations/global/workloadIdentityPools/mcmp-oidc/providers/mcmp",
+		IamIdentifier: "mcmp-admin@csta-349809.iam.gserviceaccount.com",
+	}
+
+	role, err := svc.CreateCspRole(req)
+	require.NoError(t, err)
+	require.NotNil(t, role)
+
+	assert.Equal(t, req.IdpIdentifier, role.IdpIdentifier)
+	assert.Equal(t, req.IamIdentifier, role.IamIdentifier)
+	assert.Equal(t, "created", role.Status)
+}
+
+// TestCreateCspRole_Alibaba_PersistsIdentifiers: 동일한 default 분기를 타는
+// 다른 CSP(alibaba)에서도 identifier가 저장되는지 확인.
+func TestCreateCspRole_Alibaba_PersistsIdentifiers(t *testing.T) {
+	svc := newTestCspRoleService(t)
+
+	req := &model.CreateCspRoleRequest{
+		CspRoleName:   "mciam-oidc-role",
+		CspType:       "alibaba",
+		AuthMethod:    constants.AuthMethodOIDC,
+		IdpIdentifier: "acs:ram::5513479151634744:oidc-provider/mciam-keycloak",
+		IamIdentifier: "acs:ram::5513479151634744:role/mciam-oidc-role",
+	}
+
+	role, err := svc.CreateCspRole(req)
+	require.NoError(t, err)
+	require.NotNil(t, role)
+
+	assert.Equal(t, req.IdpIdentifier, role.IdpIdentifier)
+	assert.Equal(t, req.IamIdentifier, role.IamIdentifier)
+}


### PR DESCRIPTION
## Summary

- `CreateCspRole`의 `default:` 분기(AWS 이외 모든 CSP)가 요청받은 `idpIdentifier`/`iamIdentifier`를 `CspRole` 레코드에 저장하지 않고 있었음
- admin이 CSP 콘솔에서 수동으로 생성한 리소스(OIDC/WIF Provider ARN, 대상 역할/서비스계정 이메일 등)의 식별자를 `POST /api/roles/csp`로 등록해도 항상 빈 값으로 저장되는 문제
- 수정(PUT) API도 없어 한 번 빈 값으로 생성되면 API로는 고칠 방법이 없었음 (DB 직접 수정 외 불가)