### PR TITLE
feat: add remediation guidance to CSP validation

### DIFF
--- a/src/model/csp_validation.go
+++ b/src/model/csp_validation.go
@@ -13,10 +13,19 @@ const (
 
 // ValidationStep 단일 검증 단계 결과
 type ValidationStep struct {
-	Step   int                  `json:"step"`   // 순번 (1부터)
-	Name   string               `json:"name"`   // 단계명
-	Status ValidationStepStatus `json:"status"` // ok | failed | skipped
-	Detail string               `json:"detail"` // 수행 내역 또는 오류 안내 (skipped면 "")
+	Step        int                  `json:"step"`                  // 순번 (1부터)
+	Name        string               `json:"name"`                  // 단계명
+	Status      ValidationStepStatus `json:"status"`                 // ok | failed | skipped
+	Detail      string               `json:"detail"`                 // 수행 내역 또는 오류 안내 (skipped면 "")
+	Remediation *RemediationGuide    `json:"remediation,omitempty"` // failed일 때만, CSP 콘솔에서의 조치 방법
+}
+
+// RemediationGuide 검증 실패 단계에 대한 구조화된 설정 방안
+type RemediationGuide struct {
+	Summary      string   `json:"summary"`                // 한 줄 요약
+	ConsoleSteps []string `json:"consoleSteps,omitempty"` // CSP 콘솔/CLI 조작 순서
+	Template     string   `json:"template,omitempty"`     // 선택: Trust Policy JSON 등 복사-붙여넣기 템플릿
+	DocsRef      string   `json:"docsRef,omitempty"`      // 선택: 참고 문서 링크
 }
 
 // CspValidationRequest 검증 요청

--- a/src/service/csp_validation_service.go
+++ b/src/service/csp_validation_service.go
@@ -645,14 +645,16 @@ func (s *CspValidationService) validateGCPWithOIDC(ctx context.Context, userID u
 	}
 
 	// Step 3: Keycloak OIDC 토큰 발급
-	var accessToken string
+	// GCP WIF STS는 단일 문자열 aud를 요구하므로 Access Token(aud="account")이 아니라
+	// ID Token(aud=OIDC 클라이언트 ID)을 사용해야 한다 — Alibaba OIDC(OI-1)와 동일한 이유.
+	var idToken string
 	if !stepRunner(steps, 2, nil, func() (string, error) {
 		jwt, err := s.keycloakService.GetImpersonationTokenByServiceAccount(ctx)
 		if err != nil {
 			return "", fmt.Errorf("Keycloak OIDC 토큰 발급 실패: %v", err)
 		}
-		accessToken = jwt.AccessToken
-		return fmt.Sprintf("OIDC JWT 발급 완료 (len=%d)", len(accessToken)), nil
+		idToken = jwt.IDToken
+		return fmt.Sprintf("OIDC JWT 발급 완료 (len=%d)", len(idToken)), nil
 	}) {
 		return buildFailedResponse(cspType, authMethod, 3, steps), nil
 	}
@@ -661,7 +663,7 @@ func (s *CspValidationService) validateGCPWithOIDC(ctx context.Context, userID u
 	gcpCredService := s.resolveGcpCredService()
 	var federatedToken string
 	if !stepRunner(steps, 3, gcpStsRemediation, func() (string, error) {
-		token, err := gcpCredService.ExchangeToken(ctx, wifProvider, accessToken, "jwt")
+		token, err := gcpCredService.ExchangeToken(ctx, wifProvider, idToken, "jwt")
 		if err != nil {
 			return "", fmt.Errorf("GCP STS 토큰 교환 실패: %v — WIF Pool/Provider 설정 확인", err)
 		}

--- a/src/service/csp_validation_service.go
+++ b/src/service/csp_validation_service.go
@@ -222,11 +222,12 @@ var gcpStsRemediation = &model.RemediationGuide{
 // gcpSaImpersonationRemediation SA Impersonation(step 5) 실패 시 안내 — 대상 Service Account가
 // 없거나 WIF Pool에 workloadIdentityUser 권한이 부여되어 있지 않은 경우.
 var gcpSaImpersonationRemediation = &model.RemediationGuide{
-	Summary: "대상 Service Account가 없거나, WIF Pool에서 해당 SA를 impersonate할 권한(roles/iam.workloadIdentityUser)이 없습니다.",
+	Summary: "대상 Service Account가 없거나, WIF Pool에서 해당 SA를 impersonate/토큰 발급할 권한이 없습니다.",
 	ConsoleSteps: []string{
-		"GCP Console → IAM & Admin → Service Accounts → Create Service Account (예: mciam-<role>@<project>.iam.gserviceaccount.com)",
-		"IAM & Admin → IAM → 해당 SA에 필요한 권한 부여",
-		"Service Account → Permissions → Grant Access → WIF Pool의 principalSet에 roles/iam.workloadIdentityUser 부여",
+		"GCP Console → IAM & Admin → Service Accounts → Create Service Account (예: mcmp-<role>@<project>.iam.gserviceaccount.com)",
+		"Service Account → Permissions → Grant Access → WIF Pool의 principal(또는 principalSet)에 다음 두 역할을 모두 부여: roles/iam.workloadIdentityUser + roles/iam.serviceAccountTokenCreator " +
+			"(workloadIdentityUser만으로는 부족 — 실제 토큰 발급(generateAccessToken) 시 'Permission iam.serviceAccounts.getAccessToken denied'로 실패함)",
+		"IAM & Admin → IAM → 해당 SA에 실제 사용할 리소스 권한 부여 (예: roles/compute.admin)",
 		"SA 이메일을 CspRole.iam_identifier에 등록",
 	},
 	DocsRef: "mcmp-workflow/mc-iam-manager/design/CSP-ADMIN-WORKFLOW.md#step-5",

--- a/src/service/csp_validation_service.go
+++ b/src/service/csp_validation_service.go
@@ -119,12 +119,13 @@ func buildValidationSteps(cspType, authMethod string) []model.ValidationStep {
 	return steps
 }
 
-// stepRunner 단계 실행 헬퍼 — 실패 시 false 반환
-func stepRunner(steps []model.ValidationStep, idx int, fn func() (string, error)) bool {
+// stepRunner 단계 실행 헬퍼 — 실패 시 false 반환. remediation은 실패 시에만 해당 단계에 첨부된다(nil이면 미첨부).
+func stepRunner(steps []model.ValidationStep, idx int, remediation *model.RemediationGuide, fn func() (string, error)) bool {
 	detail, err := fn()
 	if err != nil {
 		steps[idx].Status = model.ValidationStepFailed
 		steps[idx].Detail = err.Error()
+		steps[idx].Remediation = remediation
 		return false
 	}
 	steps[idx].Status = model.ValidationStepOk
@@ -186,7 +187,7 @@ func (s *CspValidationService) ValidateCredentials(ctx context.Context, userID u
 func (s *CspValidationService) validateAWSWithOIDC(ctx context.Context, userID uint, kcUserID string, workspaceID uint, cspType, authMethod string, steps []model.ValidationStep) (*model.CspValidationResponse, error) {
 	// Step 1: DB 매핑 조회
 	var mapping *model.RoleMasterCspRoleMapping
-	if !stepRunner(steps, 0, func() (string, error) {
+	if !stepRunner(steps, 0, nil, func() (string, error) {
 		userRole, err := s.resolveUserRepo().FindUserRoleInWorkspace(userID, workspaceID)
 		if err != nil || userRole == nil {
 			return "", fmt.Errorf("워크스페이스 역할 없음 — DB에 auth_method=OIDC 매핑 추가 필요")
@@ -203,7 +204,7 @@ func (s *CspValidationService) validateAWSWithOIDC(ctx context.Context, userID u
 
 	// Step 2: CspRole 설정 확인
 	var idpArn, roleArn string
-	if !stepRunner(steps, 1, func() (string, error) {
+	if !stepRunner(steps, 1, nil, func() (string, error) {
 		cspRole := mapping.CspRoles[0]
 		if cspRole.IdpIdentifier == "" || cspRole.IamIdentifier == "" {
 			return "", fmt.Errorf("CspRole.idp_identifier(OIDC Provider ARN) 또는 iam_identifier(Role ARN) 비어 있음")
@@ -217,7 +218,7 @@ func (s *CspValidationService) validateAWSWithOIDC(ctx context.Context, userID u
 
 	// Step 3: Keycloak OIDC 토큰 발급
 	var accessToken string
-	if !stepRunner(steps, 2, func() (string, error) {
+	if !stepRunner(steps, 2, nil, func() (string, error) {
 		jwt, err := s.keycloakService.GetImpersonationTokenByServiceAccount(ctx)
 		if err != nil {
 			return "", fmt.Errorf("Keycloak OIDC 토큰 발급 실패: %v — Keycloak OIDC 클라이언트 설정 또는 시크릿 확인", err)
@@ -233,14 +234,14 @@ func (s *CspValidationService) validateAWSWithOIDC(ctx context.Context, userID u
 	}
 
 	// Step 4: AWS OIDC Provider 확인
-	if !stepRunner(steps, 3, func() (string, error) {
+	if !stepRunner(steps, 3, nil, func() (string, error) {
 		return s.awsCredService.CheckOIDCProvider(ctx, idpArn)
 	}) {
 		return buildFailedResponse(cspType, authMethod, 4, steps), nil
 	}
 
 	// Step 5: IAM Role WebIdentity Trust 확인
-	if !stepRunner(steps, 4, func() (string, error) {
+	if !stepRunner(steps, 4, nil, func() (string, error) {
 		return s.awsCredService.CheckRoleTrust(ctx, roleArn, "sts:AssumeRoleWithWebIdentity", idpArn)
 	}) {
 		return buildFailedResponse(cspType, authMethod, 5, steps), nil
@@ -252,7 +253,7 @@ func (s *CspValidationService) validateAWSWithOIDC(ctx context.Context, userID u
 		defaultRegion = "ap-northeast-2"
 	}
 	var credSummary *model.CredentialSummary
-	if !stepRunner(steps, 5, func() (string, error) {
+	if !stepRunner(steps, 5, nil, func() (string, error) {
 		creds, err := s.awsCredService.AssumeRoleWithWebIdentity(ctx, roleArn, kcUserID, accessToken, idpArn, defaultRegion)
 		if err != nil {
 			return "", fmt.Errorf("AssumeRoleWithWebIdentity 실패: %v", err)
@@ -281,7 +282,7 @@ func (s *CspValidationService) validateAWSWithOIDC(ctx context.Context, userID u
 func (s *CspValidationService) validateAWSWithSAML(ctx context.Context, userID uint, workspaceID uint, cspType, authMethod string, steps []model.ValidationStep) (*model.CspValidationResponse, error) {
 	// Step 1: DB 매핑 조회
 	var mapping *model.RoleMasterCspRoleMapping
-	if !stepRunner(steps, 0, func() (string, error) {
+	if !stepRunner(steps, 0, nil, func() (string, error) {
 		userRole, err := s.resolveUserRepo().FindUserRoleInWorkspace(userID, workspaceID)
 		if err != nil || userRole == nil {
 			return "", fmt.Errorf("워크스페이스 역할 없음 — DB에 auth_method=SAML 매핑 추가 필요")
@@ -298,7 +299,7 @@ func (s *CspValidationService) validateAWSWithSAML(ctx context.Context, userID u
 
 	// Step 2: CspRole 설정 확인
 	var principalArn, roleArn, samlClientAudience string
-	if !stepRunner(steps, 1, func() (string, error) {
+	if !stepRunner(steps, 1, nil, func() (string, error) {
 		cspRole := mapping.CspRoles[0]
 		if cspRole.IdpIdentifier == "" || cspRole.IamIdentifier == "" {
 			return "", fmt.Errorf("CspRole.idp_identifier(Principal ARN) 또는 iam_identifier(Role ARN) 비어 있음")
@@ -320,7 +321,7 @@ func (s *CspValidationService) validateAWSWithSAML(ctx context.Context, userID u
 	if cspType == "aws" && !strings.Contains(kcSamlClientID, "urn:amazon") {
 		kcSamlClientID = os.Getenv("SAML_CLIENT_ID_AWS")
 	}
-	if !stepRunner(steps, 2, func() (string, error) {
+	if !stepRunner(steps, 2, nil, func() (string, error) {
 		return s.keycloakService.CheckSAMLClientConfig(ctx, kcSamlClientID)
 	}) {
 		return buildFailedResponse(cspType, authMethod, 3, steps), nil
@@ -329,7 +330,7 @@ func (s *CspValidationService) validateAWSWithSAML(ctx context.Context, userID u
 	// Step 4: SAML Assertion 발급 및 검증
 	// token exchange audience는 Keycloak 클라이언트 ID (kcSamlClientID) 사용
 	var samlAssertion string
-	if !stepRunner(steps, 3, func() (string, error) {
+	if !stepRunner(steps, 3, nil, func() (string, error) {
 		assertion, err := s.keycloakService.GetSamlAssertionByServiceAccount(ctx, kcSamlClientID)
 		if err != nil {
 			return "", fmt.Errorf("SAML Assertion 발급 실패: %v — Keycloak SAML 클라이언트 설정 확인", err)
@@ -343,14 +344,14 @@ func (s *CspValidationService) validateAWSWithSAML(ctx context.Context, userID u
 	}
 
 	// Step 5: AWS SAML Provider 확인
-	if !stepRunner(steps, 4, func() (string, error) {
+	if !stepRunner(steps, 4, nil, func() (string, error) {
 		return s.awsCredService.CheckSAMLProvider(ctx, principalArn)
 	}) {
 		return buildFailedResponse(cspType, authMethod, 5, steps), nil
 	}
 
 	// Step 6: IAM Role SAML Trust 확인
-	if !stepRunner(steps, 5, func() (string, error) {
+	if !stepRunner(steps, 5, nil, func() (string, error) {
 		return s.awsCredService.CheckRoleTrust(ctx, roleArn, "sts:AssumeRoleWithSAML", principalArn)
 	}) {
 		return buildFailedResponse(cspType, authMethod, 6, steps), nil
@@ -362,7 +363,7 @@ func (s *CspValidationService) validateAWSWithSAML(ctx context.Context, userID u
 		samlDefaultRegion = "ap-northeast-2"
 	}
 	var credSummary *model.CredentialSummary
-	if !stepRunner(steps, 6, func() (string, error) {
+	if !stepRunner(steps, 6, nil, func() (string, error) {
 		creds, err := s.awsCredService.AssumeRoleWithSAML(ctx, roleArn, principalArn, samlAssertion, samlDefaultRegion)
 		if err != nil {
 			return "", fmt.Errorf("AssumeRoleWithSAML 실패: %v", err)
@@ -391,7 +392,7 @@ func (s *CspValidationService) validateAWSWithSAML(ctx context.Context, userID u
 func (s *CspValidationService) validateAWSWithSecretKey(ctx context.Context, userID uint, workspaceID uint, cspType, authMethod string, steps []model.ValidationStep) (*model.CspValidationResponse, error) {
 	// Step 1: DB 매핑 조회
 	var mapping *model.RoleMasterCspRoleMapping
-	if !stepRunner(steps, 0, func() (string, error) {
+	if !stepRunner(steps, 0, nil, func() (string, error) {
 		userRole, err := s.resolveUserRepo().FindUserRoleInWorkspace(userID, workspaceID)
 		if err != nil || userRole == nil {
 			return "", fmt.Errorf("워크스페이스 역할 없음")
@@ -408,7 +409,7 @@ func (s *CspValidationService) validateAWSWithSecretKey(ctx context.Context, use
 
 	// Step 2: CspIdpConfig 설정 확인
 	var accessKeyID, secretKey string
-	if !stepRunner(steps, 1, func() (string, error) {
+	if !stepRunner(steps, 1, nil, func() (string, error) {
 		cspRole := mapping.CspRoles[0]
 		if cspRole.CspIdpConfig == nil {
 			return "", fmt.Errorf("CspIdpConfig 없음 — CspRole에 IDP 설정 연결 필요")
@@ -424,7 +425,7 @@ func (s *CspValidationService) validateAWSWithSecretKey(ctx context.Context, use
 	}
 
 	// Step 3: AWS 연결 확인 (GetCallerIdentity)
-	if !stepRunner(steps, 2, func() (string, error) {
+	if !stepRunner(steps, 2, nil, func() (string, error) {
 		return s.awsCredService.CheckCallerIdentity(ctx, accessKeyID, secretKey)
 	}) {
 		return buildFailedResponse(cspType, authMethod, 3, steps), nil
@@ -444,7 +445,7 @@ func (s *CspValidationService) validateAWSWithSecretKey(ctx context.Context, use
 func (s *CspValidationService) validateGCPWithOIDC(ctx context.Context, userID uint, kcUserID string, workspaceID uint, cspType, authMethod string, steps []model.ValidationStep) (*model.CspValidationResponse, error) {
 	// Step 1: DB 매핑 조회
 	var mapping *model.RoleMasterCspRoleMapping
-	if !stepRunner(steps, 0, func() (string, error) {
+	if !stepRunner(steps, 0, nil, func() (string, error) {
 		userRole, err := s.resolveUserRepo().FindUserRoleInWorkspace(userID, workspaceID)
 		if err != nil || userRole == nil {
 			return "", fmt.Errorf("워크스페이스 역할 없음")
@@ -461,7 +462,7 @@ func (s *CspValidationService) validateGCPWithOIDC(ctx context.Context, userID u
 
 	// Step 2: CspRole 설정 확인
 	var wifProvider, saEmail string
-	if !stepRunner(steps, 1, func() (string, error) {
+	if !stepRunner(steps, 1, nil, func() (string, error) {
 		cspRole := mapping.CspRoles[0]
 		if cspRole.IdpIdentifier == "" || cspRole.IamIdentifier == "" {
 			return "", fmt.Errorf("idp_identifier(WIF Provider) 또는 iam_identifier(SA email) 비어 있음")
@@ -475,7 +476,7 @@ func (s *CspValidationService) validateGCPWithOIDC(ctx context.Context, userID u
 
 	// Step 3: Keycloak OIDC 토큰 발급
 	var accessToken string
-	if !stepRunner(steps, 2, func() (string, error) {
+	if !stepRunner(steps, 2, nil, func() (string, error) {
 		jwt, err := s.keycloakService.GetImpersonationTokenByServiceAccount(ctx)
 		if err != nil {
 			return "", fmt.Errorf("Keycloak OIDC 토큰 발급 실패: %v", err)
@@ -493,20 +494,20 @@ func (s *CspValidationService) validateGCPWithOIDC(ctx context.Context, userID u
 	gcpCredService := NewGcpCredentialService()
 	var credSummary *model.CredentialSummary
 
-	if !stepRunner(steps, 3, func() (string, error) {
+	if !stepRunner(steps, 3, nil, func() (string, error) {
 		// GCP STS exchange only (ExchangeTokenAndImpersonate가 전체를 수행하므로 step 4에서 전체 실행)
 		return "GCP STS 토큰 교환 시도 중...", nil
 	}) {
 		return buildFailedResponse(cspType, authMethod, 4, steps), nil
 	}
 
-	if !stepRunner(steps, 4, func() (string, error) {
+	if !stepRunner(steps, 4, nil, func() (string, error) {
 		return "SA Impersonation 시도 중...", nil
 	}) {
 		return buildFailedResponse(cspType, authMethod, 5, steps), nil
 	}
 
-	if !stepRunner(steps, 5, func() (string, error) {
+	if !stepRunner(steps, 5, nil, func() (string, error) {
 		creds, err := gcpCredService.ExchangeTokenAndImpersonate(ctx, wifProvider, saEmail, accessToken, "jwt")
 		if err != nil {
 			return "", fmt.Errorf("GCP 자격증명 발급 실패: %v — WIF Pool/Provider 설정 또는 SA 권한 확인", err)

--- a/src/service/csp_validation_service.go
+++ b/src/service/csp_validation_service.go
@@ -213,7 +213,8 @@ var gcpStsRemediation = &model.RemediationGuide{
 		"GCP Console → IAM & Admin → Workload Identity Federation → Create Pool",
 		"Pool에 OIDC Provider 추가: Issuer URL = Keycloak realm issuer (예: https://<keycloak-host>/realms/<realm>)",
 		"Attribute mapping 설정 (google.subject = assertion.sub 등)",
-		"생성된 리소스 이름(projects/<NUM>/locations/global/workloadIdentityPools/<POOL>/providers/<PROVIDER>)을 CspRole.idp_identifier에 등록",
+		"Attribute condition은 'in' 연산자 대신 등가 비교 권장: assertion.aud == \"<Keycloak 클라이언트 ID>\" (ID Token의 aud는 배열이 아닌 단일 문자열)",
+		"생성된 리소스 이름 앞에 //iam.googleapis.com/ 접두사를 붙여 CspRole.idp_identifier에 등록 (예: //iam.googleapis.com/projects/<NUM>/locations/global/workloadIdentityPools/<POOL>/providers/<PROVIDER> — 접두사 없으면 'Unsupported audience type' 오류)",
 	},
 	DocsRef: "mcmp-workflow/mc-iam-manager/design/CSP-ADMIN-WORKFLOW.md#step-4",
 }

--- a/src/service/csp_validation_service.go
+++ b/src/service/csp_validation_service.go
@@ -25,13 +25,14 @@ type valMappingRepo interface {
 
 // CspValidationService CSP 인증 설정 단계별 검증 서비스
 type CspValidationService struct {
-	db               *gorm.DB
-	userRepo         *repository.UserRepository
-	mappingRepo      *repository.CspMappingRepository
-	userRepoIface    valUserRepo    // 테스트 주입용 (nil이면 userRepo 사용)
-	mappingRepoIface valMappingRepo // 테스트 주입용 (nil이면 mappingRepo 사용)
-	keycloakService  KeycloakService
-	awsCredService   AwsCredentialService
+	db                  *gorm.DB
+	userRepo            *repository.UserRepository
+	mappingRepo         *repository.CspMappingRepository
+	userRepoIface       valUserRepo          // 테스트 주입용 (nil이면 userRepo 사용)
+	mappingRepoIface    valMappingRepo       // 테스트 주입용 (nil이면 mappingRepo 사용)
+	keycloakService     KeycloakService
+	awsCredService      AwsCredentialService
+	gcpCredServiceIface GcpCredentialService // 테스트 주입용 (nil이면 NewGcpCredentialService() 사용)
 }
 
 // NewCspValidationService 새 CspValidationService 인스턴스 생성
@@ -191,6 +192,43 @@ func (s *CspValidationService) resolveMappingRepo() valMappingRepo {
 		return s.mappingRepoIface
 	}
 	return s.mappingRepo
+}
+
+// resolveGcpCredService 테스트 주입 우선, 없으면 프로덕션 서비스 반환
+func (s *CspValidationService) resolveGcpCredService() GcpCredentialService {
+	if s.gcpCredServiceIface != nil {
+		return s.gcpCredServiceIface
+	}
+	return NewGcpCredentialService()
+}
+
+// --- GCP OIDC 단계별 RemediationGuide ---
+// CSP 콘솔에서의 실제 조치 방법. 참고: mcmp-workflow/mc-iam-manager/design/CSP-ADMIN-WORKFLOW.md (Step 4, 5 — GCP 섹션)
+
+// gcpStsRemediation GCP STS 토큰 교환(step 4) 실패 시 안내 — WIF Pool/Provider가 없거나
+// Keycloak을 신뢰하도록 설정되어 있지 않은 경우.
+var gcpStsRemediation = &model.RemediationGuide{
+	Summary: "GCP Workload Identity Federation Pool/Provider가 Keycloak을 신뢰하도록 설정되어 있지 않거나 존재하지 않습니다.",
+	ConsoleSteps: []string{
+		"GCP Console → IAM & Admin → Workload Identity Federation → Create Pool",
+		"Pool에 OIDC Provider 추가: Issuer URL = Keycloak realm issuer (예: https://<keycloak-host>/realms/<realm>)",
+		"Attribute mapping 설정 (google.subject = assertion.sub 등)",
+		"생성된 리소스 이름(projects/<NUM>/locations/global/workloadIdentityPools/<POOL>/providers/<PROVIDER>)을 CspRole.idp_identifier에 등록",
+	},
+	DocsRef: "mcmp-workflow/mc-iam-manager/design/CSP-ADMIN-WORKFLOW.md#step-4",
+}
+
+// gcpSaImpersonationRemediation SA Impersonation(step 5) 실패 시 안내 — 대상 Service Account가
+// 없거나 WIF Pool에 workloadIdentityUser 권한이 부여되어 있지 않은 경우.
+var gcpSaImpersonationRemediation = &model.RemediationGuide{
+	Summary: "대상 Service Account가 없거나, WIF Pool에서 해당 SA를 impersonate할 권한(roles/iam.workloadIdentityUser)이 없습니다.",
+	ConsoleSteps: []string{
+		"GCP Console → IAM & Admin → Service Accounts → Create Service Account (예: mciam-<role>@<project>.iam.gserviceaccount.com)",
+		"IAM & Admin → IAM → 해당 SA에 필요한 권한 부여",
+		"Service Account → Permissions → Grant Access → WIF Pool의 principalSet에 roles/iam.workloadIdentityUser 부여",
+		"SA 이메일을 CspRole.iam_identifier에 등록",
+	},
+	DocsRef: "mcmp-workflow/mc-iam-manager/design/CSP-ADMIN-WORKFLOW.md#step-5",
 }
 
 // buildSteps CSP×AuthMethod별 전체 단계를 skipped 초기 상태로 반환
@@ -619,31 +657,36 @@ func (s *CspValidationService) validateGCPWithOIDC(ctx context.Context, userID u
 		return buildFailedResponse(cspType, authMethod, 3, steps), nil
 	}
 
-	// Step 4: GCP STS 토큰 교환
-	// Step 5: SA Impersonation
-	// Step 6: 임시자격증명 발급
-	// GCP는 ExchangeTokenAndImpersonate에서 한 번에 처리 — 단계를 순서대로 시도
-	gcpCredService := NewGcpCredentialService()
-	var credSummary *model.CredentialSummary
-
-	if !stepRunner(steps, 3, nil, func() (string, error) {
-		// GCP STS exchange only (ExchangeTokenAndImpersonate가 전체를 수행하므로 step 4에서 전체 실행)
-		return "GCP STS 토큰 교환 시도 중...", nil
+	// Step 4: GCP STS 토큰 교환 (Keycloak JWT → GCP federated access token)
+	gcpCredService := s.resolveGcpCredService()
+	var federatedToken string
+	if !stepRunner(steps, 3, gcpStsRemediation, func() (string, error) {
+		token, err := gcpCredService.ExchangeToken(ctx, wifProvider, accessToken, "jwt")
+		if err != nil {
+			return "", fmt.Errorf("GCP STS 토큰 교환 실패: %v — WIF Pool/Provider 설정 확인", err)
+		}
+		federatedToken = token
+		return fmt.Sprintf("GCP federated token 발급 완료 (len=%d)", len(federatedToken)), nil
 	}) {
 		return buildFailedResponse(cspType, authMethod, 4, steps), nil
 	}
 
-	if !stepRunner(steps, 4, nil, func() (string, error) {
-		return "SA Impersonation 시도 중...", nil
+	// Step 5: SA Impersonation (federated token → SA-impersonated access token)
+	var creds *model.CspCredentialResponse
+	if !stepRunner(steps, 4, gcpSaImpersonationRemediation, func() (string, error) {
+		c, err := gcpCredService.GenerateAccessToken(ctx, saEmail, federatedToken)
+		if err != nil {
+			return "", fmt.Errorf("SA Impersonation 실패: %v — SA 존재 여부 및 WIF Pool의 workloadIdentityUser 권한 확인", err)
+		}
+		creds = c
+		return fmt.Sprintf("SA Impersonation 완료 (accessToken len=%d)", len(creds.AccessToken)), nil
 	}) {
 		return buildFailedResponse(cspType, authMethod, 5, steps), nil
 	}
 
+	// Step 6: 임시자격증명 발급 (step 4-5에서 이미 발급된 자격증명 요약)
+	var credSummary *model.CredentialSummary
 	if !stepRunner(steps, 5, nil, func() (string, error) {
-		creds, err := gcpCredService.ExchangeTokenAndImpersonate(ctx, wifProvider, saEmail, accessToken, "jwt")
-		if err != nil {
-			return "", fmt.Errorf("GCP 자격증명 발급 실패: %v — WIF Pool/Provider 설정 또는 SA 권한 확인", err)
-		}
 		credSummary = &model.CredentialSummary{
 			AccessKeyId: creds.AccessToken,
 			Expiration:  creds.Expiration,

--- a/src/service/csp_validation_service.go
+++ b/src/service/csp_validation_service.go
@@ -45,6 +45,138 @@ func NewCspValidationService(db *gorm.DB) *CspValidationService {
 	}
 }
 
+// --- AWS 검증 실패 단계별 RemediationGuide (CSP 콘솔에서의 조치 방법) ---
+// 상세 절차는 mcmp-workflow/mc-iam-manager/design/CSP-ADMIN-WORKFLOW.md 참조.
+
+// awsOidcProviderRemediation Step 4 (AWS OIDC Provider 확인) 실패 시 안내
+var awsOidcProviderRemediation = &model.RemediationGuide{
+	Summary: "AWS에 Keycloak을 신뢰하는 OIDC Identity Provider가 등록되어 있지 않습니다.",
+	ConsoleSteps: []string{
+		"AWS Console → IAM → Identity providers → Add provider",
+		"Provider type: OpenID Connect",
+		"Provider URL: Keycloak realm issuer URL (예: https://<keycloak-host>/realms/<realm>)",
+		"Audience: mc-iam-manager Keycloak OIDC 클라이언트 ID",
+		"생성 후 ARN을 CspRole.idp_identifier에 등록",
+	},
+	DocsRef: "mcmp-workflow/mc-iam-manager/design/CSP-ADMIN-WORKFLOW.md#step-4",
+}
+
+// awsOidcRoleTrustRemediation Step 5 (IAM Role WebIdentity Trust 확인) 실패 시 안내
+var awsOidcRoleTrustRemediation = &model.RemediationGuide{
+	Summary: "IAM Role의 Trust Policy에 OIDC Provider를 통한 AssumeRoleWithWebIdentity 권한이 없습니다.",
+	ConsoleSteps: []string{
+		"AWS Console → IAM → Roles → 대상 역할 선택 → Trust relationships → Edit trust policy",
+	},
+	Template: `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "<OIDC Provider ARN>"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "<keycloak-host>/realms/<realm>:aud": "<Keycloak OIDC 클라이언트 ID>"
+        }
+      }
+    }
+  ]
+}`,
+	DocsRef: "mcmp-workflow/mc-iam-manager/design/CSP-ADMIN-WORKFLOW.md#step-5",
+}
+
+// awsKeycloakOidcClientRemediation Step 3 (Keycloak OIDC 토큰 발급) 실패 시 안내 — Keycloak 서비스 계정/클라이언트 설정 확인
+var awsKeycloakOidcClientRemediation = &model.RemediationGuide{
+	Summary: "Keycloak OIDC 클라이언트(Service Account) 설정이 올바르지 않아 토큰 발급에 실패했습니다.",
+	ConsoleSteps: []string{
+		"Keycloak Admin Console → Clients → <OIDC 클라이언트> → Settings에서 Client authentication: On, Service accounts roles: On 확인",
+		"Realm settings → Client policies에서 Token Exchange가 허용되어 있는지 확인",
+		"MC_IAM_MANAGER_KEYCLOAK_OIDC_CLIENT_ID/SECRET 환경변수가 실제 Keycloak 클라이언트와 일치하는지 확인",
+	},
+	DocsRef: "mcmp-workflow/mc-iam-manager/design/CSP-ADMIN-WORKFLOW.md#step-1",
+}
+
+// awsSamlProviderRemediation Step 5 (AWS SAML Provider 확인) 실패 시 안내
+var awsSamlProviderRemediation = &model.RemediationGuide{
+	Summary: "AWS에 Keycloak SAML 메타데이터로 등록된 SAML Identity Provider가 없습니다.",
+	ConsoleSteps: []string{
+		"AWS Console → IAM → Identity providers → Add provider",
+		"Provider type: SAML",
+		"Keycloak SAML 클라이언트의 메타데이터 XML 업로드 (예: https://<keycloak-host>/realms/<realm>/protocol/saml/descriptor)",
+		"생성 후 ARN을 CspRole.idp_identifier에 등록",
+	},
+	DocsRef: "mcmp-workflow/mc-iam-manager/design/CSP-ADMIN-WORKFLOW.md#step-4",
+}
+
+// awsSamlRoleTrustRemediation Step 6 (IAM Role SAML Trust 확인) 실패 시 안내
+var awsSamlRoleTrustRemediation = &model.RemediationGuide{
+	Summary: "IAM Role의 Trust Policy에 SAML Provider를 통한 AssumeRoleWithSAML 권한이 없습니다.",
+	ConsoleSteps: []string{
+		"AWS Console → IAM → Roles → 대상 역할 선택 → Trust relationships → Edit trust policy",
+	},
+	Template: `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "<SAML Provider ARN>"
+      },
+      "Action": "sts:AssumeRoleWithSAML",
+      "Condition": {
+        "StringEquals": {
+          "SAML:aud": "https://signin.aws.amazon.com/saml"
+        }
+      }
+    }
+  ]
+}`,
+	DocsRef: "mcmp-workflow/mc-iam-manager/design/CSP-ADMIN-WORKFLOW.md#step-5",
+}
+
+// awsKeycloakSamlClientRemediation Step 3 (Keycloak SAML 클라이언트 확인) 실패 시 안내
+var awsKeycloakSamlClientRemediation = &model.RemediationGuide{
+	Summary: "Keycloak에 AWS SAML 연동용 클라이언트가 없거나 Role attribute mapper가 설정되어 있지 않습니다.",
+	ConsoleSteps: []string{
+		"Keycloak Admin Console → Clients → Create client (Client Type: SAML)",
+		"Client ID: urn:amazon:webservices (AWS 기준)",
+		"Client scopes → Protocol mappers에 Role List mapper 추가 (Attribute name: https://aws.amazon.com/SAML/Attributes/Role)",
+	},
+	DocsRef: "mcmp-workflow/mc-iam-manager/design/CSP-ADMIN-WORKFLOW.md#step-1",
+}
+
+// awsKeycloakSamlAssertionRemediation Step 4 (SAML Assertion 발급 및 검증) 실패 시 안내
+var awsKeycloakSamlAssertionRemediation = &model.RemediationGuide{
+	Summary: "SAML Assertion 발급에 실패했습니다 — Keycloak SAML 클라이언트/서비스 계정 설정을 확인하세요.",
+	ConsoleSteps: []string{
+		"Keycloak Admin Console에서 SAML 클라이언트가 활성화(Enabled)되어 있는지 확인",
+		"MC_IAM_MANAGER_PLATFORMADMIN_ID/PASSWORD 환경변수로 platform admin 로그인이 가능한지 확인",
+		"Realm settings → Client policies에서 Token Exchange 허용 여부 확인",
+	},
+	DocsRef: "mcmp-workflow/mc-iam-manager/design/CSP-ADMIN-WORKFLOW.md#step-1",
+}
+
+// awsSecretKeyConfigRemediation Step 2 (CspIdpConfig 설정 확인, SECRET_KEY) 실패 시 안내
+var awsSecretKeyConfigRemediation = &model.RemediationGuide{
+	Summary: "AWS Access Key/Secret Key가 CspIdpConfig에 등록되어 있지 않습니다.",
+	ConsoleSteps: []string{
+		"AWS Console → IAM → Users → 대상 사용자 → Security credentials → Create access key",
+		"발급된 access_key_id/secret_access_key를 CspIdpConfig.Config에 등록 (POST /api/csp-idp-configs)",
+	},
+	DocsRef: "mcmp-workflow/mc-iam-manager/design/CSP-ADMIN-WORKFLOW.md#step-4",
+}
+
+// awsSecretKeyInvalidRemediation Step 3 (AWS 연결 확인, SECRET_KEY) 실패 시 안내
+var awsSecretKeyInvalidRemediation = &model.RemediationGuide{
+	Summary: "등록된 Access Key/Secret Key가 유효하지 않습니다 (AWS STS GetCallerIdentity 실패).",
+	ConsoleSteps: []string{
+		"AWS Console에서 해당 IAM 사용자의 Access Key가 활성 상태(Active)인지 확인",
+		"키가 비활성화/삭제되었다면 새 키를 발급하여 CspIdpConfig 갱신",
+	},
+}
+
 // resolveUserRepo 테스트 주입 우선, 없으면 프로덕션 repo 반환
 func (s *CspValidationService) resolveUserRepo() valUserRepo {
 	if s.userRepoIface != nil {
@@ -218,7 +350,7 @@ func (s *CspValidationService) validateAWSWithOIDC(ctx context.Context, userID u
 
 	// Step 3: Keycloak OIDC 토큰 발급
 	var accessToken string
-	if !stepRunner(steps, 2, nil, func() (string, error) {
+	if !stepRunner(steps, 2, awsKeycloakOidcClientRemediation, func() (string, error) {
 		jwt, err := s.keycloakService.GetImpersonationTokenByServiceAccount(ctx)
 		if err != nil {
 			return "", fmt.Errorf("Keycloak OIDC 토큰 발급 실패: %v — Keycloak OIDC 클라이언트 설정 또는 시크릿 확인", err)
@@ -234,14 +366,14 @@ func (s *CspValidationService) validateAWSWithOIDC(ctx context.Context, userID u
 	}
 
 	// Step 4: AWS OIDC Provider 확인
-	if !stepRunner(steps, 3, nil, func() (string, error) {
+	if !stepRunner(steps, 3, awsOidcProviderRemediation, func() (string, error) {
 		return s.awsCredService.CheckOIDCProvider(ctx, idpArn)
 	}) {
 		return buildFailedResponse(cspType, authMethod, 4, steps), nil
 	}
 
 	// Step 5: IAM Role WebIdentity Trust 확인
-	if !stepRunner(steps, 4, nil, func() (string, error) {
+	if !stepRunner(steps, 4, awsOidcRoleTrustRemediation, func() (string, error) {
 		return s.awsCredService.CheckRoleTrust(ctx, roleArn, "sts:AssumeRoleWithWebIdentity", idpArn)
 	}) {
 		return buildFailedResponse(cspType, authMethod, 5, steps), nil
@@ -321,7 +453,7 @@ func (s *CspValidationService) validateAWSWithSAML(ctx context.Context, userID u
 	if cspType == "aws" && !strings.Contains(kcSamlClientID, "urn:amazon") {
 		kcSamlClientID = os.Getenv("SAML_CLIENT_ID_AWS")
 	}
-	if !stepRunner(steps, 2, nil, func() (string, error) {
+	if !stepRunner(steps, 2, awsKeycloakSamlClientRemediation, func() (string, error) {
 		return s.keycloakService.CheckSAMLClientConfig(ctx, kcSamlClientID)
 	}) {
 		return buildFailedResponse(cspType, authMethod, 3, steps), nil
@@ -330,7 +462,7 @@ func (s *CspValidationService) validateAWSWithSAML(ctx context.Context, userID u
 	// Step 4: SAML Assertion 발급 및 검증
 	// token exchange audience는 Keycloak 클라이언트 ID (kcSamlClientID) 사용
 	var samlAssertion string
-	if !stepRunner(steps, 3, nil, func() (string, error) {
+	if !stepRunner(steps, 3, awsKeycloakSamlAssertionRemediation, func() (string, error) {
 		assertion, err := s.keycloakService.GetSamlAssertionByServiceAccount(ctx, kcSamlClientID)
 		if err != nil {
 			return "", fmt.Errorf("SAML Assertion 발급 실패: %v — Keycloak SAML 클라이언트 설정 확인", err)
@@ -344,14 +476,14 @@ func (s *CspValidationService) validateAWSWithSAML(ctx context.Context, userID u
 	}
 
 	// Step 5: AWS SAML Provider 확인
-	if !stepRunner(steps, 4, nil, func() (string, error) {
+	if !stepRunner(steps, 4, awsSamlProviderRemediation, func() (string, error) {
 		return s.awsCredService.CheckSAMLProvider(ctx, principalArn)
 	}) {
 		return buildFailedResponse(cspType, authMethod, 5, steps), nil
 	}
 
 	// Step 6: IAM Role SAML Trust 확인
-	if !stepRunner(steps, 5, nil, func() (string, error) {
+	if !stepRunner(steps, 5, awsSamlRoleTrustRemediation, func() (string, error) {
 		return s.awsCredService.CheckRoleTrust(ctx, roleArn, "sts:AssumeRoleWithSAML", principalArn)
 	}) {
 		return buildFailedResponse(cspType, authMethod, 6, steps), nil
@@ -409,7 +541,7 @@ func (s *CspValidationService) validateAWSWithSecretKey(ctx context.Context, use
 
 	// Step 2: CspIdpConfig 설정 확인
 	var accessKeyID, secretKey string
-	if !stepRunner(steps, 1, nil, func() (string, error) {
+	if !stepRunner(steps, 1, awsSecretKeyConfigRemediation, func() (string, error) {
 		cspRole := mapping.CspRoles[0]
 		if cspRole.CspIdpConfig == nil {
 			return "", fmt.Errorf("CspIdpConfig 없음 — CspRole에 IDP 설정 연결 필요")
@@ -425,7 +557,7 @@ func (s *CspValidationService) validateAWSWithSecretKey(ctx context.Context, use
 	}
 
 	// Step 3: AWS 연결 확인 (GetCallerIdentity)
-	if !stepRunner(steps, 2, nil, func() (string, error) {
+	if !stepRunner(steps, 2, awsSecretKeyInvalidRemediation, func() (string, error) {
 		return s.awsCredService.CheckCallerIdentity(ctx, accessKeyID, secretKey)
 	}) {
 		return buildFailedResponse(cspType, authMethod, 3, steps), nil

--- a/src/service/csp_validation_service_test.go
+++ b/src/service/csp_validation_service_test.go
@@ -611,6 +611,83 @@ func TestValidateGCPWithOIDC_Step3_KcFail(t *testing.T) {
 	assert.Equal(t, 3, resp.FailedStep)
 }
 
+// TC-VAL-GCP-04: Step 4 실패 — GCP STS 토큰 교환 실패 (WIF Pool/Provider 미설정) → remediation 첨부
+func TestValidateGCPWithOIDC_Step4_StsFail(t *testing.T) {
+	mapping := buildValMapping("OIDC",
+		"//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/kc",
+		"sa@project.iam.gserviceaccount.com",
+	)
+	kc := &mockValKcService{oidcToken: &gocloak.JWT{AccessToken: "valid-oidc-jwt-token-1234567890"}}
+	svc := newValService(stdValUserRole(), nil, mapping, nil, kc, nil)
+	svc.gcpCredServiceIface = &mockGcpCredService{exchangeErr: errors.New("GCP STS returned HTTP 400: invalid audience")}
+
+	resp, err := svc.ValidateCredentials(context.Background(), 1, "kc_user", valReq("gcp", "OIDC"))
+
+	require.NoError(t, err)
+	assert.False(t, resp.Valid)
+	assert.Equal(t, 4, resp.FailedStep)
+	require.NotNil(t, resp.Steps[3].Remediation)
+	assert.Equal(t, gcpStsRemediation.Summary, resp.Steps[3].Remediation.Summary)
+	// Step 5 이후는 skipped
+	assert.Equal(t, model.ValidationStepSkipped, resp.Steps[4].Status)
+	assert.Nil(t, resp.Steps[4].Remediation)
+}
+
+// TC-VAL-GCP-05: Step 5 실패 — SA Impersonation 실패 (SA 없음/권한 없음) → remediation 첨부
+func TestValidateGCPWithOIDC_Step5_SaImpersonationFail(t *testing.T) {
+	mapping := buildValMapping("OIDC",
+		"//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/kc",
+		"sa@project.iam.gserviceaccount.com",
+	)
+	kc := &mockValKcService{oidcToken: &gocloak.JWT{AccessToken: "valid-oidc-jwt-token-1234567890"}}
+	svc := newValService(stdValUserRole(), nil, mapping, nil, kc, nil)
+	svc.gcpCredServiceIface = &mockGcpCredService{
+		federatedToken: "federated-token-abc",
+		genErr:         errors.New("GCP IAM Credentials returned HTTP 403: permission denied"),
+	}
+
+	resp, err := svc.ValidateCredentials(context.Background(), 1, "kc_user", valReq("gcp", "OIDC"))
+
+	require.NoError(t, err)
+	assert.False(t, resp.Valid)
+	assert.Equal(t, 5, resp.FailedStep)
+	// Step 4는 성공(ok)이어야 함
+	assert.Equal(t, model.ValidationStepOk, resp.Steps[3].Status)
+	require.NotNil(t, resp.Steps[4].Remediation)
+	assert.Equal(t, gcpSaImpersonationRemediation.Summary, resp.Steps[4].Remediation.Summary)
+}
+
+// TC-VAL-GCP-06: 전체 성공 — Step 4~6 모두 통과, credentials 반환
+func TestValidateGCPWithOIDC_Step6_Success(t *testing.T) {
+	mapping := buildValMapping("OIDC",
+		"//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/kc",
+		"sa@project.iam.gserviceaccount.com",
+	)
+	kc := &mockValKcService{oidcToken: &gocloak.JWT{AccessToken: "valid-oidc-jwt-token-1234567890"}}
+	svc := newValService(stdValUserRole(), nil, mapping, nil, kc, nil)
+	svc.gcpCredServiceIface = &mockGcpCredService{
+		federatedToken: "federated-token-abc",
+		genResult: &model.CspCredentialResponse{
+			CspType:     "gcp",
+			AccessToken: "sa-impersonated-access-token",
+			TokenType:   "Bearer",
+			Expiration:  time.Now().Add(1 * time.Hour),
+		},
+	}
+
+	resp, err := svc.ValidateCredentials(context.Background(), 1, "kc_user", valReq("gcp", "OIDC"))
+
+	require.NoError(t, err)
+	assert.True(t, resp.Valid)
+	assert.Equal(t, 0, resp.FailedStep)
+	require.NotNil(t, resp.Credentials)
+	assert.Equal(t, "sa-impersonated-access-token", resp.Credentials.AccessKeyId)
+	for _, step := range resp.Steps {
+		assert.Equal(t, model.ValidationStepOk, step.Status)
+		assert.Nil(t, step.Remediation)
+	}
+}
+
 // ── 응답 구조 완전성 검증 ─────────────────────────────────────────────────────
 
 // TC-VAL-RESP-01: 실패 응답에 항상 전체 단계 포함

--- a/src/service/csp_validation_service_test.go
+++ b/src/service/csp_validation_service_test.go
@@ -206,7 +206,7 @@ func TestBuildValidationSteps_Unsupported(t *testing.T) {
 // TC-VAL-RUNNER-01: 성공 시 ok 상태 반환
 func TestStepRunner_Success(t *testing.T) {
 	steps := buildValidationSteps("aws", "SECRET_KEY")
-	ok := stepRunner(steps, 0, func() (string, error) {
+	ok := stepRunner(steps, 0, nil, func() (string, error) {
 		return "detail text", nil
 	})
 	assert.True(t, ok)
@@ -217,7 +217,7 @@ func TestStepRunner_Success(t *testing.T) {
 // TC-VAL-RUNNER-02: 실패 시 failed 상태 + false 반환
 func TestStepRunner_Failure(t *testing.T) {
 	steps := buildValidationSteps("aws", "SECRET_KEY")
-	ok := stepRunner(steps, 0, func() (string, error) {
+	ok := stepRunner(steps, 0, nil, func() (string, error) {
 		return "", errors.New("something went wrong")
 	})
 	assert.False(t, ok)

--- a/src/service/csp_validation_service_test.go
+++ b/src/service/csp_validation_service_test.go
@@ -33,11 +33,11 @@ func (m *mockValMappingRepo) FindCspRoleMappingsByRoleIDAndCspType(roleID uint, 
 }
 
 type mockValKcService struct {
-	mockKeycloakService          // 기본 stub 재사용
-	oidcToken       *gocloak.JWT
-	oidcErr         error
-	samlAssertion   string
-	samlErr         error
+	mockKeycloakService // 기본 stub 재사용
+	oidcToken           *gocloak.JWT
+	oidcErr             error
+	samlAssertion       string
+	samlErr             error
 }
 
 func (m *mockValKcService) GetImpersonationTokenByServiceAccount(ctx context.Context) (*gocloak.JWT, error) {
@@ -55,6 +55,11 @@ type mockValAwsService struct {
 	oidcErr    error
 	samlResult *model.CspCredentialResponse
 	samlErr    error
+
+	oidcProviderErr   error
+	samlProviderErr   error
+	roleTrustErr      error
+	callerIdentityErr error
 }
 
 func (m *mockValAwsService) AssumeRoleWithWebIdentity(_ context.Context, roleArn, kcUserId, token, idpArn, region string) (*model.CspCredentialResponse, error) {
@@ -64,15 +69,27 @@ func (m *mockValAwsService) AssumeRoleWithSAML(_ context.Context, roleArn, princ
 	return m.samlResult, m.samlErr
 }
 func (m *mockValAwsService) CheckOIDCProvider(_ context.Context, oidcProviderArn string) (string, error) {
+	if m.oidcProviderErr != nil {
+		return "", m.oidcProviderErr
+	}
 	return "", nil
 }
 func (m *mockValAwsService) CheckSAMLProvider(_ context.Context, samlProviderArn string) (string, error) {
+	if m.samlProviderErr != nil {
+		return "", m.samlProviderErr
+	}
 	return "", nil
 }
 func (m *mockValAwsService) CheckRoleTrust(_ context.Context, roleArn, expectedAction, expectedProviderArn string) (string, error) {
+	if m.roleTrustErr != nil {
+		return "", m.roleTrustErr
+	}
 	return "", nil
 }
 func (m *mockValAwsService) CheckCallerIdentity(_ context.Context, accessKeyID, secretKey string) (string, error) {
+	if m.callerIdentityErr != nil {
+		return "", m.callerIdentityErr
+	}
 	return "", nil
 }
 
@@ -346,6 +363,65 @@ func TestValidateAWSWithOIDC_Step6_STSFail(t *testing.T) {
 	assert.Equal(t, 6, resp.FailedStep)
 }
 
+// ── AWS OIDC 실패 단계 RemediationGuide 검증 ─────────────────────────────────
+
+// TestValidateAWSWithOIDC_Step3_Remediation: Keycloak 토큰 발급 실패 시 Keycloak 설정 안내 첨부
+func TestValidateAWSWithOIDC_Step3_Remediation(t *testing.T) {
+	mapping := buildValMapping("OIDC",
+		"arn:aws:iam::123:oidc-provider/keycloak.example.com",
+		"arn:aws:iam::123:role/test-role",
+	)
+	kc := &mockValKcService{oidcErr: errValKcFail}
+	svc := newValService(stdValUserRole(), nil, mapping, nil, kc, nil)
+
+	resp, err := svc.ValidateCredentials(context.Background(), 1, "kc_user", valReq("aws", "OIDC"))
+
+	require.NoError(t, err)
+	require.Equal(t, 3, resp.FailedStep)
+	require.NotNil(t, resp.Steps[2].Remediation)
+	assert.Equal(t, awsKeycloakOidcClientRemediation.Summary, resp.Steps[2].Remediation.Summary)
+	assert.NotEmpty(t, resp.Steps[2].Remediation.ConsoleSteps)
+}
+
+// TestValidateAWSWithOIDC_Step4_Remediation: AWS OIDC Provider 미존재 시 IAM 콘솔 안내 첨부
+func TestValidateAWSWithOIDC_Step4_Remediation(t *testing.T) {
+	mapping := buildValMapping("OIDC",
+		"arn:aws:iam::123:oidc-provider/keycloak.example.com",
+		"arn:aws:iam::123:role/test-role",
+	)
+	kc := &mockValKcService{oidcToken: &gocloak.JWT{AccessToken: "a_very_long_kc_access_token_that_exceeds_100_chars_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}}
+	awsSvc := &mockValAwsService{oidcProviderErr: errValAwsFail}
+	svc := newValService(stdValUserRole(), nil, mapping, nil, kc, awsSvc)
+
+	resp, err := svc.ValidateCredentials(context.Background(), 1, "kc_user", valReq("aws", "OIDC"))
+
+	require.NoError(t, err)
+	require.Equal(t, 4, resp.FailedStep)
+	require.NotNil(t, resp.Steps[3].Remediation)
+	assert.Equal(t, awsOidcProviderRemediation.Summary, resp.Steps[3].Remediation.Summary)
+	assert.NotEmpty(t, resp.Steps[3].Remediation.ConsoleSteps)
+	assert.Contains(t, resp.Steps[3].Remediation.DocsRef, "CSP-ADMIN-WORKFLOW.md")
+}
+
+// TestValidateAWSWithOIDC_Step5_Remediation: IAM Role Trust 실패 시 Trust Policy 템플릿 첨부
+func TestValidateAWSWithOIDC_Step5_Remediation(t *testing.T) {
+	mapping := buildValMapping("OIDC",
+		"arn:aws:iam::123:oidc-provider/keycloak.example.com",
+		"arn:aws:iam::123:role/test-role",
+	)
+	kc := &mockValKcService{oidcToken: &gocloak.JWT{AccessToken: "a_very_long_kc_access_token_that_exceeds_100_chars_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}}
+	awsSvc := &mockValAwsService{roleTrustErr: errValAwsFail}
+	svc := newValService(stdValUserRole(), nil, mapping, nil, kc, awsSvc)
+
+	resp, err := svc.ValidateCredentials(context.Background(), 1, "kc_user", valReq("aws", "OIDC"))
+
+	require.NoError(t, err)
+	require.Equal(t, 5, resp.FailedStep)
+	require.NotNil(t, resp.Steps[4].Remediation)
+	assert.Equal(t, awsOidcRoleTrustRemediation.Summary, resp.Steps[4].Remediation.Summary)
+	assert.Contains(t, resp.Steps[4].Remediation.Template, "AssumeRoleWithWebIdentity")
+}
+
 // ── AWS SAML 단계별 실패 시나리오 ─────────────────────────────────────────────
 
 // TC-VAL-SAML-01: Step 1 실패 — 워크스페이스 역할 없음
@@ -379,6 +455,46 @@ func TestValidateAWSWithSAML_Step4_AssertionFail(t *testing.T) {
 	// checkKeycloakSAMLClient는 외부 의존성이므로 Step 3은 실패할 수 있음
 	// → SAML Step 4 테스트는 integration 테스트에서 수행
 	t.Skip("Step 3 requires real Keycloak connection — covered in integration tests")
+}
+
+// ── AWS SAML 실패 단계 RemediationGuide 검증 ─────────────────────────────────
+
+// TestValidateAWSWithSAML_Step5_Remediation: AWS SAML Provider 미존재 시 IAM 콘솔 안내 첨부
+func TestValidateAWSWithSAML_Step5_Remediation(t *testing.T) {
+	mapping := buildValMapping("SAML",
+		"arn:aws:iam::123:saml-provider/keycloak",
+		"arn:aws:iam::123:role/test-role",
+	)
+	kc := &mockValKcService{samlAssertion: "assertion-data"}
+	awsSvc := &mockValAwsService{samlProviderErr: errValAwsFail}
+	svc := newValService(stdValUserRole(), nil, mapping, nil, kc, awsSvc)
+
+	resp, err := svc.ValidateCredentials(context.Background(), 1, "kc_user", valReq("aws", "SAML"))
+
+	require.NoError(t, err)
+	require.Equal(t, 5, resp.FailedStep)
+	require.NotNil(t, resp.Steps[4].Remediation)
+	assert.Equal(t, awsSamlProviderRemediation.Summary, resp.Steps[4].Remediation.Summary)
+	assert.NotEmpty(t, resp.Steps[4].Remediation.ConsoleSteps)
+}
+
+// TestValidateAWSWithSAML_Step6_Remediation: IAM Role SAML Trust 실패 시 Trust Policy 템플릿 첨부
+func TestValidateAWSWithSAML_Step6_Remediation(t *testing.T) {
+	mapping := buildValMapping("SAML",
+		"arn:aws:iam::123:saml-provider/keycloak",
+		"arn:aws:iam::123:role/test-role",
+	)
+	kc := &mockValKcService{samlAssertion: "assertion-data"}
+	awsSvc := &mockValAwsService{roleTrustErr: errValAwsFail}
+	svc := newValService(stdValUserRole(), nil, mapping, nil, kc, awsSvc)
+
+	resp, err := svc.ValidateCredentials(context.Background(), 1, "kc_user", valReq("aws", "SAML"))
+
+	require.NoError(t, err)
+	require.Equal(t, 6, resp.FailedStep)
+	require.NotNil(t, resp.Steps[5].Remediation)
+	assert.Equal(t, awsSamlRoleTrustRemediation.Summary, resp.Steps[5].Remediation.Summary)
+	assert.Contains(t, resp.Steps[5].Remediation.Template, "AssumeRoleWithSAML")
 }
 
 // ── AWS SECRET_KEY 단계별 시나리오 ────────────────────────────────────────────
@@ -419,6 +535,37 @@ func TestValidateAWSWithSecretKey_Step2_EmptyKeyID(t *testing.T) {
 	assert.False(t, resp.Valid)
 	assert.Equal(t, 2, resp.FailedStep)
 	assert.Contains(t, resp.Error, "access_key_id 또는 secret_access_key 비어 있음")
+}
+
+// ── AWS SECRET_KEY 실패 단계 RemediationGuide 검증 ───────────────────────────
+
+// TestValidateAWSWithSecretKey_Step2_Remediation: CspIdpConfig 없음 → 콘솔 안내 첨부
+func TestValidateAWSWithSecretKey_Step2_Remediation(t *testing.T) {
+	mapping := buildValMapping("SECRET_KEY", "", "") // CspIdpConfig nil
+	svc := newValService(stdValUserRole(), nil, mapping, nil, nil, nil)
+
+	resp, err := svc.ValidateCredentials(context.Background(), 1, "kc_user", valReq("aws", "SECRET_KEY"))
+
+	require.NoError(t, err)
+	require.Equal(t, 2, resp.FailedStep)
+	require.NotNil(t, resp.Steps[1].Remediation)
+	assert.Equal(t, awsSecretKeyConfigRemediation.Summary, resp.Steps[1].Remediation.Summary)
+	assert.NotEmpty(t, resp.Steps[1].Remediation.ConsoleSteps)
+}
+
+// TestValidateAWSWithSecretKey_Step3_Remediation: GetCallerIdentity 실패 → 콘솔 안내 첨부
+func TestValidateAWSWithSecretKey_Step3_Remediation(t *testing.T) {
+	mapping := buildValMappingWithSecretKey("AKIAEXAMPLE", "secretvalue")
+	awsSvc := &mockValAwsService{callerIdentityErr: errValAwsFail}
+	svc := newValService(stdValUserRole(), nil, mapping, nil, nil, awsSvc)
+
+	resp, err := svc.ValidateCredentials(context.Background(), 1, "kc_user", valReq("aws", "SECRET_KEY"))
+
+	require.NoError(t, err)
+	require.Equal(t, 3, resp.FailedStep)
+	require.NotNil(t, resp.Steps[2].Remediation)
+	assert.Equal(t, awsSecretKeyInvalidRemediation.Summary, resp.Steps[2].Remediation.Summary)
+	assert.NotEmpty(t, resp.Steps[2].Remediation.ConsoleSteps)
 }
 
 // ── GCP OIDC 단계별 시나리오 ─────────────────────────────────────────────────

--- a/src/service/gcp_credential_service.go
+++ b/src/service/gcp_credential_service.go
@@ -24,9 +24,37 @@ type GcpCredentialService interface {
 		subjectToken string,
 		subjectTokenType string, // "jwt" (OIDC) or "saml2" (SAML)
 	) (*model.CspCredentialResponse, error)
+
+	// ExchangeToken performs step 1 of the WIF flow only: exchanges a Keycloak
+	// subject token for a GCP federated access token via GCP STS. Exposed
+	// separately so callers (e.g. CspValidationService) can verify WIF
+	// Pool/Provider configuration independently of SA impersonation.
+	ExchangeToken(
+		ctx context.Context,
+		wifProviderResourceName string,
+		subjectToken string,
+		subjectTokenType string, // "jwt" (OIDC) or "saml2" (SAML)
+	) (string, error)
+
+	// GenerateAccessToken performs step 2 of the WIF flow only: impersonates
+	// the given Service Account using a previously obtained federated token.
+	// Exposed separately so callers can verify SA existence/WIF binding
+	// independently of the STS token exchange.
+	GenerateAccessToken(
+		ctx context.Context,
+		serviceAccountEmail string,
+		federatedToken string,
+	) (*model.CspCredentialResponse, error)
 }
 
 type gcpCredentialService struct{}
+
+// gcpSTSURL and gcpIAMCredentialsURLFormat are package-level vars (rather than
+// inline constants) so unit tests can point them at an httptest server.
+var (
+	gcpSTSURL                  = "https://sts.googleapis.com/v1/token"
+	gcpIAMCredentialsURLFormat = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken"
+)
 
 // NewGcpCredentialService creates a new GcpCredentialService.
 func NewGcpCredentialService() GcpCredentialService {
@@ -67,7 +95,7 @@ func (s *gcpCredentialService) ExchangeTokenAndImpersonate(
 	log.Printf("[GCP_CREDENTIAL] Starting WIF token exchange for SA: %s (tokenType: %s)", serviceAccountEmail, subjectTokenType)
 
 	// Step 1: Exchange Keycloak token for GCP federated access token via GCP STS
-	federatedToken, err := s.exchangeToken(ctx, wifProviderResourceName, subjectToken, subjectTokenType)
+	federatedToken, err := s.ExchangeToken(ctx, wifProviderResourceName, subjectToken, subjectTokenType)
 	if err != nil {
 		log.Printf("[GCP_CREDENTIAL] STS token exchange failed: %v", err)
 		return nil, fmt.Errorf("GCP STS token exchange failed: %w", err)
@@ -75,13 +103,38 @@ func (s *gcpCredentialService) ExchangeTokenAndImpersonate(
 	log.Printf("[GCP_CREDENTIAL] STS token exchange succeeded")
 
 	// Step 2: Use federated token to impersonate Service Account
-	saToken, expireTime, err := s.generateAccessToken(ctx, serviceAccountEmail, federatedToken)
+	creds, err := s.GenerateAccessToken(ctx, serviceAccountEmail, federatedToken)
 	if err != nil {
 		log.Printf("[GCP_CREDENTIAL] SA impersonation failed: %v", err)
 		return nil, fmt.Errorf("GCP SA impersonation failed: %w", err)
 	}
-	log.Printf("[GCP_CREDENTIAL] SA impersonation succeeded, expiry: %s", expireTime)
+	log.Printf("[GCP_CREDENTIAL] SA impersonation succeeded, expiry: %s", creds.Expiration)
 
+	return creds, nil
+}
+
+// ExchangeToken exchanges a Keycloak subject token for a GCP federated access
+// token via GCP STS (step 1 of the WIF flow).
+func (s *gcpCredentialService) ExchangeToken(
+	ctx context.Context,
+	wifProviderResourceName string,
+	subjectToken string,
+	subjectTokenType string,
+) (string, error) {
+	return s.exchangeToken(ctx, wifProviderResourceName, subjectToken, subjectTokenType)
+}
+
+// GenerateAccessToken impersonates the given Service Account using a
+// federated access token (step 2 of the WIF flow).
+func (s *gcpCredentialService) GenerateAccessToken(
+	ctx context.Context,
+	serviceAccountEmail string,
+	federatedToken string,
+) (*model.CspCredentialResponse, error) {
+	saToken, expireTime, err := s.generateAccessToken(ctx, serviceAccountEmail, federatedToken)
+	if err != nil {
+		return nil, err
+	}
 	return &model.CspCredentialResponse{
 		CspType:     "gcp",
 		AccessToken: saToken,
@@ -93,7 +146,7 @@ func (s *gcpCredentialService) ExchangeTokenAndImpersonate(
 // exchangeToken calls GCP STS to exchange a subject token for a federated access token.
 // subjectTokenType: "jwt" for OIDC, "saml2" for SAML2 assertion.
 func (s *gcpCredentialService) exchangeToken(ctx context.Context, audience, subjectToken, subjectTokenType string) (string, error) {
-	stsURL := "https://sts.googleapis.com/v1/token"
+	stsURL := gcpSTSURL
 
 	tokenTypeURN := "urn:ietf:params:oauth:token-type:jwt"
 	if subjectTokenType == "saml2" {
@@ -143,10 +196,7 @@ func (s *gcpCredentialService) exchangeToken(ctx context.Context, audience, subj
 
 // generateAccessToken calls GCP IAM Credentials API to impersonate a Service Account.
 func (s *gcpCredentialService) generateAccessToken(ctx context.Context, serviceAccountEmail, federatedToken string) (string, time.Time, error) {
-	iamURL := fmt.Sprintf(
-		"https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken",
-		serviceAccountEmail,
-	)
+	iamURL := fmt.Sprintf(gcpIAMCredentialsURLFormat, serviceAccountEmail)
 
 	reqBody := gcpGenerateAccessTokenRequest{
 		Scope: []string{"https://www.googleapis.com/auth/cloud-platform"},

--- a/src/service/gcp_credential_service_test.go
+++ b/src/service/gcp_credential_service_test.go
@@ -1,0 +1,145 @@
+package service
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withGcpTestURLs swaps the package-level GCP STS/IAM Credentials endpoint
+// vars for the given httptest server URLs for the duration of the test.
+func withGcpTestURLs(t *testing.T, stsURL, iamURLFormat string) {
+	t.Helper()
+	origSTS, origIAM := gcpSTSURL, gcpIAMCredentialsURLFormat
+	if stsURL != "" {
+		gcpSTSURL = stsURL
+	}
+	if iamURLFormat != "" {
+		gcpIAMCredentialsURLFormat = iamURLFormat
+	}
+	t.Cleanup(func() {
+		gcpSTSURL = origSTS
+		gcpIAMCredentialsURLFormat = origIAM
+	})
+}
+
+// TC-GCP-CRED-01: ExchangeToken — STS 200 응답 시 federated token 반환
+func TestGcpCredentialService_ExchangeToken_Success(t *testing.T) {
+	sts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"access_token":"federated-token-123","issued_token_type":"urn:ietf:params:oauth:token-type:access_token","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer sts.Close()
+	withGcpTestURLs(t, sts.URL, "")
+
+	svc := NewGcpCredentialService()
+	token, err := svc.ExchangeToken(context.Background(), "//iam.googleapis.com/projects/123/.../providers/kc", "kc-jwt", "jwt")
+
+	require.NoError(t, err)
+	assert.Equal(t, "federated-token-123", token)
+}
+
+// TC-GCP-CRED-02: ExchangeToken — STS 4xx 응답 시 오류 반환 (WIF Pool/Provider 미설정 시나리오)
+func TestGcpCredentialService_ExchangeToken_HttpError(t *testing.T) {
+	sts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":"invalid_target","error_description":"unknown audience"}`))
+	}))
+	defer sts.Close()
+	withGcpTestURLs(t, sts.URL, "")
+
+	svc := NewGcpCredentialService()
+	token, err := svc.ExchangeToken(context.Background(), "bad-audience", "kc-jwt", "jwt")
+
+	require.Error(t, err)
+	assert.Empty(t, token)
+	assert.Contains(t, err.Error(), "GCP STS returned HTTP 400")
+}
+
+// TC-GCP-CRED-03: GenerateAccessToken — IAM Credentials 200 응답 시 CspCredentialResponse 반환
+func TestGcpCredentialService_GenerateAccessToken_Success(t *testing.T) {
+	iam := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"accessToken":"sa-access-token-456","expireTime":"2099-01-01T00:00:00Z"}`))
+	}))
+	defer iam.Close()
+	withGcpTestURLs(t, "", iam.URL+"/%s")
+
+	svc := NewGcpCredentialService()
+	creds, err := svc.GenerateAccessToken(context.Background(), "sa@project.iam.gserviceaccount.com", "federated-token-123")
+
+	require.NoError(t, err)
+	require.NotNil(t, creds)
+	assert.Equal(t, "gcp", creds.CspType)
+	assert.Equal(t, "sa-access-token-456", creds.AccessToken)
+	assert.Equal(t, "Bearer", creds.TokenType)
+}
+
+// TC-GCP-CRED-04: GenerateAccessToken — IAM Credentials 403 응답 시 오류 반환 (SA 없음/권한 없음 시나리오)
+func TestGcpCredentialService_GenerateAccessToken_HttpError(t *testing.T) {
+	iam := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"error":"permission_denied"}`))
+	}))
+	defer iam.Close()
+	withGcpTestURLs(t, "", iam.URL+"/%s")
+
+	svc := NewGcpCredentialService()
+	creds, err := svc.GenerateAccessToken(context.Background(), "sa@project.iam.gserviceaccount.com", "federated-token-123")
+
+	require.Error(t, err)
+	assert.Nil(t, creds)
+	assert.Contains(t, err.Error(), "GCP IAM Credentials returned HTTP 403")
+}
+
+// TC-GCP-CRED-05: ExchangeTokenAndImpersonate — 내부적으로 ExchangeToken → GenerateAccessToken 순서로
+// 합성되며, 두 단계 모두 성공하면 최종 자격증명을 반환한다 (기존 호출부 동작 불변 확인).
+func TestGcpCredentialService_ExchangeTokenAndImpersonate_ComposesBothSteps(t *testing.T) {
+	sts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"access_token":"federated-token-xyz","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer sts.Close()
+	iam := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"accessToken":"sa-access-token-final","expireTime":"2099-01-01T00:00:00Z"}`))
+	}))
+	defer iam.Close()
+	withGcpTestURLs(t, sts.URL, iam.URL+"/%s")
+
+	svc := NewGcpCredentialService()
+	creds, err := svc.ExchangeTokenAndImpersonate(context.Background(), "wif-provider", "sa@project.iam.gserviceaccount.com", "kc-jwt", "jwt")
+
+	require.NoError(t, err)
+	require.NotNil(t, creds)
+	assert.Equal(t, "sa-access-token-final", creds.AccessToken)
+}
+
+// TC-GCP-CRED-06: ExchangeTokenAndImpersonate — STS 단계 실패 시 SA impersonation은 호출되지 않고
+// 오류가 전파된다.
+func TestGcpCredentialService_ExchangeTokenAndImpersonate_StsFailureShortCircuits(t *testing.T) {
+	sts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":"invalid_target"}`))
+	}))
+	defer sts.Close()
+	iamCalled := false
+	iam := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		iamCalled = true
+		w.Write([]byte(`{"accessToken":"should-not-be-called","expireTime":"2099-01-01T00:00:00Z"}`))
+	}))
+	defer iam.Close()
+	withGcpTestURLs(t, sts.URL, iam.URL+"/%s")
+
+	svc := NewGcpCredentialService()
+	creds, err := svc.ExchangeTokenAndImpersonate(context.Background(), "wif-provider", "sa@project.iam.gserviceaccount.com", "kc-jwt", "jwt")
+
+	require.Error(t, err)
+	assert.Nil(t, creds)
+	assert.False(t, iamCalled, "SA impersonation should not be attempted if STS token exchange failed")
+	assert.Contains(t, err.Error(), "GCP STS token exchange failed")
+}

--- a/src/service/mock_csp_credential_deps_test.go
+++ b/src/service/mock_csp_credential_deps_test.go
@@ -42,10 +42,23 @@ func (m *mockAwsCredService) CheckCallerIdentity(_ context.Context, accessKeyID,
 type mockGcpCredService struct {
 	result *model.CspCredentialResponse
 	err    error
+
+	federatedToken string
+	exchangeErr    error
+	genResult      *model.CspCredentialResponse
+	genErr         error
 }
 
 func (m *mockGcpCredService) ExchangeTokenAndImpersonate(_ context.Context, wif, sa, token, tokenType string) (*model.CspCredentialResponse, error) {
 	return m.result, m.err
+}
+
+func (m *mockGcpCredService) ExchangeToken(_ context.Context, wifProviderResourceName, subjectToken, subjectTokenType string) (string, error) {
+	return m.federatedToken, m.exchangeErr
+}
+
+func (m *mockGcpCredService) GenerateAccessToken(_ context.Context, serviceAccountEmail, federatedToken string) (*model.CspCredentialResponse, error) {
+	return m.genResult, m.genErr
 }
 
 // ── Alibaba ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `ValidationStep`에 `Remediation` 필드를 추가하고, AWS(OIDC/SAML)·GCP(OIDC) 검증 실패 단계별로 콘솔 조작 순서·Trust Policy 템플릿·문서 링크를 구조화해 응답에 포함
- GCP WIF 검증을 `ExchangeToken`/`GenerateAccessToken`으로 분리 노출해 STS 교환과 SA impersonation을 각각 실제로 체크(기존 2단계는 placeholder였음), ID Token 사용으로 통일
- 관련 정리: Tencent OIDC(`AssumeRoleWithWebIdentity`) 경로 제거, Tencent SAML 서명을 TC3-HMAC-SHA256으로 교체, Azure federated credential 토큰 요청 `grant_type` 수정, `CspRole` 개별 필드 수정 API(`PUT /api/roles/csp/id/:roleId`) 제거
