### PR TITLE
fix: AWS SAML Role 프로비저닝 지원 + ExtendedConfig API 경로 추가

### DIFF
--- a/src/model/request.go
+++ b/src/model/request.go
@@ -90,17 +90,18 @@ type WorkspaceFilterRequest struct {
 }
 
 type CreateCspRoleRequest struct {
-	ID            string               `json:"id,omitempty"`
-	CspRoleName   string               `json:"cspRoleName,omitempty"` // csp의 RoleName. 여러 role이 있기때문에 csp에 정의한 role로 구분하기 위해 사용
-	Description   string               `json:"description,omitempty"`
-	CspType       string               `json:"cspType,omitempty"`
-	AuthMethod    constants.AuthMethod `json:"authMethod,omitempty"` // 인증방식 (OIDC/SAML/SECRET_KEY), 미지정 시 OIDC 기본값
-	IdpIdentifier string               `json:"idpIdentifier,omitempty"`
-	IamIdentifier string               `json:"iamIdentifier,omitempty"`
-	Status        string               `json:"status,omitempty"`
-	Path          string               `json:"path,omitempty"`
-	IamRoleId     string               `json:"iamRoleId,omitempty"`
-	Tags          []Tag                `json:"tags,omitempty" gorm:"-"`
+	ID             string                 `json:"id,omitempty"`
+	CspRoleName    string                 `json:"cspRoleName,omitempty"` // csp의 RoleName. 여러 role이 있기때문에 csp에 정의한 role로 구분하기 위해 사용
+	Description    string                 `json:"description,omitempty"`
+	CspType        string                 `json:"cspType,omitempty"`
+	AuthMethod     constants.AuthMethod   `json:"authMethod,omitempty"` // 인증방식 (OIDC/SAML/SECRET_KEY), 미지정 시 OIDC 기본값
+	IdpIdentifier  string                 `json:"idpIdentifier,omitempty"`
+	IamIdentifier  string                 `json:"iamIdentifier,omitempty"`
+	Status         string                 `json:"status,omitempty"`
+	Path           string                 `json:"path,omitempty"`
+	IamRoleId      string                 `json:"iamRoleId,omitempty"`
+	Tags           []Tag                  `json:"tags,omitempty" gorm:"-"`
+	ExtendedConfig map[string]interface{} `json:"extendedConfig,omitempty"`
 }
 
 // CreateCspRolesRequest 복수 CSP 역할 생성 요청 구조체

--- a/src/service/csp_role_service.go
+++ b/src/service/csp_role_service.go
@@ -184,7 +184,13 @@ func (s *CspRoleService) createAwsIamRole(req *model.CreateCspRoleRequest) (*mod
 func (s *CspRoleService) createAndPollAwsIamRole(awsIamClient *iam.Client, newRole *model.CspRole, req *model.CreateCspRoleRequest) (*model.CspRole, error) {
 	idpIdentifier := ""
 
-	assumeRolePolicyDocument, err := getAwsAssumeRolePolicyDocument(newRole)
+	var assumeRolePolicyDocument string
+	var err error
+	if req.AuthMethod == constants.AuthMethodSAML {
+		assumeRolePolicyDocument, err = getAwsSamlAssumeRolePolicyDocument(req)
+	} else {
+		assumeRolePolicyDocument, err = getAwsAssumeRolePolicyDocument(newRole)
+	}
 	if err != nil {
 		newRole.Status = "failed"
 		s.cspRoleRepo.UpdateCspRoleRecord(newRole)
@@ -377,6 +383,55 @@ func getAwsAssumeRolePolicyDocument(role *model.CspRole) (string, error) {
 	return buf.String(), nil
 }
 
+// awsSamlPolicyValues AWS SAML AssumeRole 정책 문서 템플릿에 채울 값
+type awsSamlPolicyValues struct {
+	SamlProviderArn string
+}
+
+// getAwsSamlAssumeRolePolicyDocument SAML federation용 AssumeRole 정책 문서를 반환합니다.
+// SAML Provider ARN(req.IdpIdentifier, 사전에 `aws iam create-saml-provider`로 등록된 값)을
+// Federated principal로 사용한다. OIDC와 달리 발급자 정보가 env var로 결정되지 않고
+// 호출자가 등록한 SAML Provider 하나하나가 곧 신뢰 대상이므로 req에서 직접 받는다.
+func getAwsSamlAssumeRolePolicyDocument(req *model.CreateCspRoleRequest) (string, error) {
+	const policyTemplate = `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "{{.SamlProviderArn}}"
+				},
+				"Action": "sts:AssumeRoleWithSAML",
+				"Condition": {
+					"StringEquals": {
+						"SAML:aud": "https://signin.aws.amazon.com/saml"
+					}
+				}
+			}
+		]
+	}`
+
+	if req.IdpIdentifier == "" {
+		return "", fmt.Errorf("idpIdentifier (SAML provider ARN) is required for SAML CSP role creation")
+	}
+
+	values := awsSamlPolicyValues{
+		SamlProviderArn: req.IdpIdentifier,
+	}
+
+	tmpl, err := template.New("samlPolicy").Parse(policyTemplate)
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, values)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
 // mapAwsRoleToModel AWS IAM GetRole 응답을 CspRole 모델로 매핑합니다.
 func mapAwsRoleToModel(id uint, cspType string, idpIdentifier string, getRoleResult *iam.GetRoleOutput) *model.CspRole {
 	createdRole := &model.CspRole{
@@ -530,7 +585,13 @@ func (s *CspRoleService) UpdateCspRole(id uint, req *model.CreateCspRoleRequest)
 	}
 	existingRole.Name = req.CspRoleName
 	existingRole.Description = req.Description
-	return s.cspRoleRepo.UpdateCSPRole(existingRole)
+	if len(req.ExtendedConfig) > 0 {
+		existingRole.ExtendedConfig = req.ExtendedConfig
+	}
+	// DB 전용 업데이트로 변경 (기존에는 CspType 무관하게 항상 AWS UpdateRoleDescription을
+	// 호출해 GCP/Alibaba 등 비-AWS CspRole 수정 시 항상 실패했다 — SAML ExtendedConfig를
+	// 모든 CSP에서 API로 설정 가능하게 하려면 이 경로도 함께 고쳐야 한다).
+	return s.cspRoleRepo.UpdateCspRoleRecord(existingRole)
 }
 
 // DeleteCspRole CSP 역할을 삭제합니다.

--- a/src/service/csp_role_service_test.go
+++ b/src/service/csp_role_service_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/m-cmp/mc-iam-manager/constants"
@@ -55,4 +56,74 @@ func TestCreateCspRole_Alibaba_PersistsIdentifiers(t *testing.T) {
 
 	assert.Equal(t, req.IdpIdentifier, role.IdpIdentifier)
 	assert.Equal(t, req.IamIdentifier, role.IamIdentifier)
+}
+
+// TestGetAwsSamlAssumeRolePolicyDocument_Success: AWS SAML CspRole 생성 시
+// trust policy가 SAML Provider ARN을 Federated principal로, sts:AssumeRoleWithSAML을
+// Action으로 갖는지 확인한다 (기존 OIDC 전용 getAwsAssumeRolePolicyDocument와 별도 경로).
+func TestGetAwsSamlAssumeRolePolicyDocument_Success(t *testing.T) {
+	req := &model.CreateCspRoleRequest{
+		CspRoleName:   "mciam-admin-saml",
+		CspType:       "aws",
+		AuthMethod:    constants.AuthMethodSAML,
+		IdpIdentifier: "arn:aws:iam::050864702683:saml-provider/mcmp-dev-cscmzc-com-saml",
+	}
+
+	doc, err := getAwsSamlAssumeRolePolicyDocument(req)
+	require.NoError(t, err)
+
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(doc), &parsed))
+
+	statements := parsed["Statement"].([]interface{})
+	require.Len(t, statements, 1)
+	statement := statements[0].(map[string]interface{})
+
+	assert.Equal(t, "sts:AssumeRoleWithSAML", statement["Action"])
+	principal := statement["Principal"].(map[string]interface{})
+	assert.Equal(t, req.IdpIdentifier, principal["Federated"])
+	condition := statement["Condition"].(map[string]interface{})
+	stringEquals := condition["StringEquals"].(map[string]interface{})
+	assert.Equal(t, "https://signin.aws.amazon.com/saml", stringEquals["SAML:aud"])
+}
+
+// TestGetAwsSamlAssumeRolePolicyDocument_MissingIdpIdentifier: SAML Provider ARN
+// 없이는 trust policy를 만들 수 없으므로 명시적으로 에러를 반환해야 한다.
+func TestGetAwsSamlAssumeRolePolicyDocument_MissingIdpIdentifier(t *testing.T) {
+	req := &model.CreateCspRoleRequest{
+		CspRoleName: "mciam-admin-saml",
+		CspType:     "aws",
+		AuthMethod:  constants.AuthMethodSAML,
+	}
+
+	_, err := getAwsSamlAssumeRolePolicyDocument(req)
+	assert.Error(t, err)
+}
+
+// TestUpdateCspRole_PersistsExtendedConfig: SAML 발급에 필수인
+// ExtendedConfig["saml_client_id"]를 raw SQL이 아니라 UpdateCspRole API로
+// 설정할 수 있어야 한다.
+func TestUpdateCspRole_PersistsExtendedConfig(t *testing.T) {
+	svc := newTestCspRoleService(t)
+
+	created, err := svc.CreateCspRole(&model.CreateCspRoleRequest{
+		CspRoleName:   "mcmp-admin-extcfg",
+		CspType:       "gcp",
+		AuthMethod:    constants.AuthMethodOIDC,
+		IdpIdentifier: "//iam.googleapis.com/projects/x/locations/global/workloadIdentityPools/p/providers/pr",
+		IamIdentifier: "sa@project.iam.gserviceaccount.com",
+	})
+	require.NoError(t, err)
+
+	err = svc.UpdateCspRole(created.ID, &model.CreateCspRoleRequest{
+		CspRoleName: created.Name,
+		ExtendedConfig: map[string]interface{}{
+			"saml_client_id": "urn:amazon:webservices",
+		},
+	})
+	require.NoError(t, err)
+
+	updated, err := svc.GetCspRoleByID(created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "urn:amazon:webservices", updated.ExtendedConfig["saml_client_id"])
 }


### PR DESCRIPTION
## Summary

1. **`CreateCspRoleRequest`에 `ExtendedConfig` 필드 추가** — SAML 발급 시 필수인 `CspRole.ExtendedConfig["saml_client_id"]`를 API로 설정할 방법이 없었고, 기존 에러 메시지조차 raw SQL(`UPDATE mcmp_role_csp_roles SET extended_config=...`)을 안내하는 상태였다.
2. **`UpdateCspRole`의 숨은 버그 수정** — 기존에는 `CspType`과 무관하게 항상 AWS `UpdateRoleDescription`을 호출했다. 그 결과 GCP/Alibaba 등 비-AWS `CspRole`을 수정하려 하면 항상 실패했다(AWS 임시자격증명 조회 시도 → 실패). DB 전용 `UpdateCspRoleRecord`로 교체.
3. **`createAwsIamRole`에 SAML trust policy 생성 분기 추가** — 신규 AWS Role 생성 시 항상 OIDC(`AssumeRoleWithWebIdentity`) 정책만 생성했다. `req.AuthMethod == SAML`이면 `getAwsSamlAssumeRolePolicyDocument`로 `Federated: <SAML Provider ARN>` + `Action: sts:AssumeRoleWithSAML` 정책을 생성하도록 분기 추가.
