### PR TITLE
fix: UpdateCspRole이 IdpIdentifier 등 4필드를 반영하도록 수정

### DIFF
--- a/src/service/csp_role_service.go
+++ b/src/service/csp_role_service.go
@@ -585,6 +585,18 @@ func (s *CspRoleService) UpdateCspRole(id uint, req *model.CreateCspRoleRequest)
 	}
 	existingRole.Name = req.CspRoleName
 	existingRole.Description = req.Description
+	if req.IdpIdentifier != "" {
+		existingRole.IdpIdentifier = req.IdpIdentifier
+	}
+	if req.IamIdentifier != "" {
+		existingRole.IamIdentifier = req.IamIdentifier
+	}
+	if req.IamRoleId != "" {
+		existingRole.IamRoleId = req.IamRoleId
+	}
+	if req.Path != "" {
+		existingRole.Path = req.Path
+	}
 	if len(req.ExtendedConfig) > 0 {
 		existingRole.ExtendedConfig = req.ExtendedConfig
 	}

--- a/src/service/csp_role_service_test.go
+++ b/src/service/csp_role_service_test.go
@@ -155,3 +155,67 @@ func TestUpdateCspRole_PersistsCspIdpConfigID(t *testing.T) {
 	require.NotNil(t, updated.CspIdpConfigID)
 	assert.Equal(t, idpConfigID, *updated.CspIdpConfigID)
 }
+
+// TestUpdateCspRole_PersistsIdentifierFields: UpdateCspRole이 Name/Description/
+// ExtendedConfig/CspIdpConfigID만 반영하고 IdpIdentifier/IamIdentifier/IamRoleId/Path는
+// 무시하던 버그(콘솔 CSP Role Edit 저장 시 이 4필드가 항상 유실) 회귀 방지.
+func TestUpdateCspRole_PersistsIdentifierFields(t *testing.T) {
+	svc := newTestCspRoleService(t)
+
+	created, err := svc.CreateCspRole(&model.CreateCspRoleRequest{
+		CspRoleName:   "mcmp-admin-identifiers",
+		CspType:       "gcp",
+		AuthMethod:    constants.AuthMethodOIDC,
+		IdpIdentifier: "//iam.googleapis.com/projects/x/locations/global/workloadIdentityPools/p/providers/pr",
+		IamIdentifier: "sa@project.iam.gserviceaccount.com",
+	})
+	require.NoError(t, err)
+
+	err = svc.UpdateCspRole(created.ID, &model.CreateCspRoleRequest{
+		CspRoleName:   created.Name,
+		IdpIdentifier: "//iam.googleapis.com/projects/x/locations/global/workloadIdentityPools/p/providers/pr-updated",
+		IamIdentifier: "sa-updated@project.iam.gserviceaccount.com",
+		IamRoleId:     "role-id-updated",
+		Path:          "/updated/",
+	})
+	require.NoError(t, err)
+
+	updated, err := svc.GetCspRoleByID(created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "//iam.googleapis.com/projects/x/locations/global/workloadIdentityPools/p/providers/pr-updated", updated.IdpIdentifier)
+	assert.Equal(t, "sa-updated@project.iam.gserviceaccount.com", updated.IamIdentifier)
+	assert.Equal(t, "role-id-updated", updated.IamRoleId)
+	assert.Equal(t, "/updated/", updated.Path)
+}
+
+// TestUpdateCspRole_EmptyIdentifierFields_PreservesExisting: 요청에 identifier
+// 필드가 비어 있으면(옵셔널 필드 미전달) 기존 값을 보존해야 한다 — ExtendedConfig/
+// CspIdpConfigID와 동일한 "미전달 시 유지" 정책.
+func TestUpdateCspRole_EmptyIdentifierFields_PreservesExisting(t *testing.T) {
+	svc := newTestCspRoleService(t)
+
+	created, err := svc.CreateCspRole(&model.CreateCspRoleRequest{
+		CspRoleName:   "mcmp-admin-preserve",
+		CspType:       "gcp",
+		AuthMethod:    constants.AuthMethodOIDC,
+		IdpIdentifier: "//iam.googleapis.com/projects/x/locations/global/workloadIdentityPools/p/providers/pr",
+		IamIdentifier: "sa@project.iam.gserviceaccount.com",
+		IamRoleId:     "role-id-original",
+		Path:          "/original/",
+	})
+	require.NoError(t, err)
+
+	err = svc.UpdateCspRole(created.ID, &model.CreateCspRoleRequest{
+		CspRoleName: created.Name,
+		Description: "설명만 변경",
+	})
+	require.NoError(t, err)
+
+	updated, err := svc.GetCspRoleByID(created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "설명만 변경", updated.Description)
+	assert.Equal(t, created.IdpIdentifier, updated.IdpIdentifier)
+	assert.Equal(t, created.IamIdentifier, updated.IamIdentifier)
+	assert.Equal(t, created.IamRoleId, updated.IamRoleId)
+	assert.Equal(t, created.Path, updated.Path)
+}


### PR DESCRIPTION
## Summary
- CSP Role 수정 서비스가 Name/Description/ExtendedConfig/CspIdpConfigID만 반영하던 문제 수정
- 4필드는 값이 있을 때만 덮어쓰는 정책(빈 값이면 기존 값 보존) — ExtendedConfig/CspIdpConfigID와 동일한 기존 패턴 준수
- mc-web-console CSP Role Edit 화면 보강의 선행 작업 (해당 API를 그대로 소비)
