### PR TITLE
fix: validate role type on group role assignment

### DIFF
--- a/src/handler/group_role_handler.go
+++ b/src/handler/group_role_handler.go
@@ -342,10 +342,14 @@ func (h *GroupRoleHandler) UpdateGroupWorkspaceRole(c echo.Context) error {
 	}
 
 	if err := h.groupRoleService.UpdateGroupWorkspaceRole(uint(groupID), uint(workspaceID), req.RoleID); err != nil {
-		if errors.Is(err, repository.ErrGroupWorkspaceRoleNotFound) {
+		switch {
+		case errors.Is(err, repository.ErrGroupWorkspaceRoleNotFound):
 			return c.JSON(http.StatusNotFound, map[string]string{"error": "매핑을 찾을 수 없습니다"})
+		case errors.Is(err, repository.ErrRoleMasterNotFound):
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "워크스페이스 역할을 찾을 수 없습니다"})
+		default:
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		}
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}
 
 	return c.JSON(http.StatusOK, map[string]string{"message": "그룹 워크스페이스 역할이 변경되었습니다."})

--- a/src/service/group_role_service.go
+++ b/src/service/group_role_service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/m-cmp/mc-iam-manager/constants"
 	"github.com/m-cmp/mc-iam-manager/model"
 	"github.com/m-cmp/mc-iam-manager/repository"
 	"gorm.io/gorm"
@@ -15,6 +16,7 @@ type GroupRoleService struct {
 	db            *gorm.DB
 	groupRoleRepo *repository.GroupRoleRepository
 	orgRepo       *repository.OrganizationRepository
+	roleRepo      *repository.RoleRepository
 	kcService     KeycloakService
 }
 
@@ -24,6 +26,7 @@ func NewGroupRoleService(db *gorm.DB) *GroupRoleService {
 		db:            db,
 		groupRoleRepo: repository.NewGroupRoleRepository(db),
 		orgRepo:       repository.NewOrganizationRepository(db),
+		roleRepo:      repository.NewRoleRepository(db),
 		kcService:     NewKeycloakService(),
 	}
 }
@@ -38,13 +41,13 @@ func (s *GroupRoleService) AssignGroupPlatformRole(ctx context.Context, groupID,
 		return err
 	}
 
-	// 2. Role 이름 조회
-	var roleMaster model.RoleMaster
-	if err := s.db.First(&roleMaster, roleID).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return repository.ErrRoleMasterNotFound
-		}
+	// 2. Role 조회 (platform 타입 역할만 그룹에 할당 가능)
+	role, err := s.roleRepo.FindRoleByRoleID(roleID, constants.RoleTypePlatform)
+	if err != nil {
 		return fmt.Errorf("role not found: %w", err)
+	}
+	if role == nil {
+		return repository.ErrRoleMasterNotFound
 	}
 
 	// 3. DB에 저장
@@ -53,7 +56,7 @@ func (s *GroupRoleService) AssignGroupPlatformRole(ctx context.Context, groupID,
 	}
 
 	// 4. Keycloak: 그룹에 realm role 추가
-	if err := s.kcService.AddRealmRoleToGroup(ctx, org.Name, roleMaster.Name); err != nil {
+	if err := s.kcService.AddRealmRoleToGroup(ctx, org.Name, role.Name); err != nil {
 		// DB rollback
 		_ = s.groupRoleRepo.DeleteGroupPlatformRole(groupID, roleID)
 		return fmt.Errorf("failed to assign role to keycloak group: %w", err)
@@ -130,13 +133,13 @@ func (s *GroupRoleService) AssignGroupWorkspace(groupID, workspaceID, roleID uin
 		}
 		return fmt.Errorf("error checking workspace: %w", err)
 	}
-	// role 존재 여부 확인
-	var roleMaster model.RoleMaster
-	if err := s.db.First(&roleMaster, roleID).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return repository.ErrRoleMasterNotFound
-		}
+	// role 존재 여부 확인 (workspace 타입 역할만 그룹-워크스페이스에 할당 가능)
+	role, err := s.roleRepo.FindRoleByRoleID(roleID, constants.RoleTypeWorkspace)
+	if err != nil {
 		return fmt.Errorf("error checking role: %w", err)
+	}
+	if role == nil {
+		return repository.ErrRoleMasterNotFound
 	}
 	return s.groupRoleRepo.CreateGroupWorkspaceRole(groupID, workspaceID, roleID)
 }
@@ -148,6 +151,14 @@ func (s *GroupRoleService) GetGroupWorkspaces(groupID uint) ([]model.GroupWorksp
 
 // UpdateGroupWorkspaceRole 그룹-워크스페이스 역할 변경
 func (s *GroupRoleService) UpdateGroupWorkspaceRole(groupID, workspaceID, roleID uint) error {
+	// role 존재 여부 확인 (workspace 타입 역할만 할당 가능)
+	role, err := s.roleRepo.FindRoleByRoleID(roleID, constants.RoleTypeWorkspace)
+	if err != nil {
+		return fmt.Errorf("error checking role: %w", err)
+	}
+	if role == nil {
+		return repository.ErrRoleMasterNotFound
+	}
 	return s.groupRoleRepo.UpdateGroupWorkspaceRole(groupID, workspaceID, roleID)
 }
 

--- a/src/service/group_role_service_test.go
+++ b/src/service/group_role_service_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/m-cmp/mc-iam-manager/constants"
 	"github.com/m-cmp/mc-iam-manager/model"
 	"github.com/m-cmp/mc-iam-manager/repository"
 	"github.com/stretchr/testify/assert"
@@ -48,6 +49,7 @@ func newTestGroupRoleService(t *testing.T) (*GroupRoleService, *gorm.DB) {
 		db:            db,
 		groupRoleRepo: repository.NewGroupRoleRepository(db),
 		orgRepo:       repository.NewOrganizationRepository(db),
+		roleRepo:      repository.NewRoleRepository(db),
 		kcService:     nil, // KC 불필요한 메서드만 테스트
 	}
 	return svc, db
@@ -64,6 +66,8 @@ func createGRTestRole(t *testing.T, db *gorm.DB, name string) *model.RoleMaster 
 	t.Helper()
 	role := &model.RoleMaster{Name: name}
 	require.NoError(t, db.Create(role).Error)
+	require.NoError(t, db.Create(&model.RoleSub{RoleID: role.ID, RoleType: constants.RoleTypePlatform}).Error)
+	require.NoError(t, db.Create(&model.RoleSub{RoleID: role.ID, RoleType: constants.RoleTypeWorkspace}).Error)
 	return role
 }
 
@@ -99,6 +103,22 @@ func TestGroupRoleAssignPlatformRole_RoleNotFound(t *testing.T) {
 	svc.kcService = nil // KC nil이면 KC 이전에서 실패
 
 	err := svc.AssignGroupPlatformRole(context.Background(), org.ID, 99999)
+
+	require.Error(t, err)
+	assert.Equal(t, repository.ErrRoleMasterNotFound, err)
+}
+
+// TC-GR-APR-03: workspace 전용 역할을 플랫폼 역할로 할당 시도 → ErrRoleMasterNotFound
+// (roleMaster-roleSub에서 workspace 타입인 역할은 platform-role 자리에 할당될 수 없어야 한다)
+func TestGroupRoleAssignPlatformRole_WrongRoleType(t *testing.T) {
+	svc, db := newTestGroupRoleService(t)
+	org := createGRTestOrg(t, db, "test-group-apr03", "GR03")
+
+	workspaceOnlyRole := &model.RoleMaster{Name: "workspace-only-apr03"}
+	require.NoError(t, db.Create(workspaceOnlyRole).Error)
+	require.NoError(t, db.Create(&model.RoleSub{RoleID: workspaceOnlyRole.ID, RoleType: constants.RoleTypeWorkspace}).Error)
+
+	err := svc.AssignGroupPlatformRole(context.Background(), org.ID, workspaceOnlyRole.ID)
 
 	require.Error(t, err)
 	assert.Equal(t, repository.ErrRoleMasterNotFound, err)
@@ -140,6 +160,23 @@ func TestGroupRoleAssignGroupWorkspace_Success(t *testing.T) {
 	err := svc.AssignGroupWorkspace(org.ID, ws.ID, role.ID)
 
 	require.NoError(t, err)
+}
+
+// TC-GR-AGW-04: platform 전용 역할을 워크스페이스 역할로 할당 시도 → ErrRoleMasterNotFound
+// (roleMaster-roleSub에서 platform 타입인 역할은 group-workspace 자리에 할당될 수 없어야 한다)
+func TestGroupRoleAssignGroupWorkspace_WrongRoleType(t *testing.T) {
+	svc, db := newTestGroupRoleService(t)
+	org := createGRTestOrg(t, db, "test-group-agw04", "GW04")
+	ws := createGRTestWorkspace(t, db, "ws-agw04")
+
+	platformOnlyRole := &model.RoleMaster{Name: "platform-only-agw04"}
+	require.NoError(t, db.Create(platformOnlyRole).Error)
+	require.NoError(t, db.Create(&model.RoleSub{RoleID: platformOnlyRole.ID, RoleType: constants.RoleTypePlatform}).Error)
+
+	err := svc.AssignGroupWorkspace(org.ID, ws.ID, platformOnlyRole.ID)
+
+	require.Error(t, err)
+	assert.Equal(t, repository.ErrRoleMasterNotFound, err)
 }
 
 // ── GetGroupWorkspaces ────────────────────────────────────────────────────────
@@ -315,6 +352,7 @@ func setupGroupRoleServiceTestDB(t *testing.T) *gorm.DB {
 		&model.Organization{},
 		&model.Workspace{},
 		&model.RoleMaster{},
+		&model.RoleSub{},
 		&model.GroupPlatformRole{},
 		&model.GroupWorkspaceRole{},
 	)
@@ -340,6 +378,8 @@ func seedRole(t *testing.T, db *gorm.DB, name string) *model.RoleMaster {
 	t.Helper()
 	role := &model.RoleMaster{Name: name}
 	require.NoError(t, db.Create(role).Error)
+	require.NoError(t, db.Create(&model.RoleSub{RoleID: role.ID, RoleType: constants.RoleTypePlatform}).Error)
+	require.NoError(t, db.Create(&model.RoleSub{RoleID: role.ID, RoleType: constants.RoleTypeWorkspace}).Error)
 	return role
 }
 
@@ -446,8 +486,9 @@ func TestGroupRoleService_UpdateGroupWorkspaceRole(t *testing.T) {
 func TestGroupRoleService_UpdateGroupWorkspaceRole_NotFound(t *testing.T) {
 	db := setupGroupRoleServiceTestDB(t)
 	svc := NewGroupRoleService(db)
+	role := seedRole(t, db, "svc-notfound-role")
 
-	err := svc.UpdateGroupWorkspaceRole(9999, 9999, 1)
+	err := svc.UpdateGroupWorkspaceRole(9999, 9999, role.ID)
 	assert.ErrorIs(t, err, repository.ErrGroupWorkspaceRoleNotFound)
 }
 


### PR DESCRIPTION
## Summary

`GroupRoleService.AssignGroupPlatformRole` / `AssignGroupWorkspace` / `UpdateGroupWorkspaceRole` only checked that the given `role_id` existed — not that its `RoleSub.RoleType` actually matched the slot being assigned (platform vs workspace).

The equivalent user-level assignment (`RoleService.AssignPlatformRole` / `AssignWorkspaceRole`) already validates this by looking up the role filtered by type. Group-level assignment was missing the same check, so a workspace-typed role could be assigned as a group's platform role (or a platform-typed role assigned to a group-workspace mapping) with no error — breaking the invariant that platform/workspace roles stay in their respective slots.

Fix: all three group-role assignment paths now resolve the role via `roleRepo.FindRoleByRoleID(roleID, expectedType)` and return `ErrRoleMasterNotFound` when the type doesn't match, mirroring the existing user-level pattern.
