### PR TITLE
fix: Tencent AssumeRoleWithSAML TC3 서명 거부 버그 수정

### DIFF
--- a/src/service/tencent_credential_service.go
+++ b/src/service/tencent_credential_service.go
@@ -115,12 +115,6 @@ func (s *tencentCredentialService) AssumeRoleWithSAML(
 
 	now := time.Now().UTC()
 	timestamp := fmt.Sprintf("%d", now.Unix())
-	date := now.Format("2006-01-02")
-
-	authHeader, err := buildTencentTC3Auth(secretID, secretKey, date, timestamp, string(payloadBytes))
-	if err != nil {
-		return nil, fmt.Errorf("failed to build Tencent TC3 signature: %w", err)
-	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tencentStsEndpoint, strings.NewReader(string(payloadBytes)))
 	if err != nil {
@@ -131,7 +125,11 @@ func (s *tencentCredentialService) AssumeRoleWithSAML(
 	req.Header.Set("X-TC-Action", "AssumeRoleWithSAML")
 	req.Header.Set("X-TC-Version", tencentStsVersion)
 	req.Header.Set("X-TC-Timestamp", timestamp)
-	req.Header.Set("Authorization", authHeader)
+	// AssumeRoleWithSAML은 AWS/Alibaba/GCP의 SAML/OIDC federation entry point와 마찬가지로
+	// 사전 자격증명 없이 호출 가능한 진입점이라 TC3-HMAC-SHA256 서명을 요구하지 않는다.
+	// Tencent 문서상 Authorization 헤더는 리터럴 문자열 "SKIP"이어야 한다 — 서명을 보내면
+	// "Must be SKIP" 오류로 거부된다(실 API 호출로 확인, 039 Phase 2).
+	req.Header.Set("Authorization", "SKIP")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/src/service/tencent_credential_service.go
+++ b/src/service/tencent_credential_service.go
@@ -107,7 +107,6 @@ func (s *tencentCredentialService) AssumeRoleWithSAML(
 		"PrincipalArn":    principalArn,
 		"SAMLAssertion":   samlAssertion,
 		"RoleSessionName": sessionName,
-		"Region":          region,
 	}
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
@@ -126,6 +125,7 @@ func (s *tencentCredentialService) AssumeRoleWithSAML(
 	req.Header.Set("X-TC-Action", "AssumeRoleWithSAML")
 	req.Header.Set("X-TC-Version", tencentStsVersion)
 	req.Header.Set("X-TC-Timestamp", timestamp)
+	req.Header.Set("X-TC-Region", region)
 	// AssumeRoleWithSAML은 AWS/Alibaba/GCP의 SAML/OIDC federation entry point와 마찬가지로
 	// 사전 자격증명 없이 호출 가능한 진입점이라 TC3-HMAC-SHA256 서명을 요구하지 않는다.
 	// Tencent 문서상 Authorization 헤더는 리터럴 문자열 "SKIP"이어야 한다 — 서명을 보내면

--- a/src/service/tencent_credential_service.go
+++ b/src/service/tencent_credential_service.go
@@ -107,6 +107,7 @@ func (s *tencentCredentialService) AssumeRoleWithSAML(
 		"PrincipalArn":    principalArn,
 		"SAMLAssertion":   samlAssertion,
 		"RoleSessionName": sessionName,
+		"Region":          region,
 	}
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {


### PR DESCRIPTION
## 배경

039_SAML방식CSP확장 Phase 2(Tencent) 실인프라 검증 중 발견. Tencent STS의 `AssumeRoleWithSAML`은 AWS `AssumeRoleWithSAML`/Alibaba `AssumeRoleWithSAML`/GCP WIF token-exchange와 동일하게, 사전에 유효한 자격증명 없이 외부 IdP가 발급한 SAML assertion만으로 호출 가능해야 하는 federation entry point다.

기존 코드(`tencent_credential_service.go`)는 이 액션 호출 시에도 항상 TC3-HMAC-SHA256으로 서명한 `Authorization` 헤더를 보내고 있었다. 실제 Tencent STS API에 호출해보니 `AuthFailure.InvalidAuthorization: ... Must be SKIP`으로 매번 거부됐다 — Tencent 문서상 이 액션은 `Authorization: SKIP` 리터럴 문자열을 요구한다.

기존 단위테스트(`TestGetTemporaryCredentials_Tencent_SAML_Success`)는 `tencentCredService.AssumeRoleWithSAML`을 인터페이스 레벨에서 mock하기 때문에 실제 HTTP 헤더 내용을 검증하지 않아 이 버그가 발견되지 못했다.

## 변경 사항

- `AssumeRoleWithSAML`의 `Authorization` 헤더를 TC3 서명 대신 리터럴 `"SKIP"`으로 고정
- 이제 사용되지 않는 TC3 서명 관련 지역 변수(`date`) 제거
