### PR TITLE
fix: Azure Federated Credential grant_type 수정

### DIFF
--- a/src/service/azure_credential_service.go
+++ b/src/service/azure_credential_service.go
@@ -62,7 +62,7 @@ func (s *azureCredentialService) GetTokenByFederatedCredential(
 	tokenURL := fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", tenantID)
 
 	formData := url.Values{}
-	formData.Set("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer")
+	formData.Set("grant_type", "client_credentials")
 	formData.Set("client_id", clientID)
 	formData.Set("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
 	formData.Set("client_assertion", keycloakJWT)


### PR DESCRIPTION
## 요약
- `GetTokenByFederatedCredential`이 `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer`로 Azure AD 토큰 엔드포인트를 호출하고 있었는데, Azure Workload Identity Federation(Federated Credential)은 `client_credentials` grant에 `client_assertion`/`client_assertion_type`을 실어 클라이언트 자신을 인증하는 방식이라 실제로는 `AADSTS900144: The request body must contain the following parameter: 'assertion'` 오류로 항상 실패했다.
- `grant_type`을 `client_credentials`로 변경.

## 검증
- 실제 Azure AD 테넌트(App Registration + Federated Credential) 대상으로 Keycloak 서비스계정 토큰을 client_assertion으로 교환 → 정상적으로 ARM access token 발급.
- 발급된 토큰으로 실제 구독의 `resourcegroups` 목록 조회(`management.azure.com`) 성공 확인.
