### PR TITLE
fix: CspRole 수정 API 라우트 누락 수정

### DIFF
--- a/src/handler/role_handler.go
+++ b/src/handler/role_handler.go
@@ -901,6 +901,44 @@ func (h *RoleHandler) CreateCspRole(c echo.Context) error {
 	return c.JSON(http.StatusCreated, createdRole)
 }
 
+// @Summary Update CSP role
+// @Description CspRole(mcmp_role_csp_roles) 레코드를 수정합니다. Name/Description/ExtendedConfig를 반영합니다.
+// @Description AWS의 경우 클라우드 측 리소스는 건드리지 않고 DB만 갱신합니다(SAML saml_client_id 등 설정용).
+// @Tags roles
+// @Accept json
+// @Produce json
+// @Param roleId path string true "CSP Role ID"
+// @Param role body model.CreateCspRoleRequest true "CSP Role Info"
+// @Success 200 {object} model.CspRole
+// @Failure 400 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Security BearerAuth
+// @Router /api/roles/csp/id/{roleId} [put]
+// @Id updateCspRoleRecord
+func (h *RoleHandler) UpdateCspRoleRecord(c echo.Context) error {
+	roleIDInt, err := util.StringToUint(c.Param("roleId"))
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "잘못된 csp 역할 ID 형식입니다"})
+	}
+
+	var req model.CreateCspRoleRequest
+	if err := c.Bind(&req); err != nil {
+		c.Logger().Debugf("Bind error: %v", err)
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "잘못된 요청 형식입니다"})
+	}
+
+	if err := h.cspRoleService.UpdateCspRole(roleIDInt, &req); err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	updatedRole, err := h.cspRoleService.GetCspRoleByID(roleIDInt)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	return c.JSON(http.StatusOK, updatedRole)
+}
+
 // @Summary Get platform role by ID
 // @Description Get platform role details by ID
 // @Tags roles

--- a/src/main.go
+++ b/src/main.go
@@ -339,6 +339,7 @@ func main() {
 		roles.POST("/csp/batch", roleHandler.CreateCspRoles)
 		//roles.DELETE("/csp", roleHandler.DeleteCspRole)
 		roles.DELETE("/csp/id/:roleId", roleHandler.DeleteCspRole) //단건삭제
+		roles.PUT("/csp/id/:roleId", roleHandler.UpdateCspRoleRecord)
 		roles.GET("/csp/id/:roleId", roleHandler.GetCspRoleByID)
 		roles.GET("/csp/name/:roleName", roleHandler.GetCspRoleByName)
 

--- a/src/model/request.go
+++ b/src/model/request.go
@@ -102,6 +102,7 @@ type CreateCspRoleRequest struct {
 	IamRoleId      string                 `json:"iamRoleId,omitempty"`
 	Tags           []Tag                  `json:"tags,omitempty" gorm:"-"`
 	ExtendedConfig map[string]interface{} `json:"extendedConfig,omitempty"`
+	CspIdpConfigID *uint                  `json:"cspIdpConfigId,omitempty"` // 이 CspRole이 사용할 CspIdpConfig(OIDC/SAML 등 트러스트 설정) 연결
 }
 
 // CreateCspRolesRequest 복수 CSP 역할 생성 요청 구조체

--- a/src/service/csp_role_service.go
+++ b/src/service/csp_role_service.go
@@ -588,6 +588,9 @@ func (s *CspRoleService) UpdateCspRole(id uint, req *model.CreateCspRoleRequest)
 	if len(req.ExtendedConfig) > 0 {
 		existingRole.ExtendedConfig = req.ExtendedConfig
 	}
+	if req.CspIdpConfigID != nil {
+		existingRole.CspIdpConfigID = req.CspIdpConfigID
+	}
 	// DB 전용 업데이트로 변경 (기존에는 CspType 무관하게 항상 AWS UpdateRoleDescription을
 	// 호출해 GCP/Alibaba 등 비-AWS CspRole 수정 시 항상 실패했다 — SAML ExtendedConfig를
 	// 모든 CSP에서 API로 설정 가능하게 하려면 이 경로도 함께 고쳐야 한다).

--- a/src/service/csp_role_service_test.go
+++ b/src/service/csp_role_service_test.go
@@ -127,3 +127,31 @@ func TestUpdateCspRole_PersistsExtendedConfig(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "urn:amazon:webservices", updated.ExtendedConfig["saml_client_id"])
 }
+
+// TestUpdateCspRole_PersistsCspIdpConfigID: CspRole이 어떤 CspIdpConfig(OIDC/SAML
+// 트러스트 설정)를 쓸지는 CspIdpConfigID FK로 연결되는데, 이 필드를 설정할 API가
+// 없었다(raw SQL만 가능). UpdateCspRole로 설정 가능해야 한다.
+func TestUpdateCspRole_PersistsCspIdpConfigID(t *testing.T) {
+	svc := newTestCspRoleService(t)
+
+	created, err := svc.CreateCspRole(&model.CreateCspRoleRequest{
+		CspRoleName:   "mcmp-admin-idpcfg",
+		CspType:       "gcp",
+		AuthMethod:    constants.AuthMethodOIDC,
+		IdpIdentifier: "//iam.googleapis.com/projects/x/locations/global/workloadIdentityPools/p/providers/pr",
+		IamIdentifier: "sa@project.iam.gserviceaccount.com",
+	})
+	require.NoError(t, err)
+
+	idpConfigID := uint(42)
+	err = svc.UpdateCspRole(created.ID, &model.CreateCspRoleRequest{
+		CspRoleName:    created.Name,
+		CspIdpConfigID: &idpConfigID,
+	})
+	require.NoError(t, err)
+
+	updated, err := svc.GetCspRoleByID(created.ID)
+	require.NoError(t, err)
+	require.NotNil(t, updated.CspIdpConfigID)
+	assert.Equal(t, idpConfigID, *updated.CspIdpConfigID)
+}


### PR DESCRIPTION
## 개요 
`handler/role_handler.go`의 기존 `UpdateCspRole` 함수는 이름은 같지만 실제로는 `RoleMaster`(mc-iam-manager 자체 역할 계층)를 다루는 별개 핸들러이고, swagger 주석에 `@Router /api/roles/csp-roles/id/{roleId} [put]`라고 적혀 있음에도 `main.go`에 등록조차 안 되어 있었다. 
## 변경 사항

- `RoleHandler.UpdateCspRoleRecord` 신규 핸들러 추가 — `cspRoleService.UpdateCspRole` 호출
- `PUT /api/roles/csp/id/:roleId` 라우트 등록 (기존 `POST`/`GET`/`DELETE /api/roles/csp/id/:roleId`와 동일 URL 패밀리)
