### PR TITLE
fix: mcmp API 레지스트리 updateCspRole 액션이 미등록 라우트를 가리키던 문제 수정

### DIFF
--- a/asset/mcmpapi/service-actions.yaml
+++ b/asset/mcmpapi/service-actions.yaml
@@ -1204,8 +1204,8 @@ serviceActions:
             description: Update CSP policy details
         updateCspRole:
             method: put
-            resourcePath: /api/roles/csp-roles/id/{roleId}
-            description: Update role information
+            resourcePath: /api/roles/csp/id/{roleId}
+            description: Update CSP role record (idp/iam identifiers, description, extended config)
         updateGroupWorkspaceRole:
             method: put
             resourcePath: /api/groups/id/{groupId}/workspaces/{workspaceId}

--- a/conf/mc-iam-manager/api.yaml
+++ b/conf/mc-iam-manager/api.yaml
@@ -928,8 +928,8 @@ serviceActions:
       description: Update CSP policy details
     updateCspRole:
       method: put
-      resourcePath: /api/roles/csp-roles/id/{roleId}
-      description: Update role information
+      resourcePath: /api/roles/csp/id/{roleId}
+      description: Update CSP role record (idp/iam identifiers, description, extended config)
     listCSPRoles:
       method: post
       resourcePath: /api/roles/csp/list

--- a/conf/mc-iam-manager/service-actions.yaml
+++ b/conf/mc-iam-manager/service-actions.yaml
@@ -1204,8 +1204,8 @@ serviceActions:
             description: Update CSP policy details
         updateCspRole:
             method: put
-            resourcePath: /api/roles/csp-roles/id/{roleId}
-            description: Update role information
+            resourcePath: /api/roles/csp/id/{roleId}
+            description: Update CSP role record (idp/iam identifiers, description, extended config)
         updateGroupWorkspaceRole:
             method: put
             resourcePath: /api/groups/id/{groupId}/workspaces/{workspaceId}


### PR DESCRIPTION
## Summary
- 레지스트리 `updateCspRole` 액션이 `PUT /api/roles/csp-roles/id/{roleId}`를 /api/roles/csp/id/{roleId}`로 resourcePath 수정
- 레지스트리가 3개 파일에 중복 정의돼 있어 모두 동기화(`asset/mcmpapi/service-actions.yaml`, `conf/mc-iam-manager/api.yaml`, `conf/mc-iam-manager/service-actions.yaml`)
