### PR TITLE
fix: group deletion cleanup, role-to-group lookup, bulk user removal

### DIFF
--- a/src/handler/group_role_handler.go
+++ b/src/handler/group_role_handler.go
@@ -128,6 +128,54 @@ func (h *GroupRoleHandler) GetAvailableGroupPlatformRoles(c echo.Context) error 
 	return c.JSON(http.StatusOK, roles)
 }
 
+// ListGroupsByPlatformRole godoc
+// @Summary 특정 Platform Role이 부여된 그룹 목록 조회
+// @Description 특정 플랫폼 역할이 할당된 그룹 목록을 조회합니다 (역할→그룹 역방향 조회).
+// @Tags roles
+// @Produce json
+// @Param roleId path int true "역할 ID"
+// @Success 200 {array} model.GroupPlatformRoleResponse
+// @Failure 400 {object} map[string]string
+// @Security BearerAuth
+// @Router /api/roles/mappings/platform-roles/id/{roleId}/groups [get]
+// @Id listGroupsByPlatformRole
+func (h *GroupRoleHandler) ListGroupsByPlatformRole(c echo.Context) error {
+	roleID, err := strconv.ParseUint(c.Param("roleId"), 10, 32)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid role ID"})
+	}
+
+	groups, err := h.groupRoleService.ListGroupsByPlatformRole(uint(roleID))
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	return c.JSON(http.StatusOK, groups)
+}
+
+// ListGroupsByWorkspaceRole godoc
+// @Summary 특정 Workspace Role이 부여된 그룹 목록 조회
+// @Description 특정 워크스페이스 역할이 할당된 그룹 목록을 조회합니다 (역할→그룹 역방향 조회).
+// @Tags roles
+// @Produce json
+// @Param roleId path int true "역할 ID"
+// @Success 200 {array} model.GroupWorkspaceRoleResponse
+// @Failure 400 {object} map[string]string
+// @Security BearerAuth
+// @Router /api/roles/mappings/workspace-roles/id/{roleId}/groups [get]
+// @Id listGroupsByWorkspaceRole
+func (h *GroupRoleHandler) ListGroupsByWorkspaceRole(c echo.Context) error {
+	roleID, err := strconv.ParseUint(c.Param("roleId"), 10, 32)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid role ID"})
+	}
+
+	groups, err := h.groupRoleService.ListGroupsByWorkspaceRole(uint(roleID))
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	return c.JSON(http.StatusOK, groups)
+}
+
 // GetAvailableGroupWorkspaces godoc
 // @Summary 그룹에 매핑 가능한 워크스페이스 목록 조회
 // @Description 그룹에 아직 매핑되지 않은 워크스페이스 목록을 조회합니다.
@@ -413,6 +461,46 @@ func (h *GroupRoleHandler) RemoveGroupUser(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, map[string]string{"message": "사용자가 그룹에서 제거되었습니다."})
+}
+
+// RemoveGroupUsers godoc
+// @Summary 그룹에서 사용자 일괄 제거 (Keycloak 동기화 포함)
+// @Description 그룹에서 사용자 목록을 일괄 제거합니다. DB + Keycloak 그룹 동기화.
+// @Tags groups
+// @Accept json
+// @Produce json
+// @Param groupId path int true "그룹 ID"
+// @Param body body model.RemoveGroupUsersRequest true "사용자 일괄 제거 요청"
+// @Success 200 {object} map[string]string
+// @Failure 400 {object} map[string]string
+// @Failure 404 {object} map[string]string
+// @Security BearerAuth
+// @Router /api/groups/id/{groupId}/users [delete]
+// @Id removeGroupUsers
+func (h *GroupRoleHandler) RemoveGroupUsers(c echo.Context) error {
+	groupID, err := strconv.ParseUint(c.Param("groupId"), 10, 32)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid group ID"})
+	}
+
+	var req model.RemoveGroupUsersRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request format"})
+	}
+	if err := c.Validate(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+	}
+
+	if err := h.groupRoleService.RemoveUsersFromGroup(c.Request().Context(), uint(groupID), req.UserIDs); err != nil {
+		switch {
+		case errors.Is(err, repository.ErrOrganizationNotFound):
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "그룹을 찾을 수 없습니다"})
+		default:
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+		}
+	}
+
+	return c.JSON(http.StatusOK, map[string]string{"message": "사용자가 그룹에서 일괄 제거되었습니다."})
 }
 
 // AssignUserGroups godoc

--- a/src/handler/organization_handler.go
+++ b/src/handler/organization_handler.go
@@ -240,7 +240,7 @@ func (h *OrganizationHandler) DeleteOrganization(c echo.Context) error {
 	cascade := c.QueryParam("cascade") == "true"
 
 	if cascade {
-		if err := h.orgService.DeleteOrganizationCascade(uint(id)); err != nil {
+		if err := h.orgService.DeleteOrganizationCascade(c.Request().Context(), uint(id)); err != nil {
 			if errors.Is(err, repository.ErrOrganizationNotFound) {
 				return c.JSON(http.StatusNotFound, map[string]string{"error": "조직을 찾을 수 없습니다"})
 			}
@@ -249,7 +249,7 @@ func (h *OrganizationHandler) DeleteOrganization(c echo.Context) error {
 		return c.NoContent(http.StatusNoContent)
 	}
 
-	if err := h.orgService.DeleteOrganization(uint(id)); err != nil {
+	if err := h.orgService.DeleteOrganization(c.Request().Context(), uint(id)); err != nil {
 		switch {
 		case errors.Is(err, repository.ErrOrganizationNotFound):
 			return c.JSON(http.StatusNotFound, map[string]string{"error": "조직을 찾을 수 없습니다"})

--- a/src/main.go
+++ b/src/main.go
@@ -345,8 +345,10 @@ func main() {
 		roles.POST("/mappings/list", roleHandler.ListRoleMasterMappings)
 		roles.GET("/mappings/role/id/:roleId", roleHandler.GetRoleMasterMappings)
 		roles.POST("/mappings/platform-roles/users/list", roleHandler.ListUsersByPlatformRole)
+		roles.GET("/mappings/platform-roles/id/:roleId/groups", groupRoleHandler.ListGroupsByPlatformRole, middleware.PlatformRoleMiddleware(middleware.Write))
 
 		roles.POST("/mappings/workspace-roles/users/list", roleHandler.ListUsersByWorkspaceRole)
+		roles.GET("/mappings/workspace-roles/id/:roleId/groups", groupRoleHandler.ListGroupsByWorkspaceRole, middleware.PlatformRoleMiddleware(middleware.Write))
 		roles.POST("/mappings/csp-roles/list", roleHandler.ListRoleMasterMappingsByCspRole)
 	}
 
@@ -532,6 +534,7 @@ func main() {
 		// 그룹 사용자 관리 (그룹 입장, Keycloak 동기화 포함)
 		groups.POST("/id/:groupId/users", groupRoleHandler.AssignGroupUsers)
 		groups.DELETE("/id/:groupId/users/:userId", groupRoleHandler.RemoveGroupUser)
+		groups.DELETE("/id/:groupId/users", groupRoleHandler.RemoveGroupUsers)
 
 		// 그룹 플랫폼 역할 관리 (DB + Keycloak)
 		groups.POST("/id/:groupId/platform-roles", groupRoleHandler.AssignGroupPlatformRole)

--- a/src/model/group_role.go
+++ b/src/model/group_role.go
@@ -88,6 +88,11 @@ type AssignGroupUsersRequest struct {
 	UserIDs []uint `json:"user_ids" validate:"required,min=1"`
 }
 
+// RemoveGroupUsersRequest 그룹에서 사용자 일괄 제거 요청 (group 입장)
+type RemoveGroupUsersRequest struct {
+	UserIDs []uint `json:"user_ids" validate:"required,min=1"`
+}
+
 // PlatformRoleSimple 플랫폼 역할 간단 정보
 type PlatformRoleSimple struct {
 	RoleID      uint   `json:"role_id"`

--- a/src/repository/group_role_repository.go
+++ b/src/repository/group_role_repository.go
@@ -59,6 +59,21 @@ func (r *GroupRoleRepository) FindGroupPlatformRoles(groupID uint) ([]model.Grou
 	return results, nil
 }
 
+// FindGroupsByPlatformRoleID 특정 platform role이 부여된 그룹 목록 조회 (역할→그룹 역방향 조회)
+func (r *GroupRoleRepository) FindGroupsByPlatformRoleID(roleID uint) ([]model.GroupPlatformRoleResponse, error) {
+	results := make([]model.GroupPlatformRoleResponse, 0)
+	err := r.db.Table("mcmp_group_platform_roles gpr").
+		Select("gpr.group_id, o.name as group_name, gpr.role_id, rm.name as role_name, gpr.created_at").
+		Joins("JOIN mcmp_organizations o ON o.id = gpr.group_id").
+		Joins("JOIN mcmp_role_masters rm ON rm.id = gpr.role_id").
+		Where("gpr.role_id = ?", roleID).
+		Scan(&results).Error
+	if err != nil {
+		return nil, fmt.Errorf("error finding groups by platform role: %w", err)
+	}
+	return results, nil
+}
+
 // FindGroupPlatformRoleByRoleID 특정 그룹-역할 매핑 조회
 func (r *GroupRoleRepository) FindGroupPlatformRoleByRoleID(groupID, roleID uint) (*model.GroupPlatformRole, error) {
 	var record model.GroupPlatformRole
@@ -135,6 +150,22 @@ func (r *GroupRoleRepository) FindGroupWorkspaceRoles(groupID uint) ([]model.Gro
 	return results, nil
 }
 
+// FindGroupsByWorkspaceRoleID 특정 workspace role이 부여된 그룹 목록 조회 (역할→그룹 역방향 조회)
+func (r *GroupRoleRepository) FindGroupsByWorkspaceRoleID(roleID uint) ([]model.GroupWorkspaceRoleResponse, error) {
+	results := make([]model.GroupWorkspaceRoleResponse, 0)
+	err := r.db.Table("mcmp_group_workspace_roles gwr").
+		Select("gwr.group_id, o.name as group_name, gwr.workspace_id, w.name as workspace_name, gwr.role_id, rm.name as role_name, gwr.created_at").
+		Joins("JOIN mcmp_organizations o ON o.id = gwr.group_id").
+		Joins("JOIN mcmp_workspaces w ON w.id = gwr.workspace_id").
+		Joins("JOIN mcmp_role_masters rm ON rm.id = gwr.role_id").
+		Where("gwr.role_id = ?", roleID).
+		Scan(&results).Error
+	if err != nil {
+		return nil, fmt.Errorf("error finding groups by workspace role: %w", err)
+	}
+	return results, nil
+}
+
 // UpdateGroupWorkspaceRole 그룹-워크스페이스 역할 변경
 func (r *GroupRoleRepository) UpdateGroupWorkspaceRole(groupID, workspaceID, roleID uint) error {
 	result := r.db.Model(&model.GroupWorkspaceRole{}).
@@ -147,20 +178,6 @@ func (r *GroupRoleRepository) UpdateGroupWorkspaceRole(groupID, workspaceID, rol
 		return ErrGroupWorkspaceRoleNotFound
 	}
 	return nil
-}
-
-// FindAvailableWorkspacesForGroup 그룹에 미매핑된 워크스페이스 목록 조회
-func (r *GroupRoleRepository) FindAvailableWorkspacesForGroup(groupID uint) ([]*model.Workspace, error) {
-	var workspaces []*model.Workspace
-	err := r.db.Where("id NOT IN (?)",
-		r.db.Table("mcmp_group_workspace_roles").
-			Select("workspace_id").
-			Where("group_id = ?", groupID),
-	).Find(&workspaces).Error
-	if err != nil {
-		return nil, fmt.Errorf("error finding available workspaces: %w", err)
-	}
-	return workspaces, nil
 }
 
 // DeleteGroupWorkspaceRole 그룹-워크스페이스 매핑 삭제

--- a/src/repository/group_role_repository_test.go
+++ b/src/repository/group_role_repository_test.go
@@ -177,28 +177,61 @@ func TestGroupRoleRepository_DeleteGroupWorkspaceRole_NotFound(t *testing.T) {
 	assert.ErrorIs(t, err, ErrGroupWorkspaceRoleNotFound)
 }
 
-// --- FindAvailableWorkspacesForGroup ---
+// --- FindGroupsByPlatformRoleID / FindGroupsByWorkspaceRoleID (역할→그룹 역방향 조회) ---
 
-func TestGroupRoleRepository_FindAvailableWorkspacesForGroup(t *testing.T) {
+func TestGroupRoleRepository_FindGroupsByPlatformRoleID(t *testing.T) {
 	db := setupGroupRoleTestDB(t)
 	repo := NewGroupRoleRepository(db)
 
-	org := seedOrganization(t, db, "AvailGroup", "GRP-007")
-	ws1 := seedWorkspace(t, db, "Workspace-E")
-	ws2 := seedWorkspace(t, db, "Workspace-F")
-	ws3 := seedWorkspace(t, db, "Workspace-G")
-	role := seedRoleMaster(t, db, "dev")
+	orgA := seedOrganization(t, db, "PlatformRoleGroupA", "GRP-008")
+	orgB := seedOrganization(t, db, "PlatformRoleGroupB", "GRP-009")
+	roleX := seedRoleMaster(t, db, "role-x")
+	roleY := seedRoleMaster(t, db, "role-y")
 
-	// ws1만 매핑
-	require.NoError(t, repo.CreateGroupWorkspaceRole(org.ID, ws1.ID, role.ID))
+	require.NoError(t, db.Create(&model.GroupPlatformRole{GroupID: orgA.ID, RoleID: roleX.ID}).Error)
+	require.NoError(t, db.Create(&model.GroupPlatformRole{GroupID: orgB.ID, RoleID: roleY.ID}).Error)
 
-	available, err := repo.FindAvailableWorkspacesForGroup(org.ID)
+	results, err := repo.FindGroupsByPlatformRoleID(roleX.ID)
 	assert.NoError(t, err)
-	// ws2, ws3은 미매핑 → 2개 반환
-	assert.Len(t, available, 2)
+	require.Len(t, results, 1)
+	assert.Equal(t, orgA.ID, results[0].GroupID)
+	assert.Equal(t, "role-x", results[0].RoleName)
+}
 
-	ids := []uint{available[0].ID, available[1].ID}
-	assert.Contains(t, ids, ws2.ID)
-	assert.Contains(t, ids, ws3.ID)
-	assert.NotContains(t, ids, ws1.ID)
+func TestGroupRoleRepository_FindGroupsByPlatformRoleID_Empty(t *testing.T) {
+	db := setupGroupRoleTestDB(t)
+	repo := NewGroupRoleRepository(db)
+
+	results, err := repo.FindGroupsByPlatformRoleID(9999)
+	assert.NoError(t, err)
+	assert.Len(t, results, 0)
+}
+
+func TestGroupRoleRepository_FindGroupsByWorkspaceRoleID(t *testing.T) {
+	db := setupGroupRoleTestDB(t)
+	repo := NewGroupRoleRepository(db)
+
+	orgA := seedOrganization(t, db, "WorkspaceRoleGroupA", "GRP-010")
+	orgB := seedOrganization(t, db, "WorkspaceRoleGroupB", "GRP-011")
+	ws := seedWorkspace(t, db, "Workspace-Reverse")
+	roleX := seedRoleMaster(t, db, "ws-role-x")
+	roleY := seedRoleMaster(t, db, "ws-role-y")
+
+	require.NoError(t, repo.CreateGroupWorkspaceRole(orgA.ID, ws.ID, roleX.ID))
+	require.NoError(t, repo.CreateGroupWorkspaceRole(orgB.ID, ws.ID, roleY.ID))
+
+	results, err := repo.FindGroupsByWorkspaceRoleID(roleX.ID)
+	assert.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, orgA.ID, results[0].GroupID)
+	assert.Equal(t, ws.ID, results[0].WorkspaceID)
+}
+
+func TestGroupRoleRepository_FindGroupsByWorkspaceRoleID_Empty(t *testing.T) {
+	db := setupGroupRoleTestDB(t)
+	repo := NewGroupRoleRepository(db)
+
+	results, err := repo.FindGroupsByWorkspaceRoleID(9999)
+	assert.NoError(t, err)
+	assert.Len(t, results, 0)
 }

--- a/src/repository/organization_repository.go
+++ b/src/repository/organization_repository.go
@@ -109,16 +109,25 @@ func (r *OrganizationRepository) Update(id uint, updates map[string]interface{})
 	return nil
 }
 
-// Delete 조직 삭제
+// Delete 조직 삭제 (group-role 매핑도 함께 정리)
 func (r *OrganizationRepository) Delete(id uint) error {
-	result := r.db.Delete(&model.Organization{}, "id = ?", id)
-	if result.Error != nil {
-		return result.Error
-	}
-	if result.RowsAffected == 0 {
-		return ErrOrganizationNotFound
-	}
-	return nil
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("group_id = ?", id).Delete(&model.GroupPlatformRole{}).Error; err != nil {
+			return fmt.Errorf("error deleting group platform role mappings: %w", err)
+		}
+		if err := tx.Where("group_id = ?", id).Delete(&model.GroupWorkspaceRole{}).Error; err != nil {
+			return fmt.Errorf("error deleting group workspace role mappings: %w", err)
+		}
+
+		result := tx.Delete(&model.Organization{}, "id = ?", id)
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return ErrOrganizationNotFound
+		}
+		return nil
+	})
 }
 
 // UpsertOrganizations 조직 목록을 Upsert (organization_code 기준, 멱등성 보장)
@@ -644,6 +653,14 @@ func (r *OrganizationRepository) DeleteCascade(orgID uint) error {
 			return fmt.Errorf("error deleting user mappings for cascade: %w", err)
 		}
 
+		// group-role 매핑 삭제 (platform role, workspace role)
+		if err := tx.Where("group_id IN ?", ids).Delete(&model.GroupPlatformRole{}).Error; err != nil {
+			return fmt.Errorf("error deleting group platform role mappings for cascade: %w", err)
+		}
+		if err := tx.Where("group_id IN ?", ids).Delete(&model.GroupWorkspaceRole{}).Error; err != nil {
+			return fmt.Errorf("error deleting group workspace role mappings for cascade: %w", err)
+		}
+
 		// 하위 조직 먼저 삭제 (코드 DESC 정렬 = 깊은 자식 먼저)
 		if err := tx.Where("id IN ? AND id != ?", ids, orgID).
 			Order("organization_code DESC").
@@ -658,6 +675,25 @@ func (r *OrganizationRepository) DeleteCascade(orgID uint) error {
 
 		return nil
 	})
+}
+
+// FindSubtreeOrganizations 조직과 모든 하위 조직(자신 포함)을 조회
+// DeleteCascade로 삭제되기 전에 Keycloak 그룹 정리 대상(이름 목록)을 파악하는 용도로 사용
+func (r *OrganizationRepository) FindSubtreeOrganizations(orgID uint) ([]model.Organization, error) {
+	var orgs []model.Organization
+	query := `
+        WITH RECURSIVE subtree AS (
+            SELECT id FROM mcmp_organizations WHERE id = ?
+            UNION ALL
+            SELECT o.id FROM mcmp_organizations o
+            INNER JOIN subtree s ON o.parent_id = s.id
+        )
+        SELECT o.* FROM mcmp_organizations o WHERE o.id IN (SELECT id FROM subtree)
+    `
+	if err := r.db.Raw(query, orgID).Scan(&orgs).Error; err != nil {
+		return nil, fmt.Errorf("error querying subtree organizations: %w", err)
+	}
+	return orgs, nil
 }
 
 func init() {

--- a/src/service/group_role_service.go
+++ b/src/service/group_role_service.go
@@ -72,6 +72,16 @@ func (s *GroupRoleService) GetAvailablePlatformRoles(groupID uint) ([]model.Role
 	return s.groupRoleRepo.FindAvailablePlatformRoles(groupID)
 }
 
+// ListGroupsByPlatformRole 특정 platform role이 부여된 그룹 목록 조회 (역할→그룹 역방향 조회)
+func (s *GroupRoleService) ListGroupsByPlatformRole(roleID uint) ([]model.GroupPlatformRoleResponse, error) {
+	return s.groupRoleRepo.FindGroupsByPlatformRoleID(roleID)
+}
+
+// ListGroupsByWorkspaceRole 특정 workspace role이 부여된 그룹 목록 조회 (역할→그룹 역방향 조회)
+func (s *GroupRoleService) ListGroupsByWorkspaceRole(roleID uint) ([]model.GroupWorkspaceRoleResponse, error) {
+	return s.groupRoleRepo.FindGroupsByWorkspaceRoleID(roleID)
+}
+
 // GetAvailableWorkspaces 그룹에 매핑되지 않은 워크스페이스 목록 조회
 func (s *GroupRoleService) GetAvailableWorkspaces(groupID uint) ([]model.Workspace, error) {
 	return s.groupRoleRepo.FindAvailableWorkspaces(groupID)
@@ -146,11 +156,6 @@ func (s *GroupRoleService) RemoveGroupWorkspaceRole(groupID, workspaceID uint) e
 	return s.groupRoleRepo.DeleteGroupWorkspaceRole(groupID, workspaceID)
 }
 
-// GetAvailableGroupWorkspaces 그룹에 미매핑된 워크스페이스 목록 조회
-func (s *GroupRoleService) GetAvailableGroupWorkspaces(groupID uint) ([]*model.Workspace, error) {
-	return s.groupRoleRepo.FindAvailableWorkspacesForGroup(groupID)
-}
-
 // --- User-Group (with Keycloak sync) ---
 
 // AssignUserToGroups 사용자를 그룹에 할당 (DB + Keycloak 동기화)
@@ -201,6 +206,36 @@ func (s *GroupRoleService) AssignUsersToGroup(ctx context.Context, groupID uint,
 		if user.KcId != "" {
 			if err := s.kcService.EnsureGroupExistsAndAssignUser(ctx, user.KcId, org.Name); err != nil {
 				return fmt.Errorf("failed to assign user %d to keycloak group '%s': %w", userID, org.Name, err)
+			}
+		}
+	}
+	return nil
+}
+
+// RemoveUsersFromGroup 그룹에서 사용자 일괄 제거 (그룹 입장, DB + Keycloak 동기화)
+func (s *GroupRoleService) RemoveUsersFromGroup(ctx context.Context, groupID uint, userIDs []uint) error {
+	// 그룹 존재 확인
+	org, err := s.orgRepo.FindByID(groupID)
+	if err != nil {
+		return err
+	}
+
+	for _, userID := range userIDs {
+		// 사용자 KC ID 조회
+		var user model.User
+		if err := s.db.First(&user, userID).Error; err != nil {
+			return fmt.Errorf("user not found: %d", userID)
+		}
+
+		// DB 삭제
+		if err := s.orgRepo.RemoveUserFromOrganization(userID, groupID); err != nil {
+			return fmt.Errorf("failed to remove user %d from group in DB: %w", userID, err)
+		}
+
+		// Keycloak 동기화
+		if user.KcId != "" {
+			if err := s.kcService.RemoveUserFromGroup(ctx, user.KcId, org.Name); err != nil {
+				return fmt.Errorf("keycloak group removal failed for user %d (DB already updated): %w", userID, err)
 			}
 		}
 	}

--- a/src/service/group_role_service_test.go
+++ b/src/service/group_role_service_test.go
@@ -74,6 +74,13 @@ func createGRTestWorkspace(t *testing.T, db *gorm.DB, name string) *model.Worksp
 	return ws
 }
 
+func createGRTestUser(t *testing.T, db *gorm.DB, username, kcID string) *model.User {
+	t.Helper()
+	u := &model.User{Username: username, KcId: kcID}
+	require.NoError(t, db.Create(u).Error)
+	return u
+}
+
 // ── AssignGroupPlatformRole — KC 호출 전 검증 실패 케이스 ─────────────────────
 
 // TC-GR-APR-01: 그룹(조직)이 존재하지 않는 경우 → 오류 반환
@@ -219,6 +226,66 @@ func TestGroupRoleGetAvailableWorkspaces_ReturnsUnassigned(t *testing.T) {
 	}
 	assert.Contains(t, ids, ws2.ID)
 	assert.NotContains(t, ids, ws1.ID)
+}
+
+// ── ListGroupsByPlatformRole / ListGroupsByWorkspaceRole (역할→그룹 역방향 조회) ──
+
+// TC-GR-LGPR-01: 특정 platform role이 부여된 그룹만 반환, 다른 역할을 가진 그룹은 제외
+func TestGroupRoleListGroupsByPlatformRole_ReturnsAssignedGroupsOnly(t *testing.T) {
+	svc, db := newTestGroupRoleService(t)
+	orgA := createGRTestOrg(t, db, "test-group-lgpr01-a", "LGPR01A")
+	orgB := createGRTestOrg(t, db, "test-group-lgpr01-b", "LGPR01B")
+	roleX := createGRTestRole(t, db, "role-lgpr01-x")
+	roleY := createGRTestRole(t, db, "role-lgpr01-y")
+
+	svc.kcService = &mockKeycloakService{}
+	require.NoError(t, svc.AssignGroupPlatformRole(context.Background(), orgA.ID, roleX.ID))
+	require.NoError(t, svc.AssignGroupPlatformRole(context.Background(), orgB.ID, roleY.ID))
+
+	results, err := svc.ListGroupsByPlatformRole(roleX.ID)
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, orgA.ID, results[0].GroupID)
+}
+
+// TC-GR-LGPR-02: 아무 그룹에도 할당되지 않은 역할 → 빈 슬라이스
+func TestGroupRoleListGroupsByPlatformRole_Empty(t *testing.T) {
+	svc, _ := newTestGroupRoleService(t)
+
+	results, err := svc.ListGroupsByPlatformRole(99999)
+
+	require.NoError(t, err)
+	assert.Len(t, results, 0)
+}
+
+// TC-GR-LGWR-01: 특정 workspace role이 부여된 그룹만 반환
+func TestGroupRoleListGroupsByWorkspaceRole_ReturnsAssignedGroupsOnly(t *testing.T) {
+	svc, db := newTestGroupRoleService(t)
+	orgA := createGRTestOrg(t, db, "test-group-lgwr01-a", "LGWR01A")
+	orgB := createGRTestOrg(t, db, "test-group-lgwr01-b", "LGWR01B")
+	ws := createGRTestWorkspace(t, db, "ws-lgwr01")
+	roleX := createGRTestRole(t, db, "role-lgwr01-x")
+	roleY := createGRTestRole(t, db, "role-lgwr01-y")
+
+	require.NoError(t, svc.AssignGroupWorkspace(orgA.ID, ws.ID, roleX.ID))
+	require.NoError(t, svc.AssignGroupWorkspace(orgB.ID, ws.ID, roleY.ID))
+
+	results, err := svc.ListGroupsByWorkspaceRole(roleX.ID)
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, orgA.ID, results[0].GroupID)
+}
+
+// TC-GR-LGWR-02: 아무 그룹에도 할당되지 않은 역할 → 빈 슬라이스
+func TestGroupRoleListGroupsByWorkspaceRole_Empty(t *testing.T) {
+	svc, _ := newTestGroupRoleService(t)
+
+	results, err := svc.ListGroupsByWorkspaceRole(99999)
+
+	require.NoError(t, err)
+	assert.Len(t, results, 0)
 }
 
 // ── GetUserAccessSummary ──────────────────────────────────────────────────────
@@ -408,20 +475,43 @@ func TestGroupRoleService_RemoveGroupWorkspaceRole_NotFound(t *testing.T) {
 	assert.ErrorIs(t, err, repository.ErrGroupWorkspaceRoleNotFound)
 }
 
-// GetAvailableGroupWorkspaces
-func TestGroupRoleService_GetAvailableGroupWorkspaces(t *testing.T) {
-	db := setupGroupRoleServiceTestDB(t)
-	svc := NewGroupRoleService(db)
+// ── RemoveUsersFromGroup (bulk) ──────────────────────────────────────────────
 
-	org := seedOrg(t, db, "Group-I", "SVC-009")
-	ws1 := seedWs(t, db, "Workspace-H")
-	ws2 := seedWs(t, db, "Workspace-I")
-	role := seedRole(t, db, "svc-lead")
+// TC-GR-RUFG-01: 그룹이 존재하지 않는 경우 → ErrOrganizationNotFound
+func TestGroupRoleRemoveUsersFromGroup_OrgNotFound(t *testing.T) {
+	svc, _ := newTestGroupRoleService(t)
 
-	require.NoError(t, svc.AssignGroupWorkspace(org.ID, ws1.ID, role.ID))
+	err := svc.RemoveUsersFromGroup(context.Background(), 99999, []uint{1})
 
-	available, err := svc.GetAvailableGroupWorkspaces(org.ID)
-	assert.NoError(t, err)
-	assert.Len(t, available, 1)
-	assert.Equal(t, ws2.ID, available[0].ID)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, repository.ErrOrganizationNotFound)
+}
+
+// TC-GR-RUFG-02: 존재하지 않는 사용자 ID가 포함된 경우 → 오류 반환
+func TestGroupRoleRemoveUsersFromGroup_UserNotFound(t *testing.T) {
+	svc, db := newTestGroupRoleService(t)
+	org := createGRTestOrg(t, db, "test-group-rufg02", "RUFG02")
+
+	err := svc.RemoveUsersFromGroup(context.Background(), org.ID, []uint{99999})
+
+	require.Error(t, err)
+}
+
+// TC-GR-RUFG-03: 여러 사용자를 그룹에서 일괄 제거 → 모두 제거됨
+func TestGroupRoleRemoveUsersFromGroup_Success(t *testing.T) {
+	svc, db := newTestGroupRoleService(t)
+	svc.kcService = &mockKeycloakService{}
+	org := createGRTestOrg(t, db, "test-group-rufg03", "RUFG03")
+	userA := createGRTestUser(t, db, "user-rufg03-a", "kc-rufg03-a")
+	userB := createGRTestUser(t, db, "user-rufg03-b", "kc-rufg03-b")
+
+	require.NoError(t, db.Create(&model.UserOrganization{UserID: userA.ID, OrganizationID: org.ID}).Error)
+	require.NoError(t, db.Create(&model.UserOrganization{UserID: userB.ID, OrganizationID: org.ID}).Error)
+
+	err := svc.RemoveUsersFromGroup(context.Background(), org.ID, []uint{userA.ID, userB.ID})
+	require.NoError(t, err)
+
+	var count int64
+	db.Model(&model.UserOrganization{}).Where("organization_id = ?", org.ID).Count(&count)
+	assert.Equal(t, int64(0), count)
 }

--- a/src/service/keycloak_service.go
+++ b/src/service/keycloak_service.go
@@ -92,6 +92,8 @@ type KeycloakService interface {
 	AddRealmRoleToGroup(ctx context.Context, groupName, roleName string) error
 	// RemoveRealmRoleFromGroup removes a realm role from a Keycloak group
 	RemoveRealmRoleFromGroup(ctx context.Context, groupName, roleName string) error
+	// DeleteGroup deletes a Keycloak group by name (no-op if the group doesn't exist)
+	DeleteGroup(ctx context.Context, groupName string) error
 	// CheckSAMLClientConfig Keycloak SAML 클라이언트 존재 및 protocol mapper 구성 확인
 	CheckSAMLClientConfig(ctx context.Context, clientID string) (string, error)
 }
@@ -1891,6 +1893,34 @@ func (s *keycloakService) RemoveRealmRoleFromGroup(ctx context.Context, groupNam
 	}
 
 	log.Printf("Successfully removed realm role '%s' from Keycloak group '%s'", roleName, groupName)
+	return nil
+}
+
+// DeleteGroup deletes a Keycloak group by name. No-op (not an error) if the group doesn't exist.
+func (s *keycloakService) DeleteGroup(ctx context.Context, groupName string) error {
+	if config.KC == nil || config.KC.Client == nil {
+		return fmt.Errorf("keycloak configuration not initialized")
+	}
+
+	token, err := config.KC.GetAdminToken(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get admin token: %w", err)
+	}
+
+	groupID, err := s.findGroupByName(ctx, token.AccessToken, groupName)
+	if err != nil {
+		return err
+	}
+	if groupID == "" {
+		log.Printf("Keycloak group '%s' not found, skipping deletion", groupName)
+		return nil
+	}
+
+	if err := config.KC.Client.DeleteGroup(ctx, token.AccessToken, config.KC.Realm, groupID); err != nil {
+		return fmt.Errorf("failed to delete keycloak group '%s': %w", groupName, err)
+	}
+
+	log.Printf("Successfully deleted Keycloak group '%s'", groupName)
 	return nil
 }
 

--- a/src/service/mock_keycloak_service_test.go
+++ b/src/service/mock_keycloak_service_test.go
@@ -125,6 +125,9 @@ func (m *mockKeycloakService) AddRealmRoleToGroup(ctx context.Context, groupName
 func (m *mockKeycloakService) RemoveRealmRoleFromGroup(ctx context.Context, groupName, roleName string) error {
 	return nil
 }
+func (m *mockKeycloakService) DeleteGroup(ctx context.Context, groupName string) error {
+	return nil
+}
 func (m *mockKeycloakService) CheckSAMLClientConfig(ctx context.Context, clientID string) (string, error) {
 	return "", nil
 }

--- a/src/service/organization_service.go
+++ b/src/service/organization_service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -19,15 +20,17 @@ var ErrMaxDepthExceeded = errors.New("organization tree depth would exceed maxim
 
 // OrganizationService 조직 비즈니스 로직
 type OrganizationService struct {
-	db      *gorm.DB
-	orgRepo *repository.OrganizationRepository
+	db        *gorm.DB
+	orgRepo   *repository.OrganizationRepository
+	kcService KeycloakService
 }
 
 // NewOrganizationService OrganizationService 생성자
 func NewOrganizationService(db *gorm.DB) *OrganizationService {
 	return &OrganizationService{
-		db:      db,
-		orgRepo: repository.NewOrganizationRepository(db),
+		db:        db,
+		orgRepo:   repository.NewOrganizationRepository(db),
+		kcService: NewKeycloakService(),
 	}
 }
 
@@ -241,11 +244,30 @@ func (s *OrganizationService) CheckOrganizationDeletable(orgID uint) (*model.Org
 }
 
 // DeleteOrganizationCascade 조직 및 모든 하위 조직/사용자 매핑을 cascade 삭제 (RQ-M2-UG-036-02)
-func (s *OrganizationService) DeleteOrganizationCascade(orgID uint) error {
-	if _, err := s.orgRepo.FindByID(orgID); err != nil {
+func (s *OrganizationService) DeleteOrganizationCascade(ctx context.Context, orgID uint) error {
+	subtree, err := s.orgRepo.FindSubtreeOrganizations(orgID)
+	if err != nil {
 		return err
 	}
-	return s.orgRepo.DeleteCascade(orgID)
+	if len(subtree) == 0 {
+		return repository.ErrOrganizationNotFound
+	}
+
+	if err := s.orgRepo.DeleteCascade(orgID); err != nil {
+		return err
+	}
+
+	// Keycloak 그룹 정리 (DB는 이미 삭제됨, best-effort)
+	var kcErrs []error
+	for _, org := range subtree {
+		if err := s.kcService.DeleteGroup(ctx, org.Name); err != nil {
+			kcErrs = append(kcErrs, fmt.Errorf("group '%s': %w", org.Name, err))
+		}
+	}
+	if len(kcErrs) > 0 {
+		return fmt.Errorf("keycloak group cleanup failed for %d group(s) (DB already updated): %w", len(kcErrs), errors.Join(kcErrs...))
+	}
+	return nil
 }
 
 // SearchOrganizations name/code 필터로 조직 목록 검색 (평면 목록 반환)
@@ -364,9 +386,10 @@ func (s *OrganizationService) UpdateOrganization(id uint, req *model.UpdateOrgan
 }
 
 // DeleteOrganization 조직 삭제 (하위 조직/소속 사용자 존재 시 차단)
-func (s *OrganizationService) DeleteOrganization(id uint) error {
+func (s *OrganizationService) DeleteOrganization(ctx context.Context, id uint) error {
 	// 조직 존재 확인
-	if _, err := s.orgRepo.FindByID(id); err != nil {
+	org, err := s.orgRepo.FindByID(id)
+	if err != nil {
 		return err
 	}
 
@@ -388,7 +411,15 @@ func (s *OrganizationService) DeleteOrganization(id uint) error {
 		return repository.ErrOrganizationHasUsers
 	}
 
-	return s.orgRepo.Delete(id)
+	if err := s.orgRepo.Delete(id); err != nil {
+		return err
+	}
+
+	// Keycloak 그룹 정리 (DB는 이미 삭제됨, best-effort)
+	if err := s.kcService.DeleteGroup(ctx, org.Name); err != nil {
+		return fmt.Errorf("keycloak group cleanup failed (DB already updated): %w", err)
+	}
+	return nil
 }
 
 // --- 사용자-조직 매핑 ---

--- a/src/service/organization_service_test.go
+++ b/src/service/organization_service_test.go
@@ -30,6 +30,7 @@ package service
 //       (INTEGRATION_TEST=1 로 게이팅, DB 미연결 시 skip)
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -55,6 +56,9 @@ func setupOrgServiceTestDB(t *testing.T) *gorm.DB {
 		&model.Organization{},
 		&model.User{},
 		&model.UserOrganization{},
+		&model.RoleMaster{},
+		&model.GroupPlatformRole{},
+		&model.GroupWorkspaceRole{},
 	))
 	return db
 }
@@ -63,6 +67,7 @@ func newTestOrgService(t *testing.T) (*OrganizationService, *gorm.DB) {
 	t.Helper()
 	db := setupOrgServiceTestDB(t)
 	svc := NewOrganizationService(db)
+	svc.kcService = &mockKeycloakService{} // 실제 Keycloak 연동 없이 DB 로직만 검증
 	return svc, db
 }
 
@@ -285,7 +290,7 @@ func TestGetOrganizationByCode_Success(t *testing.T) {
 func TestDeleteOrganization_NotFound(t *testing.T) {
 	svc, _ := newTestOrgService(t)
 
-	err := svc.DeleteOrganization(99999)
+	err := svc.DeleteOrganization(context.Background(), 99999)
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, repository.ErrOrganizationNotFound)
@@ -297,7 +302,7 @@ func TestDeleteOrganization_HasChildren(t *testing.T) {
 	parent := createOrg(t, db, "01", "Parent", nil)
 	createOrg(t, db, "0101", "Child", &parent.ID)
 
-	err := svc.DeleteOrganization(parent.ID)
+	err := svc.DeleteOrganization(context.Background(), parent.ID)
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, repository.ErrOrganizationHasChildren)
@@ -315,7 +320,7 @@ func TestDeleteOrganization_HasUsers(t *testing.T) {
 		OrganizationID: org.ID,
 	}).Error)
 
-	err := svc.DeleteOrganization(org.ID)
+	err := svc.DeleteOrganization(context.Background(), org.ID)
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, repository.ErrOrganizationHasUsers)
@@ -326,7 +331,7 @@ func TestDeleteOrganization_Success(t *testing.T) {
 	svc, db := newTestOrgService(t)
 	org := createOrg(t, db, "01", "Temp", nil)
 
-	err := svc.DeleteOrganization(org.ID)
+	err := svc.DeleteOrganization(context.Background(), org.ID)
 
 	require.NoError(t, err)
 
@@ -334,6 +339,26 @@ func TestDeleteOrganization_Success(t *testing.T) {
 	var count int64
 	db.Model(&model.Organization{}).Where("id = ?", org.ID).Count(&count)
 	assert.Equal(t, int64(0), count)
+}
+
+// TC-DO-05: 조직 삭제 시 group_platform_roles/group_workspace_roles 매핑도 함께 정리됨
+func TestDeleteOrganization_CleansUpGroupRoleMappings(t *testing.T) {
+	svc, db := newTestOrgService(t)
+	org := createOrg(t, db, "01", "Temp", nil)
+
+	role := &model.RoleMaster{Name: "role-do-05"}
+	require.NoError(t, db.Create(role).Error)
+	require.NoError(t, db.Create(&model.GroupPlatformRole{GroupID: org.ID, RoleID: role.ID}).Error)
+	require.NoError(t, db.Create(&model.GroupWorkspaceRole{GroupID: org.ID, WorkspaceID: 1, RoleID: role.ID}).Error)
+
+	err := svc.DeleteOrganization(context.Background(), org.ID)
+	require.NoError(t, err)
+
+	var gprCount, gwrCount int64
+	db.Model(&model.GroupPlatformRole{}).Where("group_id = ?", org.ID).Count(&gprCount)
+	db.Model(&model.GroupWorkspaceRole{}).Where("group_id = ?", org.ID).Count(&gwrCount)
+	assert.Equal(t, int64(0), gprCount)
+	assert.Equal(t, int64(0), gwrCount)
 }
 
 // ── CheckOrganizationDeletable 테스트 ─────────────────────────────────────────
@@ -396,10 +421,33 @@ func TestCheckOrganizationDeletable_Deletable(t *testing.T) {
 func TestDeleteOrganizationCascade_NotFound(t *testing.T) {
 	svc, _ := newTestOrgService(t)
 
-	err := svc.DeleteOrganizationCascade(99999)
+	err := svc.DeleteOrganizationCascade(context.Background(), 99999)
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, repository.ErrOrganizationNotFound)
+}
+
+// TC-DC-02: 하위 조직 및 group-role 매핑까지 함께 cascade 삭제됨
+func TestDeleteOrganizationCascade_Success(t *testing.T) {
+	svc, db := newTestOrgService(t)
+	parent := createOrg(t, db, "01", "Parent", nil)
+	child := createOrg(t, db, "0101", "Child", &parent.ID)
+
+	role := &model.RoleMaster{Name: "role-dc-02"}
+	require.NoError(t, db.Create(role).Error)
+	require.NoError(t, db.Create(&model.GroupPlatformRole{GroupID: parent.ID, RoleID: role.ID}).Error)
+	require.NoError(t, db.Create(&model.GroupWorkspaceRole{GroupID: child.ID, WorkspaceID: 1, RoleID: role.ID}).Error)
+
+	err := svc.DeleteOrganizationCascade(context.Background(), parent.ID)
+	require.NoError(t, err)
+
+	var orgCount, gprCount, gwrCount int64
+	db.Model(&model.Organization{}).Where("id IN ?", []uint{parent.ID, child.ID}).Count(&orgCount)
+	db.Model(&model.GroupPlatformRole{}).Where("group_id = ?", parent.ID).Count(&gprCount)
+	db.Model(&model.GroupWorkspaceRole{}).Where("group_id = ?", child.ID).Count(&gwrCount)
+	assert.Equal(t, int64(0), orgCount)
+	assert.Equal(t, int64(0), gprCount)
+	assert.Equal(t, int64(0), gwrCount)
 }
 
 // ── AssignUserToOrganizations 테스트 ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two related fixes to group/role management, found while reviewing the group-role API surface for gaps after the group platform-role and workspace-role assignment features shipped:

### 1. Deleting a group left orphaned role mappings and a stale Keycloak group

`OrganizationRepository.Delete` / `DeleteCascade` only removed the group's `mcmp_users_organizations` rows — `mcmp_group_platform_roles` and `mcmp_group_workspace_roles` rows referencing the deleted group were never cleaned up, and the corresponding Keycloak group was never deleted either (`KeycloakService` had no `DeleteGroup` method, and `organization_service.go` never called into Keycloak on delete at all).

Because `EnsureGroupExistsAndAssignUser` resolves Keycloak groups **by name**, recreating a group with the same name after deletion would silently reuse the old Keycloak group — including whatever realm roles were still attached to it. A deleted-and-recreated group could end up with role grants nobody explicitly assigned.

Fix: `Delete`/`DeleteCascade` now clean up both mapping tables in the same transaction, and a new `KeycloakService.DeleteGroup` is called from `OrganizationService` after a successful DB delete (best-effort, matching the existing pattern used elsewhere for Keycloak cleanup after DB writes).

### 2. Missing role→group lookup, and a bulk-removal gap in the group API

- `role_handler.go` had role→user lookups (`ListUsersByPlatformRole` / `ListUsersByWorkspaceRole`) but no equivalent role→group lookup, so there was no way to answer "which groups have this role?" for auditing/admin purposes. Added `GET /api/roles/mappings/platform-roles/id/{roleId}/groups` and the workspace-role equivalent.
- `AssignGroupUsers` (adding users to a group) already supported bulk operation, but removing users only supported one at a time (`RemoveGroupUser`). Added `DELETE /api/groups/id/{groupId}/users` for bulk removal, matching the existing bulk-assign endpoint.
- Removed `GroupRoleService.GetAvailableGroupWorkspaces` and `GroupRoleRepository.FindAvailableWorkspacesForGroup` — dead code not wired to any handler, duplicating the actually-used `GetAvailableWorkspaces`/`FindAvailableWorkspaces`.

## Test plan
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./service/... ./repository/... ./handler/...` — all pass except one pre-existing, unrelated failure (`TestValidateMenuResourceIframeRequiresFramework`, confirmed already failing on `develop`)
- [x] New/updated unit tests: mapping cleanup on group delete (single + cascade), role-type exclusion on the reverse lookup, bulk removal success/not-found paths
- [x] Rebuilt this branch into a live dev stack and verified end-to-end via direct API calls: group deletion cleans up both mapping tables, reverse lookup returns/excludes groups correctly, bulk removal works and 404s for a nonexistent group
- [x] Added and ran matching regression tests in the e2e suite against this branch's build (8/8 passed) — see MZC-CSC/mcmp-e2e#5