### PR TITLE
feat(M4-CSP): Tencent OIDC 기반 임시 자격증명 발급(AssumeRoleWithWebIdentity) 추가

### DIFF
--- a/src/service/csp_credential_service.go
+++ b/src/service/csp_credential_service.go
@@ -349,6 +349,28 @@ func (s *CspCredentialService) GetTemporaryCredentials(ctx context.Context, user
 		}
 	case "tencent":
 		switch authMethod {
+		case model.AuthMethodOIDC:
+			secretID := ""
+			secretKey := ""
+			if targetCspRole.CspIdpConfig != nil {
+				secretID = targetCspRole.CspIdpConfig.Config["secret_id"]
+				secretKey = targetCspRole.CspIdpConfig.Config["secret_key"]
+			}
+			// SAML 경로와 동일하게 secret_id/secret_key 설정을 요구한다. Authorization: SKIP 특성상
+			// STS 호출 자체에는 필요 없을 수 있지만(SAML에서 확인된 내용), 일관성을 위해 유지 —
+			// 불필요 여부 확인 및 요건 완화는 이 작업 범위 밖.
+			if secretID == "" || secretKey == "" {
+				return nil, fmt.Errorf("Tencent OIDC requires secret_id and secret_key in CspIdpConfig")
+			}
+			impersonationToken, err := s.keycloakService.GetImpersonationTokenByServiceAccount(ctx)
+			if err != nil {
+				log.Printf("[CSP_CREDENTIAL] Error getting impersonation token for Tencent: %v", err)
+				return nil, fmt.Errorf("failed to get impersonation token for Tencent: %w", err)
+			}
+			// GCP/Alibaba OIDC와 동일한 이유로 AccessToken이 아니라 IDToken을 사용해야 한다 —
+			// Tencent STS ProviderId="OIDC" 검증은 aud가 등록된 Client ID와 일치하는 ID Token을 요구한다.
+			log.Printf("[CSP_CREDENTIAL] Calling Tencent AssumeRoleWithWebIdentity...")
+			return s.tencentCredService.AssumeRoleWithWebIdentity(ctx, secretID, secretKey, roleArn, "OIDC", impersonationToken.IDToken, region)
 		case model.AuthMethodSAML:
 			secretID := ""
 			secretKey := ""

--- a/src/service/csp_credential_service_test.go
+++ b/src/service/csp_credential_service_test.go
@@ -483,6 +483,72 @@ func TestGetTemporaryCredentials_Tencent_SAML_MissingConfig(t *testing.T) {
 	assert.Contains(t, err.Error(), "Tencent SAML requires secret_id and secret_key")
 }
 
+// TC-CRED-17c: Tencent OIDC — 정상 발급
+func TestGetTemporaryCredentials_Tencent_OIDC_Success(t *testing.T) {
+	config := map[string]string{
+		"secret_id":  "my-secret-id",
+		"secret_key": "my-secret-key",
+	}
+	svc := newCredServiceWithMocks(credServiceDeps{
+		aws:      &mockAwsCredService{},
+		gcp:      &mockGcpCredService{},
+		alibaba:  &mockAlibabaCredService{},
+		azure:    &mockAzureCredService{},
+		tencent:  &mockTencentCredService{oidcResult: tencentOidcCred},
+		ibm:      &mockIbmCredService{},
+		kc:       oidcKC(),
+		userRepo: &mockUserRepoForCred{role: stdUserRole()},
+		mapRepo:  &mockCspMappingRepo{mapping: buildMapping(constants.AuthMethodOIDC, idpArn, roleArn, model.AuthMethodOIDC, config)},
+	})
+
+	cred, err := svc.GetTemporaryCredentials(context.Background(), 1, "kc_user_id", req("tencent", "OIDC"))
+	require.NoError(t, err)
+	assert.Equal(t, "STS_TENCENT_OIDC", cred.AccessKeyId)
+	assert.Equal(t, "tencent", cred.CspType)
+}
+
+// TC-CRED-17d: Tencent OIDC — config 누락 → 에러
+func TestGetTemporaryCredentials_Tencent_OIDC_MissingConfig(t *testing.T) {
+	svc := newCredServiceWithMocks(credServiceDeps{
+		aws:      &mockAwsCredService{},
+		gcp:      &mockGcpCredService{},
+		alibaba:  &mockAlibabaCredService{},
+		azure:    &mockAzureCredService{},
+		tencent:  &mockTencentCredService{},
+		ibm:      &mockIbmCredService{},
+		kc:       oidcKC(),
+		userRepo: &mockUserRepoForCred{role: stdUserRole()},
+		mapRepo:  &mockCspMappingRepo{mapping: buildMapping(constants.AuthMethodOIDC, idpArn, roleArn, model.AuthMethodOIDC, nil)},
+	})
+
+	_, err := svc.GetTemporaryCredentials(context.Background(), 1, "kc_user_id", req("tencent", "OIDC"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Tencent OIDC requires secret_id and secret_key")
+}
+
+// TC-CRED-17e: Tencent OIDC — Keycloak 토큰 획득 실패
+func TestGetTemporaryCredentials_Tencent_OIDC_KeycloakFail(t *testing.T) {
+	config := map[string]string{
+		"secret_id":  "my-secret-id",
+		"secret_key": "my-secret-key",
+	}
+	svc := newCredServiceWithMocks(credServiceDeps{
+		aws:      &mockAwsCredService{},
+		gcp:      &mockGcpCredService{},
+		alibaba:  &mockAlibabaCredService{},
+		azure:    &mockAzureCredService{},
+		tencent:  &mockTencentCredService{},
+		ibm:      &mockIbmCredService{},
+		kc:       failOidcKC(),
+		userRepo: &mockUserRepoForCred{role: stdUserRole()},
+		mapRepo:  &mockCspMappingRepo{mapping: buildMapping(constants.AuthMethodOIDC, idpArn, roleArn, model.AuthMethodOIDC, config)},
+	})
+
+	_, err := svc.GetTemporaryCredentials(context.Background(), 1, "kc_user_id", req("tencent", "OIDC"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get impersonation token for Tencent")
+}
+
 // ── IBM ───────────────────────────────────────────────────────────────────────
 
 // TC-CRED-18: IBM OIDC — 정상 발급

--- a/src/service/mock_csp_credential_deps_test.go
+++ b/src/service/mock_csp_credential_deps_test.go
@@ -82,11 +82,20 @@ func (m *mockAzureCredService) GetTokenByFederatedCredential(_ context.Context, 
 // ── Tencent ───────────────────────────────────────────────────────────────────
 
 type mockTencentCredService struct {
-	result *model.CspCredentialResponse
-	err    error
+	result     *model.CspCredentialResponse
+	err        error
+	oidcResult *model.CspCredentialResponse
+	oidcErr    error
 }
 
 func (m *mockTencentCredService) AssumeRoleWithSAML(_ context.Context, secretID, secretKey, roleArn, principalArn, samlAssertion, region string) (*model.CspCredentialResponse, error) {
+	return m.result, m.err
+}
+
+func (m *mockTencentCredService) AssumeRoleWithWebIdentity(_ context.Context, secretID, secretKey, roleArn, providerId, webIdentityToken, region string) (*model.CspCredentialResponse, error) {
+	if m.oidcResult != nil || m.oidcErr != nil {
+		return m.oidcResult, m.oidcErr
+	}
 	return m.result, m.err
 }
 
@@ -176,6 +185,13 @@ var tencentSamlCred = &model.CspCredentialResponse{
 	AccessKeyId:     "STS_TENCENT",
 	SecretAccessKey: "tencent_secret",
 	SessionToken:    "tencent_token",
+}
+
+var tencentOidcCred = &model.CspCredentialResponse{
+	CspType:         "tencent",
+	AccessKeyId:     "STS_TENCENT_OIDC",
+	SecretAccessKey: "tencent_oidc_secret",
+	SessionToken:    "tencent_oidc_token",
 }
 
 var ibmOidcCred = &model.CspCredentialResponse{

--- a/src/service/tencent_credential_service.go
+++ b/src/service/tencent_credential_service.go
@@ -17,7 +17,7 @@ import (
 )
 
 // TencentCredentialService defines operations for obtaining Tencent Cloud
-// temporary credentials via CAM AssumeRoleWithSAML.
+// temporary credentials via CAM AssumeRoleWithSAML / AssumeRoleWithWebIdentity.
 type TencentCredentialService interface {
 	AssumeRoleWithSAML(
 		ctx context.Context,
@@ -26,6 +26,15 @@ type TencentCredentialService interface {
 		roleArn string,
 		principalArn string,
 		samlAssertion string,
+		region string,
+	) (*model.CspCredentialResponse, error)
+	AssumeRoleWithWebIdentity(
+		ctx context.Context,
+		secretID string,
+		secretKey string,
+		roleArn string,
+		providerId string,
+		webIdentityToken string,
 		region string,
 	) (*model.CspCredentialResponse, error)
 }
@@ -170,6 +179,108 @@ func (s *tencentCredentialService) AssumeRoleWithSAML(
 	}
 
 	log.Printf("[TENCENT_CREDENTIAL] AssumeRoleWithSAML succeeded, Expiration: %s", expiration)
+
+	return &model.CspCredentialResponse{
+		CspType:         "tencent",
+		AccessKeyId:     creds.TmpSecretId,
+		SecretAccessKey: creds.TmpSecretKey,
+		SessionToken:    creds.Token,
+		Expiration:      expiration,
+		Region:          region,
+	}, nil
+}
+
+// AssumeRoleWithWebIdentity calls Tencent Cloud CAM STS to exchange an OIDC
+// Web Identity token (e.g. Keycloak ID Token) for temporary credentials
+// (TmpSecretId + TmpSecretKey + Token).
+//
+// secretID:         Tencent Cloud API Secret ID (SAML 경로와의 일관성을 위해 유지 — SKIP 인증이라 STS
+//                    호출 자체에는 사용되지 않지만, 설정 검증 용도로 SAML과 동일하게 요구한다)
+// secretKey:         Tencent Cloud API Secret Key (위와 동일한 이유로 유지)
+// roleArn:           Tencent CAM Role ARN (e.g., qcs::cam::uin/123:roleName/myRole)
+// providerId:        OIDC IdP 식별자 — SAML의 PrincipalArn(전체 ARN)과 달리 리터럴 문자열 "OIDC"
+// webIdentityToken:  Keycloak이 발급한 OIDC ID Token (AccessToken이 아님 — aud가 클라이언트 ID인 ID Token 필요)
+// region:            Tencent Cloud region (X-TC-Region 헤더로 전달; STS 자체는 글로벌 엔드포인트)
+func (s *tencentCredentialService) AssumeRoleWithWebIdentity(
+	ctx context.Context,
+	secretID string,
+	secretKey string,
+	roleArn string,
+	providerId string,
+	webIdentityToken string,
+	region string,
+) (*model.CspCredentialResponse, error) {
+	log.Printf("[TENCENT_CREDENTIAL] AssumeRoleWithWebIdentity - RoleArn: %s, ProviderId: %s", roleArn, providerId)
+
+	sessionName := fmt.Sprintf("mciam-%d", time.Now().Unix())
+
+	payload := map[string]string{
+		"RoleArn":          roleArn,
+		"ProviderId":       providerId,
+		"WebIdentityToken": webIdentityToken,
+		"RoleSessionName":  sessionName,
+	}
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal Tencent STS request: %w", err)
+	}
+
+	now := time.Now().UTC()
+	timestamp := fmt.Sprintf("%d", now.Unix())
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tencentStsEndpoint, strings.NewReader(string(payloadBytes)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Tencent STS request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Host", tencentStsHost)
+	req.Header.Set("X-TC-Action", "AssumeRoleWithWebIdentity")
+	req.Header.Set("X-TC-Version", tencentStsVersion)
+	req.Header.Set("X-TC-Timestamp", timestamp)
+	req.Header.Set("X-TC-Region", region)
+	// AssumeRoleWithSAML과 동일한 federation entry point 계열이므로 TC3-HMAC-SHA256 서명을 요구하지
+	// 않을 것으로 예상된다 — Authorization 헤더는 리터럴 문자열 "SKIP" (039 Phase 2에서 SAML로 실 API
+	// 확인된 내용을 준용; OIDC 자체는 아직 실 API로 검증되지 않았으니 인프라 검증 단계에서 재확인 필요).
+	req.Header.Set("Authorization", "SKIP")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("Tencent STS request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Tencent STS response: %w", err)
+	}
+
+	// Check for Tencent API error in response body (Tencent always returns 200 for API-level errors)
+	var errResp tencentErrorResponse
+	if jsonErr := json.Unmarshal(body, &errResp); jsonErr == nil && errResp.Response.Error.Code != "" {
+		return nil, fmt.Errorf("Tencent STS error [%s]: %s", errResp.Response.Error.Code, errResp.Response.Error.Message)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Tencent STS returned HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	var stsResp tencentStsResponse
+	if err := json.Unmarshal(body, &stsResp); err != nil {
+		return nil, fmt.Errorf("failed to parse Tencent STS response: %w", err)
+	}
+
+	creds := stsResp.Response.Credentials
+	if creds.TmpSecretId == "" || creds.TmpSecretKey == "" {
+		return nil, fmt.Errorf("Tencent STS returned empty credentials")
+	}
+
+	expiration := time.Unix(stsResp.Response.ExpiredTime, 0)
+	if stsResp.Response.ExpiredTime == 0 {
+		log.Printf("[TENCENT_CREDENTIAL] Warning: ExpiredTime is 0, using 1h from now")
+		expiration = time.Now().Add(time.Hour)
+	}
+
+	log.Printf("[TENCENT_CREDENTIAL] AssumeRoleWithWebIdentity succeeded, Expiration: %s", expiration)
 
 	return &model.CspCredentialResponse{
 		CspType:         "tencent",


### PR DESCRIPTION
## Summary
- Tencent Cloud CAM STS `AssumeRoleWithWebIdentity` 액션을 통한 OIDC 기반 임시 자격증명 발급 구현
- 기존 `AssumeRoleWithSAML`(Tencent, 실 API 검증 완료)과 동일한 federation entry point 패턴 적용: `Authorization: SKIP`, `X-TC-Region` 헤더, `X-TC-Action: AssumeRoleWithWebIdentity`
- `csp_credential_service.go`의 `case "tencent":`에 `AuthMethodOIDC` 분기 추가 — Keycloak impersonation token의 `IDToken`(AccessToken 아님)을 `WebIdentityToken`으로 사용