### PR TITLE
chore: remove legacy project-by-id actions from unused mcmp_api.yaml asset

### DIFF
--- a/asset/mcmpapi/mcmp_api.yaml
+++ b/asset/mcmpapi/mcmp_api.yaml
@@ -852,18 +852,6 @@ serviceActions:
       method: delete
       resourcePath: /api/wsprj/workspace/id/{workspaceId}/project/id/{projectId}
       description: "workspace - projects mapping 단건 삭제"
-    Deleteprojectbyid:
-      method: delete
-      resourcePath: /api/prj/project/id/{projectId}
-      description: "project 삭제"
-    Getprojectbyid:
-      method: get
-      resourcePath: /api/prj/project/id/{projectId}
-      description: "project 단건 조회"
-    Updateprojectbyid:
-      method: put
-      resourcePath: /api/prj/project/id/{projectId}
-      description: "project 수정"
     Searchprojectsbyname:
       method: get
       resourcePath: /api/prj/project/{projectName}


### PR DESCRIPTION
## 변경 내용

`asset/mcmpapi/mcmp_api.yaml`에 남아있던 legacy 경로(`/api/prj/project/id/{projectId}`) 기반 액션 3개를 삭제한다.

- `Deleteprojectbyid` (delete)
- `Getprojectbyid` (get)
- `Updateprojectbyid` (put)
