### PR TITLE
fix: Tencent OIDC ProviderId 리터럴 값 버그 수정

### DIFF
--- a/src/service/csp_credential_service.go
+++ b/src/service/csp_credential_service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/m-cmp/mc-iam-manager/model"
 	"github.com/m-cmp/mc-iam-manager/repository"
@@ -368,9 +369,17 @@ func (s *CspCredentialService) GetTemporaryCredentials(ctx context.Context, user
 				return nil, fmt.Errorf("failed to get impersonation token for Tencent: %w", err)
 			}
 			// GCP/Alibaba OIDC와 동일한 이유로 AccessToken이 아니라 IDToken을 사용해야 한다 —
-			// Tencent STS ProviderId="OIDC" 검증은 aud가 등록된 Client ID와 일치하는 ID Token을 요구한다.
-			log.Printf("[CSP_CREDENTIAL] Calling Tencent AssumeRoleWithWebIdentity...")
-			return s.tencentCredService.AssumeRoleWithWebIdentity(ctx, secretID, secretKey, roleArn, "OIDC", impersonationToken.IDToken, region)
+			// Tencent STS의 aud 검증은 등록된 OIDC Provider의 Client ID와 일치하는 ID Token을 요구한다.
+			// ProviderId는 실 API 검증 결과 문서 예시의 리터럴 "OIDC"가 아니라 CAM에 등록한
+			// OIDC Provider의 실제 Name이어야 한다 — 리터럴 "OIDC"를 보내면 "identity no exist"로
+			// 항상 실패한다(034 태스크 Tencent OIDC 실인프라 검증에서 발견). idpArn은
+			// "qcs::cam::uin/{uin}:oidc-provider/{name}" 형식이므로 마지막 "/" 뒤의 Name을 추출한다.
+			providerName := idpArn
+			if idx := strings.LastIndex(idpArn, "/"); idx != -1 {
+				providerName = idpArn[idx+1:]
+			}
+			log.Printf("[CSP_CREDENTIAL] Calling Tencent AssumeRoleWithWebIdentity... ProviderId: %s", providerName)
+			return s.tencentCredService.AssumeRoleWithWebIdentity(ctx, secretID, secretKey, roleArn, providerName, impersonationToken.IDToken, region)
 		case model.AuthMethodSAML:
 			secretID := ""
 			secretKey := ""

--- a/src/service/csp_credential_service_test.go
+++ b/src/service/csp_credential_service_test.go
@@ -507,6 +507,33 @@ func TestGetTemporaryCredentials_Tencent_OIDC_Success(t *testing.T) {
 	assert.Equal(t, "tencent", cred.CspType)
 }
 
+// TC-CRED-17c-2: Tencent OIDC — ProviderId는 CAM OIDC Provider ARN의 리터럴 "OIDC"가
+// 아니라 등록된 Provider Name(ARN 마지막 세그먼트)이어야 한다. 실 API 검증에서 리터럴
+// "OIDC"를 보내면 "identity no exist"로 항상 실패함을 확인한 회귀 방지 테스트.
+func TestGetTemporaryCredentials_Tencent_OIDC_ProviderIdExtractedFromArn(t *testing.T) {
+	config := map[string]string{
+		"secret_id":  "my-secret-id",
+		"secret_key": "my-secret-key",
+	}
+	tencentIdpArn := "qcs::cam::uin/200043476729:oidc-provider/mcmp-dev-keycloak-oidc"
+	mockTencent := &mockTencentCredService{oidcResult: tencentOidcCred}
+	svc := newCredServiceWithMocks(credServiceDeps{
+		aws:      &mockAwsCredService{},
+		gcp:      &mockGcpCredService{},
+		alibaba:  &mockAlibabaCredService{},
+		azure:    &mockAzureCredService{},
+		tencent:  mockTencent,
+		ibm:      &mockIbmCredService{},
+		kc:       oidcKC(),
+		userRepo: &mockUserRepoForCred{role: stdUserRole()},
+		mapRepo:  &mockCspMappingRepo{mapping: buildMapping(constants.AuthMethodOIDC, tencentIdpArn, roleArn, model.AuthMethodOIDC, config)},
+	})
+
+	_, err := svc.GetTemporaryCredentials(context.Background(), 1, "kc_user_id", req("tencent", "OIDC"))
+	require.NoError(t, err)
+	assert.Equal(t, "mcmp-dev-keycloak-oidc", mockTencent.capturedProviderId)
+}
+
 // TC-CRED-17d: Tencent OIDC — config 누락 → 에러
 func TestGetTemporaryCredentials_Tencent_OIDC_MissingConfig(t *testing.T) {
 	svc := newCredServiceWithMocks(credServiceDeps{

--- a/src/service/mock_csp_credential_deps_test.go
+++ b/src/service/mock_csp_credential_deps_test.go
@@ -82,10 +82,11 @@ func (m *mockAzureCredService) GetTokenByFederatedCredential(_ context.Context, 
 // ── Tencent ───────────────────────────────────────────────────────────────────
 
 type mockTencentCredService struct {
-	result     *model.CspCredentialResponse
-	err        error
-	oidcResult *model.CspCredentialResponse
-	oidcErr    error
+	result             *model.CspCredentialResponse
+	err                error
+	oidcResult         *model.CspCredentialResponse
+	oidcErr            error
+	capturedProviderId string
 }
 
 func (m *mockTencentCredService) AssumeRoleWithSAML(_ context.Context, secretID, secretKey, roleArn, principalArn, samlAssertion, region string) (*model.CspCredentialResponse, error) {
@@ -93,6 +94,7 @@ func (m *mockTencentCredService) AssumeRoleWithSAML(_ context.Context, secretID,
 }
 
 func (m *mockTencentCredService) AssumeRoleWithWebIdentity(_ context.Context, secretID, secretKey, roleArn, providerId, webIdentityToken, region string) (*model.CspCredentialResponse, error) {
+	m.capturedProviderId = providerId
 	if m.oidcResult != nil || m.oidcErr != nil {
 		return m.oidcResult, m.oidcErr
 	}

--- a/src/service/tencent_credential_service.go
+++ b/src/service/tencent_credential_service.go
@@ -198,7 +198,8 @@ func (s *tencentCredentialService) AssumeRoleWithSAML(
 //                    호출 자체에는 사용되지 않지만, 설정 검증 용도로 SAML과 동일하게 요구한다)
 // secretKey:         Tencent Cloud API Secret Key (위와 동일한 이유로 유지)
 // roleArn:           Tencent CAM Role ARN (e.g., qcs::cam::uin/123:roleName/myRole)
-// providerId:        OIDC IdP 식별자 — SAML의 PrincipalArn(전체 ARN)과 달리 리터럴 문자열 "OIDC"
+// providerId:        CAM에 등록한 OIDC Provider의 Name(전체 ARN이 아님). 문서 예시의 리터럴
+//                    "OIDC"를 그대로 보내면 "identity no exist"로 항상 실패함을 실 API로 확인함.
 // webIdentityToken:  Keycloak이 발급한 OIDC ID Token (AccessToken이 아님 — aud가 클라이언트 ID인 ID Token 필요)
 // region:            Tencent Cloud region (X-TC-Region 헤더로 전달; STS 자체는 글로벌 엔드포인트)
 func (s *tencentCredentialService) AssumeRoleWithWebIdentity(


### PR DESCRIPTION
## 요약
- `AssumeRoleWithWebIdentity` 호출 시 `ProviderId`로 API 문서 예시의 리터럴 `"OIDC"`를 그대로 보내고 있었는데, 실 API 검증 결과 CAM은 이를 항상 `InternalError.UnknownError: identity no exist`로 거부한다.
- `ProviderId`는 `CreateOIDCConfig`로 등록한 Provider의 **실제 Name**이어야 한다. `CspRole.IdpIdentifier`에 저장되는 `qcs::cam::uin/{uin}:oidc-provider/{name}` 형태 ARN의 마지막 세그먼트(Name)를 추출해 전달하도록 수정.

## 검증
- 실 Tencent CAM 계정에 OIDC Identity Provider 등록(JWKS는 base64 인코딩 필요 — 이것도 실 API로 확인한 요구사항) + Role 신뢰정책(`sts:AssumeRoleWithWebIdentity`, federated principal = oidc-provider ARN) 구성.
- 리터럴 `"OIDC"`로는 어떤 Role을 대상으로 해도 동일하게 실패 → Provider Name으로 바꾸자 정상 발급 확인.
- 발급된 임시 자격증명으로 `GetCallerIdentity`, `DescribeInstances` 실제 조회 성공.
- mc-iam-manager API(`POST /api/csp-idp-configs`/`POST /api/roles/csp`/`POST /api/roles/csp-roles`/`POST /api/workspaces/temporary-credentials`) 전 구간을 실제 호출로 재현해 검증.
