### PR TITLE
fix: mcmp API 레지스트리 동기화 버그 수정 + CSP Role 관련 API 정리

### DIFF
--- a/asset/mcmpapi/service-actions.yaml
+++ b/asset/mcmpapi/service-actions.yaml
@@ -333,7 +333,7 @@ serviceActions:
         _meta:
             version: 0.5.2
             repository: https://github.com/m-cmp/mc-iam-manager
-            generatedAt: "2026-06-01T02:11:43Z"
+            generatedAt: "2026-07-28T08:00:50Z"
         CreateFrameworkService:
             method: post
             resourcePath: /api/mcmp-apis

--- a/conf/mc-iam-manager/service-actions.yaml
+++ b/conf/mc-iam-manager/service-actions.yaml
@@ -333,7 +333,7 @@ serviceActions:
         _meta:
             version: 0.5.2
             repository: https://github.com/m-cmp/mc-iam-manager
-            generatedAt: "2026-06-01T02:11:43Z"
+            generatedAt: "2026-07-28T08:00:50Z"
         CreateFrameworkService:
             method: post
             resourcePath: /api/mcmp-apis

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -3061,6 +3061,72 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "그룹에서 사용자 목록을 일괄 제거합니다. DB + Keycloak 그룹 동기화.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "groups"
+                ],
+                "summary": "그룹에서 사용자 일괄 제거 (Keycloak 동기화 포함)",
+                "operationId": "removeGroupUsers",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "그룹 ID",
+                        "name": "groupId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "사용자 일괄 제거 요청",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.RemoveGroupUsersRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/groups/id/{groupId}/users/{userId}": {
@@ -7157,78 +7223,6 @@ const docTemplate = `{
             }
         },
         "/api/roles/csp-roles/id/{roleId}": {
-            "put": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Update role information",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "roles"
-                ],
-                "summary": "Update csp role",
-                "operationId": "updateCspRole",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Role ID",
-                        "name": "roleId",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Role Info",
-                        "name": "role",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/model.CreateRoleRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/model.RoleMaster"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
             "delete": {
                 "security": [
                     {
@@ -7339,6 +7333,71 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/roles/csp-roles/master/id/{roleId}": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "RoleSub.RoleType이 csp인 RoleMaster(플랫폼 역할 정의: name/description/parentId)를 수정합니다.\nCSP 클라우드 측 역할 레코드(mcmp_role_csp_roles)를 수정하는 UpdateCspRole(/api/roles/csp/id/{roleId})과는 다른 리소스입니다 — 혼동 방지를 위해 operationId를 updateCspRoleMaster로 분리했습니다.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "Update CSP-type platform role (RoleMaster)",
+                "operationId": "updateCspRoleMaster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CSP-type Platform Role ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "CSP-type Role Info",
+                        "name": "role",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CreateRoleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.RoleMaster"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/roles/csp/id/{roleId}": {
             "get": {
                 "security": [
@@ -7376,6 +7435,69 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "CspRole(mcmp_role_csp_roles) 레코드를 수정합니다. Name/Description/ExtendedConfig를 반영합니다.\nAWS의 경우 클라우드 측 리소스는 건드리지 않고 DB만 갱신합니다(SAML saml_client_id 등 설정용).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "Update CSP role",
+                "operationId": "updateCspRole",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CSP Role ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "CSP Role Info",
+                        "name": "role",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CreateCspRoleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.CspRole"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -7956,6 +8078,53 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/roles/mappings/platform-roles/id/{roleId}/groups": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "특정 플랫폼 역할이 할당된 그룹 목록을 조회합니다 (역할→그룹 역방향 조회).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "특정 Platform Role이 부여된 그룹 목록 조회",
+                "operationId": "listGroupsByPlatformRole",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "역할 ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.GroupPlatformRoleResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/roles/mappings/platform-roles/users/list": {
             "post": {
                 "security": [
@@ -8065,6 +8234,53 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/roles/mappings/workspace-roles/id/{roleId}/groups": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "특정 워크스페이스 역할이 할당된 그룹 목록을 조회합니다 (역할→그룹 역방향 조회).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "특정 Workspace Role이 부여된 그룹 목록 조회",
+                "operationId": "listGroupsByWorkspaceRole",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "역할 ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.GroupWorkspaceRoleResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -8331,6 +8547,69 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update the details of an existing platform role (RoleMaster: name/description/parentId, RoleSub type list)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "Update platform role",
+                "operationId": "updatePlatformRole",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Platform Role ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Platform Role Info",
+                        "name": "role",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CreateRoleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.RoleMaster"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -8732,6 +9011,69 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update the details of an existing workspace role (RoleMaster: name/description/parentId, RoleSub type list)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "Update workspace role",
+                "operationId": "updateWorkspaceRole",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace Role ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Workspace Role Info",
+                        "name": "role",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CreateRoleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.RoleMaster"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -12815,11 +13157,6 @@ const docTemplate = `{
                 "RoleTypePlatform": "플랫폼 역할",
                 "RoleTypeWorkspace": "워크스페이스 역할"
             },
-            "x-enum-descriptions": [
-                "플랫폼 역할",
-                "워크스페이스 역할",
-                "CSP 역할"
-            ],
             "x-enum-varnames": [
                 "RoleTypePlatform",
                 "RoleTypeWorkspace",
@@ -13466,6 +13803,10 @@ const docTemplate = `{
                         }
                     ]
                 },
+                "cspIdpConfigId": {
+                    "description": "이 CspRole이 사용할 CspIdpConfig(OIDC/SAML 등 트러스트 설정) 연결",
+                    "type": "integer"
+                },
                 "cspRoleName": {
                     "description": "csp의 RoleName. 여러 role이 있기때문에 csp에 정의한 role로 구분하기 위해 사용",
                     "type": "string"
@@ -13475,6 +13816,10 @@ const docTemplate = `{
                 },
                 "description": {
                     "type": "string"
+                },
+                "extendedConfig": {
+                    "type": "object",
+                    "additionalProperties": true
                 },
                 "iamIdentifier": {
                     "type": "string"
@@ -14677,11 +15022,6 @@ const docTemplate = `{
                 "PolicyTypeInline": "인라인 정책 (역할에 직접 포함)",
                 "PolicyTypeManaged": "관리형 정책 (독립 정책)"
             },
-            "x-enum-descriptions": [
-                "인라인 정책 (역할에 직접 포함)",
-                "관리형 정책 (독립 정책)",
-                "사용자 정의 정책"
-            ],
             "x-enum-varnames": [
                 "PolicyTypeInline",
                 "PolicyTypeManaged",
@@ -14861,6 +15201,45 @@ const docTemplate = `{
                 },
                 "nsId": {
                     "type": "string"
+                }
+            }
+        },
+        "model.RemediationGuide": {
+            "type": "object",
+            "properties": {
+                "consoleSteps": {
+                    "description": "CSP 콘솔/CLI 조작 순서",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "docsRef": {
+                    "description": "선택: 참고 문서 링크",
+                    "type": "string"
+                },
+                "summary": {
+                    "description": "한 줄 요약",
+                    "type": "string"
+                },
+                "template": {
+                    "description": "선택: Trust Policy JSON 등 복사-붙여넣기 템플릿",
+                    "type": "string"
+                }
+            }
+        },
+        "model.RemoveGroupUsersRequest": {
+            "type": "object",
+            "required": [
+                "user_ids"
+            ],
+            "properties": {
+                "user_ids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "integer"
+                    }
                 }
             }
         },
@@ -15529,6 +15908,14 @@ const docTemplate = `{
                 "name": {
                     "description": "단계명",
                     "type": "string"
+                },
+                "remediation": {
+                    "description": "failed일 때만, CSP 콘솔에서의 조치 방법",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.RemediationGuide"
+                        }
+                    ]
                 },
                 "status": {
                     "description": "ok | failed | skipped",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -3055,6 +3055,72 @@
                         }
                     }
                 }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "그룹에서 사용자 목록을 일괄 제거합니다. DB + Keycloak 그룹 동기화.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "groups"
+                ],
+                "summary": "그룹에서 사용자 일괄 제거 (Keycloak 동기화 포함)",
+                "operationId": "removeGroupUsers",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "그룹 ID",
+                        "name": "groupId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "사용자 일괄 제거 요청",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.RemoveGroupUsersRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/groups/id/{groupId}/users/{userId}": {
@@ -7151,78 +7217,6 @@
             }
         },
         "/api/roles/csp-roles/id/{roleId}": {
-            "put": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Update role information",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "roles"
-                ],
-                "summary": "Update csp role",
-                "operationId": "updateCspRole",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Role ID",
-                        "name": "roleId",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Role Info",
-                        "name": "role",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/model.CreateRoleRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/model.RoleMaster"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
             "delete": {
                 "security": [
                     {
@@ -7333,6 +7327,71 @@
                 }
             }
         },
+        "/api/roles/csp-roles/master/id/{roleId}": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "RoleSub.RoleType이 csp인 RoleMaster(플랫폼 역할 정의: name/description/parentId)를 수정합니다.\nCSP 클라우드 측 역할 레코드(mcmp_role_csp_roles)를 수정하는 UpdateCspRole(/api/roles/csp/id/{roleId})과는 다른 리소스입니다 — 혼동 방지를 위해 operationId를 updateCspRoleMaster로 분리했습니다.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "Update CSP-type platform role (RoleMaster)",
+                "operationId": "updateCspRoleMaster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CSP-type Platform Role ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "CSP-type Role Info",
+                        "name": "role",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CreateRoleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.RoleMaster"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/roles/csp/id/{roleId}": {
             "get": {
                 "security": [
@@ -7370,6 +7429,69 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "CspRole(mcmp_role_csp_roles) 레코드를 수정합니다. Name/Description/ExtendedConfig를 반영합니다.\nAWS의 경우 클라우드 측 리소스는 건드리지 않고 DB만 갱신합니다(SAML saml_client_id 등 설정용).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "Update CSP role",
+                "operationId": "updateCspRole",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CSP Role ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "CSP Role Info",
+                        "name": "role",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CreateCspRoleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.CspRole"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -7950,6 +8072,53 @@
                 }
             }
         },
+        "/api/roles/mappings/platform-roles/id/{roleId}/groups": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "특정 플랫폼 역할이 할당된 그룹 목록을 조회합니다 (역할→그룹 역방향 조회).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "특정 Platform Role이 부여된 그룹 목록 조회",
+                "operationId": "listGroupsByPlatformRole",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "역할 ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.GroupPlatformRoleResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/roles/mappings/platform-roles/users/list": {
             "post": {
                 "security": [
@@ -8059,6 +8228,53 @@
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/roles/mappings/workspace-roles/id/{roleId}/groups": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "특정 워크스페이스 역할이 할당된 그룹 목록을 조회합니다 (역할→그룹 역방향 조회).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "특정 Workspace Role이 부여된 그룹 목록 조회",
+                "operationId": "listGroupsByWorkspaceRole",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "역할 ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.GroupWorkspaceRoleResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -8325,6 +8541,69 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update the details of an existing platform role (RoleMaster: name/description/parentId, RoleSub type list)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "Update platform role",
+                "operationId": "updatePlatformRole",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Platform Role ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Platform Role Info",
+                        "name": "role",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CreateRoleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.RoleMaster"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -8726,6 +9005,69 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update the details of an existing workspace role (RoleMaster: name/description/parentId, RoleSub type list)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "Update workspace role",
+                "operationId": "updateWorkspaceRole",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace Role ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Workspace Role Info",
+                        "name": "role",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CreateRoleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.RoleMaster"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -12809,11 +13151,6 @@
                 "RoleTypePlatform": "플랫폼 역할",
                 "RoleTypeWorkspace": "워크스페이스 역할"
             },
-            "x-enum-descriptions": [
-                "플랫폼 역할",
-                "워크스페이스 역할",
-                "CSP 역할"
-            ],
             "x-enum-varnames": [
                 "RoleTypePlatform",
                 "RoleTypeWorkspace",
@@ -13460,6 +13797,10 @@
                         }
                     ]
                 },
+                "cspIdpConfigId": {
+                    "description": "이 CspRole이 사용할 CspIdpConfig(OIDC/SAML 등 트러스트 설정) 연결",
+                    "type": "integer"
+                },
                 "cspRoleName": {
                     "description": "csp의 RoleName. 여러 role이 있기때문에 csp에 정의한 role로 구분하기 위해 사용",
                     "type": "string"
@@ -13469,6 +13810,10 @@
                 },
                 "description": {
                     "type": "string"
+                },
+                "extendedConfig": {
+                    "type": "object",
+                    "additionalProperties": true
                 },
                 "iamIdentifier": {
                     "type": "string"
@@ -14671,11 +15016,6 @@
                 "PolicyTypeInline": "인라인 정책 (역할에 직접 포함)",
                 "PolicyTypeManaged": "관리형 정책 (독립 정책)"
             },
-            "x-enum-descriptions": [
-                "인라인 정책 (역할에 직접 포함)",
-                "관리형 정책 (독립 정책)",
-                "사용자 정의 정책"
-            ],
             "x-enum-varnames": [
                 "PolicyTypeInline",
                 "PolicyTypeManaged",
@@ -14855,6 +15195,45 @@
                 },
                 "nsId": {
                     "type": "string"
+                }
+            }
+        },
+        "model.RemediationGuide": {
+            "type": "object",
+            "properties": {
+                "consoleSteps": {
+                    "description": "CSP 콘솔/CLI 조작 순서",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "docsRef": {
+                    "description": "선택: 참고 문서 링크",
+                    "type": "string"
+                },
+                "summary": {
+                    "description": "한 줄 요약",
+                    "type": "string"
+                },
+                "template": {
+                    "description": "선택: Trust Policy JSON 등 복사-붙여넣기 템플릿",
+                    "type": "string"
+                }
+            }
+        },
+        "model.RemoveGroupUsersRequest": {
+            "type": "object",
+            "required": [
+                "user_ids"
+            ],
+            "properties": {
+                "user_ids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "integer"
+                    }
                 }
             }
         },
@@ -15523,6 +15902,14 @@
                 "name": {
                     "description": "단계명",
                     "type": "string"
+                },
+                "remediation": {
+                    "description": "failed일 때만, CSP 콘솔에서의 조치 방법",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.RemediationGuide"
+                        }
+                    ]
                 },
                 "status": {
                     "description": "ok | failed | skipped",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -44,10 +44,6 @@ definitions:
       RoleTypeCSP: CSP 역할
       RoleTypePlatform: 플랫폼 역할
       RoleTypeWorkspace: 워크스페이스 역할
-    x-enum-descriptions:
-    - 플랫폼 역할
-    - 워크스페이스 역할
-    - CSP 역할
     x-enum-varnames:
     - RoleTypePlatform
     - RoleTypeWorkspace
@@ -480,6 +476,9 @@ definitions:
         allOf:
         - $ref: '#/definitions/constants.AuthMethod'
         description: 인증방식 (OIDC/SAML/SECRET_KEY), 미지정 시 OIDC 기본값
+      cspIdpConfigId:
+        description: 이 CspRole이 사용할 CspIdpConfig(OIDC/SAML 등 트러스트 설정) 연결
+        type: integer
       cspRoleName:
         description: csp의 RoleName. 여러 role이 있기때문에 csp에 정의한 role로 구분하기 위해 사용
         type: string
@@ -487,6 +486,9 @@ definitions:
         type: string
       description:
         type: string
+      extendedConfig:
+        additionalProperties: true
+        type: object
       iamIdentifier:
         type: string
       iamRoleId:
@@ -1293,10 +1295,6 @@ definitions:
       PolicyTypeCustom: 사용자 정의 정책
       PolicyTypeInline: 인라인 정책 (역할에 직접 포함)
       PolicyTypeManaged: 관리형 정책 (독립 정책)
-    x-enum-descriptions:
-    - 인라인 정책 (역할에 직접 포함)
-    - 관리형 정책 (독립 정책)
-    - 사용자 정의 정책
     x-enum-varnames:
     - PolicyTypeInline
     - PolicyTypeManaged
@@ -1415,6 +1413,33 @@ definitions:
         type: string
       nsId:
         type: string
+    type: object
+  model.RemediationGuide:
+    properties:
+      consoleSteps:
+        description: CSP 콘솔/CLI 조작 순서
+        items:
+          type: string
+        type: array
+      docsRef:
+        description: '선택: 참고 문서 링크'
+        type: string
+      summary:
+        description: 한 줄 요약
+        type: string
+      template:
+        description: '선택: Trust Policy JSON 등 복사-붙여넣기 템플릿'
+        type: string
+    type: object
+  model.RemoveGroupUsersRequest:
+    properties:
+      user_ids:
+        items:
+          type: integer
+        minItems: 1
+        type: array
+    required:
+    - user_ids
     type: object
   model.ResetPasswordRequest:
     properties:
@@ -1862,6 +1887,10 @@ definitions:
       name:
         description: 단계명
         type: string
+      remediation:
+        allOf:
+        - $ref: '#/definitions/model.RemediationGuide'
+        description: failed일 때만, CSP 콘솔에서의 조치 방법
       status:
         allOf:
         - $ref: '#/definitions/model.ValidationStepStatus'
@@ -3884,6 +3913,49 @@ paths:
       tags:
       - groups
   /api/groups/id/{groupId}/users:
+    delete:
+      consumes:
+      - application/json
+      description: 그룹에서 사용자 목록을 일괄 제거합니다. DB + Keycloak 그룹 동기화.
+      operationId: removeGroupUsers
+      parameters:
+      - description: 그룹 ID
+        in: path
+        name: groupId
+        required: true
+        type: integer
+      - description: 사용자 일괄 제거 요청
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/model.RemoveGroupUsersRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 그룹에서 사용자 일괄 제거 (Keycloak 동기화 포함)
+      tags:
+      - groups
     post:
       consumes:
       - application/json
@@ -6715,53 +6787,6 @@ paths:
       summary: Delete csp role
       tags:
       - roles
-    put:
-      consumes:
-      - application/json
-      description: Update role information
-      operationId: updateCspRole
-      parameters:
-      - description: Role ID
-        in: path
-        name: roleId
-        required: true
-        type: string
-      - description: Role Info
-        in: body
-        name: role
-        required: true
-        schema:
-          $ref: '#/definitions/model.CreateRoleRequest'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/model.RoleMaster'
-        "400":
-          description: Bad Request
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "404":
-          description: Not Found
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "500":
-          description: Internal Server Error
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-      security:
-      - BearerAuth: []
-      summary: Update csp role
-      tags:
-      - roles
   /api/roles/csp-roles/list:
     post:
       consumes:
@@ -6799,6 +6824,50 @@ paths:
       summary: Get role-CSP role mapping
       tags:
       - roles
+  /api/roles/csp-roles/master/id/{roleId}:
+    put:
+      consumes:
+      - application/json
+      description: |-
+        RoleSub.RoleType이 csp인 RoleMaster(플랫폼 역할 정의: name/description/parentId)를 수정합니다.
+        CSP 클라우드 측 역할 레코드(mcmp_role_csp_roles)를 수정하는 UpdateCspRole(/api/roles/csp/id/{roleId})과는 다른 리소스입니다 — 혼동 방지를 위해 operationId를 updateCspRoleMaster로 분리했습니다.
+      operationId: updateCspRoleMaster
+      parameters:
+      - description: CSP-type Platform Role ID
+        in: path
+        name: roleId
+        required: true
+        type: string
+      - description: CSP-type Role Info
+        in: body
+        name: role
+        required: true
+        schema:
+          $ref: '#/definitions/model.CreateRoleRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.RoleMaster'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Update CSP-type platform role (RoleMaster)
+      tags:
+      - roles
   /api/roles/csp/id/{roleId}:
     get:
       consumes:
@@ -6833,6 +6902,49 @@ paths:
       security:
       - BearerAuth: []
       summary: Get csp role by ID
+      tags:
+      - roles
+    put:
+      consumes:
+      - application/json
+      description: |-
+        CspRole(mcmp_role_csp_roles) 레코드를 수정합니다. Name/Description/ExtendedConfig를 반영합니다.
+        AWS의 경우 클라우드 측 리소스는 건드리지 않고 DB만 갱신합니다(SAML saml_client_id 등 설정용).
+      operationId: updateCspRole
+      parameters:
+      - description: CSP Role ID
+        in: path
+        name: roleId
+        required: true
+        type: string
+      - description: CSP Role Info
+        in: body
+        name: role
+        required: true
+        schema:
+          $ref: '#/definitions/model.CreateCspRoleRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.CspRole'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Update CSP role
       tags:
       - roles
   /api/roles/csp/list:
@@ -7195,6 +7307,36 @@ paths:
       summary: List role master mappings
       tags:
       - roles
+  /api/roles/mappings/platform-roles/id/{roleId}/groups:
+    get:
+      description: 특정 플랫폼 역할이 할당된 그룹 목록을 조회합니다 (역할→그룹 역방향 조회).
+      operationId: listGroupsByPlatformRole
+      parameters:
+      - description: 역할 ID
+        in: path
+        name: roleId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.GroupPlatformRoleResponse'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 특정 Platform Role이 부여된 그룹 목록 조회
+      tags:
+      - roles
   /api/roles/mappings/platform-roles/users/list:
     post:
       consumes:
@@ -7269,6 +7411,36 @@ paths:
       security:
       - BearerAuth: []
       summary: Get role master mappings
+      tags:
+      - roles
+  /api/roles/mappings/workspace-roles/id/{roleId}/groups:
+    get:
+      description: 특정 워크스페이스 역할이 할당된 그룹 목록을 조회합니다 (역할→그룹 역방향 조회).
+      operationId: listGroupsByWorkspaceRole
+      parameters:
+      - description: 역할 ID
+        in: path
+        name: roleId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.GroupWorkspaceRoleResponse'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 특정 Workspace Role이 부여된 그룹 목록 조회
       tags:
       - roles
   /api/roles/mappings/workspace-roles/users/list:
@@ -7478,6 +7650,48 @@ paths:
       security:
       - BearerAuth: []
       summary: Get platform role by ID
+      tags:
+      - roles
+    put:
+      consumes:
+      - application/json
+      description: 'Update the details of an existing platform role (RoleMaster: name/description/parentId,
+        RoleSub type list)'
+      operationId: updatePlatformRole
+      parameters:
+      - description: Platform Role ID
+        in: path
+        name: roleId
+        required: true
+        type: string
+      - description: Platform Role Info
+        in: body
+        name: role
+        required: true
+        schema:
+          $ref: '#/definitions/model.CreateRoleRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.RoleMaster'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Update platform role
       tags:
       - roles
   /api/roles/platform-roles/name/{roleName}:
@@ -7735,6 +7949,48 @@ paths:
       security:
       - BearerAuth: []
       summary: Get workspace role by ID
+      tags:
+      - roles
+    put:
+      consumes:
+      - application/json
+      description: 'Update the details of an existing workspace role (RoleMaster:
+        name/description/parentId, RoleSub type list)'
+      operationId: updateWorkspaceRole
+      parameters:
+      - description: Workspace Role ID
+        in: path
+        name: roleId
+        required: true
+        type: string
+      - description: Workspace Role Info
+        in: body
+        name: role
+        required: true
+        schema:
+          $ref: '#/definitions/model.CreateRoleRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.RoleMaster'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Update workspace role
       tags:
       - roles
   /api/roles/workspace-roles/list:

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -3061,6 +3061,72 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "그룹에서 사용자 목록을 일괄 제거합니다. DB + Keycloak 그룹 동기화.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "groups"
+                ],
+                "summary": "그룹에서 사용자 일괄 제거 (Keycloak 동기화 포함)",
+                "operationId": "removeGroupUsers",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "그룹 ID",
+                        "name": "groupId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "사용자 일괄 제거 요청",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.RemoveGroupUsersRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/groups/id/{groupId}/users/{userId}": {
@@ -7157,78 +7223,6 @@ const docTemplate = `{
             }
         },
         "/api/roles/csp-roles/id/{roleId}": {
-            "put": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Update role information",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "roles"
-                ],
-                "summary": "Update csp role",
-                "operationId": "updateCspRole",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Role ID",
-                        "name": "roleId",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Role Info",
-                        "name": "role",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/model.CreateRoleRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/model.RoleMaster"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
             "delete": {
                 "security": [
                     {
@@ -7339,6 +7333,71 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/roles/csp-roles/master/id/{roleId}": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "RoleSub.RoleType이 csp인 RoleMaster(플랫폼 역할 정의: name/description/parentId)를 수정합니다.\nCSP 클라우드 측 역할 레코드(mcmp_role_csp_roles)를 수정하는 UpdateCspRole(/api/roles/csp/id/{roleId})과는 다른 리소스입니다 — 혼동 방지를 위해 operationId를 updateCspRoleMaster로 분리했습니다.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "Update CSP-type platform role (RoleMaster)",
+                "operationId": "updateCspRoleMaster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CSP-type Platform Role ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "CSP-type Role Info",
+                        "name": "role",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CreateRoleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.RoleMaster"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/roles/csp/id/{roleId}": {
             "get": {
                 "security": [
@@ -7376,6 +7435,69 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "CspRole(mcmp_role_csp_roles) 레코드를 수정합니다. Name/Description/ExtendedConfig를 반영합니다.\nAWS의 경우 클라우드 측 리소스는 건드리지 않고 DB만 갱신합니다(SAML saml_client_id 등 설정용).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "Update CSP role",
+                "operationId": "updateCspRole",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CSP Role ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "CSP Role Info",
+                        "name": "role",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CreateCspRoleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.CspRole"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -7956,6 +8078,53 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/roles/mappings/platform-roles/id/{roleId}/groups": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "특정 플랫폼 역할이 할당된 그룹 목록을 조회합니다 (역할→그룹 역방향 조회).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "특정 Platform Role이 부여된 그룹 목록 조회",
+                "operationId": "listGroupsByPlatformRole",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "역할 ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.GroupPlatformRoleResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/roles/mappings/platform-roles/users/list": {
             "post": {
                 "security": [
@@ -8065,6 +8234,53 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/roles/mappings/workspace-roles/id/{roleId}/groups": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "특정 워크스페이스 역할이 할당된 그룹 목록을 조회합니다 (역할→그룹 역방향 조회).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "특정 Workspace Role이 부여된 그룹 목록 조회",
+                "operationId": "listGroupsByWorkspaceRole",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "역할 ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.GroupWorkspaceRoleResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -8331,6 +8547,69 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update the details of an existing platform role (RoleMaster: name/description/parentId, RoleSub type list)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "Update platform role",
+                "operationId": "updatePlatformRole",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Platform Role ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Platform Role Info",
+                        "name": "role",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CreateRoleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.RoleMaster"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -8732,6 +9011,69 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update the details of an existing workspace role (RoleMaster: name/description/parentId, RoleSub type list)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "Update workspace role",
+                "operationId": "updateWorkspaceRole",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace Role ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Workspace Role Info",
+                        "name": "role",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CreateRoleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.RoleMaster"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -12815,11 +13157,6 @@ const docTemplate = `{
                 "RoleTypePlatform": "플랫폼 역할",
                 "RoleTypeWorkspace": "워크스페이스 역할"
             },
-            "x-enum-descriptions": [
-                "플랫폼 역할",
-                "워크스페이스 역할",
-                "CSP 역할"
-            ],
             "x-enum-varnames": [
                 "RoleTypePlatform",
                 "RoleTypeWorkspace",
@@ -13466,6 +13803,10 @@ const docTemplate = `{
                         }
                     ]
                 },
+                "cspIdpConfigId": {
+                    "description": "이 CspRole이 사용할 CspIdpConfig(OIDC/SAML 등 트러스트 설정) 연결",
+                    "type": "integer"
+                },
                 "cspRoleName": {
                     "description": "csp의 RoleName. 여러 role이 있기때문에 csp에 정의한 role로 구분하기 위해 사용",
                     "type": "string"
@@ -13475,6 +13816,10 @@ const docTemplate = `{
                 },
                 "description": {
                     "type": "string"
+                },
+                "extendedConfig": {
+                    "type": "object",
+                    "additionalProperties": true
                 },
                 "iamIdentifier": {
                     "type": "string"
@@ -14677,11 +15022,6 @@ const docTemplate = `{
                 "PolicyTypeInline": "인라인 정책 (역할에 직접 포함)",
                 "PolicyTypeManaged": "관리형 정책 (독립 정책)"
             },
-            "x-enum-descriptions": [
-                "인라인 정책 (역할에 직접 포함)",
-                "관리형 정책 (독립 정책)",
-                "사용자 정의 정책"
-            ],
             "x-enum-varnames": [
                 "PolicyTypeInline",
                 "PolicyTypeManaged",
@@ -14861,6 +15201,45 @@ const docTemplate = `{
                 },
                 "nsId": {
                     "type": "string"
+                }
+            }
+        },
+        "model.RemediationGuide": {
+            "type": "object",
+            "properties": {
+                "consoleSteps": {
+                    "description": "CSP 콘솔/CLI 조작 순서",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "docsRef": {
+                    "description": "선택: 참고 문서 링크",
+                    "type": "string"
+                },
+                "summary": {
+                    "description": "한 줄 요약",
+                    "type": "string"
+                },
+                "template": {
+                    "description": "선택: Trust Policy JSON 등 복사-붙여넣기 템플릿",
+                    "type": "string"
+                }
+            }
+        },
+        "model.RemoveGroupUsersRequest": {
+            "type": "object",
+            "required": [
+                "user_ids"
+            ],
+            "properties": {
+                "user_ids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "integer"
+                    }
                 }
             }
         },
@@ -15529,6 +15908,14 @@ const docTemplate = `{
                 "name": {
                     "description": "단계명",
                     "type": "string"
+                },
+                "remediation": {
+                    "description": "failed일 때만, CSP 콘솔에서의 조치 방법",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.RemediationGuide"
+                        }
+                    ]
                 },
                 "status": {
                     "description": "ok | failed | skipped",

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -3055,6 +3055,72 @@
                         }
                     }
                 }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "그룹에서 사용자 목록을 일괄 제거합니다. DB + Keycloak 그룹 동기화.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "groups"
+                ],
+                "summary": "그룹에서 사용자 일괄 제거 (Keycloak 동기화 포함)",
+                "operationId": "removeGroupUsers",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "그룹 ID",
+                        "name": "groupId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "사용자 일괄 제거 요청",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.RemoveGroupUsersRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/groups/id/{groupId}/users/{userId}": {
@@ -7151,78 +7217,6 @@
             }
         },
         "/api/roles/csp-roles/id/{roleId}": {
-            "put": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Update role information",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "roles"
-                ],
-                "summary": "Update csp role",
-                "operationId": "updateCspRole",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Role ID",
-                        "name": "roleId",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Role Info",
-                        "name": "role",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/model.CreateRoleRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/model.RoleMaster"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
             "delete": {
                 "security": [
                     {
@@ -7333,6 +7327,71 @@
                 }
             }
         },
+        "/api/roles/csp-roles/master/id/{roleId}": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "RoleSub.RoleType이 csp인 RoleMaster(플랫폼 역할 정의: name/description/parentId)를 수정합니다.\nCSP 클라우드 측 역할 레코드(mcmp_role_csp_roles)를 수정하는 UpdateCspRole(/api/roles/csp/id/{roleId})과는 다른 리소스입니다 — 혼동 방지를 위해 operationId를 updateCspRoleMaster로 분리했습니다.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "Update CSP-type platform role (RoleMaster)",
+                "operationId": "updateCspRoleMaster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CSP-type Platform Role ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "CSP-type Role Info",
+                        "name": "role",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CreateRoleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.RoleMaster"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/roles/csp/id/{roleId}": {
             "get": {
                 "security": [
@@ -7370,6 +7429,69 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "CspRole(mcmp_role_csp_roles) 레코드를 수정합니다. Name/Description/ExtendedConfig를 반영합니다.\nAWS의 경우 클라우드 측 리소스는 건드리지 않고 DB만 갱신합니다(SAML saml_client_id 등 설정용).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "Update CSP role",
+                "operationId": "updateCspRole",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CSP Role ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "CSP Role Info",
+                        "name": "role",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CreateCspRoleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.CspRole"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -7950,6 +8072,53 @@
                 }
             }
         },
+        "/api/roles/mappings/platform-roles/id/{roleId}/groups": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "특정 플랫폼 역할이 할당된 그룹 목록을 조회합니다 (역할→그룹 역방향 조회).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "특정 Platform Role이 부여된 그룹 목록 조회",
+                "operationId": "listGroupsByPlatformRole",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "역할 ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.GroupPlatformRoleResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/roles/mappings/platform-roles/users/list": {
             "post": {
                 "security": [
@@ -8059,6 +8228,53 @@
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/roles/mappings/workspace-roles/id/{roleId}/groups": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "특정 워크스페이스 역할이 할당된 그룹 목록을 조회합니다 (역할→그룹 역방향 조회).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "특정 Workspace Role이 부여된 그룹 목록 조회",
+                "operationId": "listGroupsByWorkspaceRole",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "역할 ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.GroupWorkspaceRoleResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -8325,6 +8541,69 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update the details of an existing platform role (RoleMaster: name/description/parentId, RoleSub type list)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "Update platform role",
+                "operationId": "updatePlatformRole",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Platform Role ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Platform Role Info",
+                        "name": "role",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CreateRoleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.RoleMaster"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -8726,6 +9005,69 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update the details of an existing workspace role (RoleMaster: name/description/parentId, RoleSub type list)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "Update workspace role",
+                "operationId": "updateWorkspaceRole",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace Role ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Workspace Role Info",
+                        "name": "role",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CreateRoleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.RoleMaster"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -12809,11 +13151,6 @@
                 "RoleTypePlatform": "플랫폼 역할",
                 "RoleTypeWorkspace": "워크스페이스 역할"
             },
-            "x-enum-descriptions": [
-                "플랫폼 역할",
-                "워크스페이스 역할",
-                "CSP 역할"
-            ],
             "x-enum-varnames": [
                 "RoleTypePlatform",
                 "RoleTypeWorkspace",
@@ -13460,6 +13797,10 @@
                         }
                     ]
                 },
+                "cspIdpConfigId": {
+                    "description": "이 CspRole이 사용할 CspIdpConfig(OIDC/SAML 등 트러스트 설정) 연결",
+                    "type": "integer"
+                },
                 "cspRoleName": {
                     "description": "csp의 RoleName. 여러 role이 있기때문에 csp에 정의한 role로 구분하기 위해 사용",
                     "type": "string"
@@ -13469,6 +13810,10 @@
                 },
                 "description": {
                     "type": "string"
+                },
+                "extendedConfig": {
+                    "type": "object",
+                    "additionalProperties": true
                 },
                 "iamIdentifier": {
                     "type": "string"
@@ -14671,11 +15016,6 @@
                 "PolicyTypeInline": "인라인 정책 (역할에 직접 포함)",
                 "PolicyTypeManaged": "관리형 정책 (독립 정책)"
             },
-            "x-enum-descriptions": [
-                "인라인 정책 (역할에 직접 포함)",
-                "관리형 정책 (독립 정책)",
-                "사용자 정의 정책"
-            ],
             "x-enum-varnames": [
                 "PolicyTypeInline",
                 "PolicyTypeManaged",
@@ -14855,6 +15195,45 @@
                 },
                 "nsId": {
                     "type": "string"
+                }
+            }
+        },
+        "model.RemediationGuide": {
+            "type": "object",
+            "properties": {
+                "consoleSteps": {
+                    "description": "CSP 콘솔/CLI 조작 순서",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "docsRef": {
+                    "description": "선택: 참고 문서 링크",
+                    "type": "string"
+                },
+                "summary": {
+                    "description": "한 줄 요약",
+                    "type": "string"
+                },
+                "template": {
+                    "description": "선택: Trust Policy JSON 등 복사-붙여넣기 템플릿",
+                    "type": "string"
+                }
+            }
+        },
+        "model.RemoveGroupUsersRequest": {
+            "type": "object",
+            "required": [
+                "user_ids"
+            ],
+            "properties": {
+                "user_ids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "integer"
+                    }
                 }
             }
         },
@@ -15523,6 +15902,14 @@
                 "name": {
                     "description": "단계명",
                     "type": "string"
+                },
+                "remediation": {
+                    "description": "failed일 때만, CSP 콘솔에서의 조치 방법",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.RemediationGuide"
+                        }
+                    ]
                 },
                 "status": {
                     "description": "ok | failed | skipped",

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -44,10 +44,6 @@ definitions:
       RoleTypeCSP: CSP 역할
       RoleTypePlatform: 플랫폼 역할
       RoleTypeWorkspace: 워크스페이스 역할
-    x-enum-descriptions:
-    - 플랫폼 역할
-    - 워크스페이스 역할
-    - CSP 역할
     x-enum-varnames:
     - RoleTypePlatform
     - RoleTypeWorkspace
@@ -480,6 +476,9 @@ definitions:
         allOf:
         - $ref: '#/definitions/constants.AuthMethod'
         description: 인증방식 (OIDC/SAML/SECRET_KEY), 미지정 시 OIDC 기본값
+      cspIdpConfigId:
+        description: 이 CspRole이 사용할 CspIdpConfig(OIDC/SAML 등 트러스트 설정) 연결
+        type: integer
       cspRoleName:
         description: csp의 RoleName. 여러 role이 있기때문에 csp에 정의한 role로 구분하기 위해 사용
         type: string
@@ -487,6 +486,9 @@ definitions:
         type: string
       description:
         type: string
+      extendedConfig:
+        additionalProperties: true
+        type: object
       iamIdentifier:
         type: string
       iamRoleId:
@@ -1293,10 +1295,6 @@ definitions:
       PolicyTypeCustom: 사용자 정의 정책
       PolicyTypeInline: 인라인 정책 (역할에 직접 포함)
       PolicyTypeManaged: 관리형 정책 (독립 정책)
-    x-enum-descriptions:
-    - 인라인 정책 (역할에 직접 포함)
-    - 관리형 정책 (독립 정책)
-    - 사용자 정의 정책
     x-enum-varnames:
     - PolicyTypeInline
     - PolicyTypeManaged
@@ -1415,6 +1413,33 @@ definitions:
         type: string
       nsId:
         type: string
+    type: object
+  model.RemediationGuide:
+    properties:
+      consoleSteps:
+        description: CSP 콘솔/CLI 조작 순서
+        items:
+          type: string
+        type: array
+      docsRef:
+        description: '선택: 참고 문서 링크'
+        type: string
+      summary:
+        description: 한 줄 요약
+        type: string
+      template:
+        description: '선택: Trust Policy JSON 등 복사-붙여넣기 템플릿'
+        type: string
+    type: object
+  model.RemoveGroupUsersRequest:
+    properties:
+      user_ids:
+        items:
+          type: integer
+        minItems: 1
+        type: array
+    required:
+    - user_ids
     type: object
   model.ResetPasswordRequest:
     properties:
@@ -1862,6 +1887,10 @@ definitions:
       name:
         description: 단계명
         type: string
+      remediation:
+        allOf:
+        - $ref: '#/definitions/model.RemediationGuide'
+        description: failed일 때만, CSP 콘솔에서의 조치 방법
       status:
         allOf:
         - $ref: '#/definitions/model.ValidationStepStatus'
@@ -3884,6 +3913,49 @@ paths:
       tags:
       - groups
   /api/groups/id/{groupId}/users:
+    delete:
+      consumes:
+      - application/json
+      description: 그룹에서 사용자 목록을 일괄 제거합니다. DB + Keycloak 그룹 동기화.
+      operationId: removeGroupUsers
+      parameters:
+      - description: 그룹 ID
+        in: path
+        name: groupId
+        required: true
+        type: integer
+      - description: 사용자 일괄 제거 요청
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/model.RemoveGroupUsersRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 그룹에서 사용자 일괄 제거 (Keycloak 동기화 포함)
+      tags:
+      - groups
     post:
       consumes:
       - application/json
@@ -6715,53 +6787,6 @@ paths:
       summary: Delete csp role
       tags:
       - roles
-    put:
-      consumes:
-      - application/json
-      description: Update role information
-      operationId: updateCspRole
-      parameters:
-      - description: Role ID
-        in: path
-        name: roleId
-        required: true
-        type: string
-      - description: Role Info
-        in: body
-        name: role
-        required: true
-        schema:
-          $ref: '#/definitions/model.CreateRoleRequest'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/model.RoleMaster'
-        "400":
-          description: Bad Request
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "404":
-          description: Not Found
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "500":
-          description: Internal Server Error
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-      security:
-      - BearerAuth: []
-      summary: Update csp role
-      tags:
-      - roles
   /api/roles/csp-roles/list:
     post:
       consumes:
@@ -6799,6 +6824,50 @@ paths:
       summary: Get role-CSP role mapping
       tags:
       - roles
+  /api/roles/csp-roles/master/id/{roleId}:
+    put:
+      consumes:
+      - application/json
+      description: |-
+        RoleSub.RoleType이 csp인 RoleMaster(플랫폼 역할 정의: name/description/parentId)를 수정합니다.
+        CSP 클라우드 측 역할 레코드(mcmp_role_csp_roles)를 수정하는 UpdateCspRole(/api/roles/csp/id/{roleId})과는 다른 리소스입니다 — 혼동 방지를 위해 operationId를 updateCspRoleMaster로 분리했습니다.
+      operationId: updateCspRoleMaster
+      parameters:
+      - description: CSP-type Platform Role ID
+        in: path
+        name: roleId
+        required: true
+        type: string
+      - description: CSP-type Role Info
+        in: body
+        name: role
+        required: true
+        schema:
+          $ref: '#/definitions/model.CreateRoleRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.RoleMaster'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Update CSP-type platform role (RoleMaster)
+      tags:
+      - roles
   /api/roles/csp/id/{roleId}:
     get:
       consumes:
@@ -6833,6 +6902,49 @@ paths:
       security:
       - BearerAuth: []
       summary: Get csp role by ID
+      tags:
+      - roles
+    put:
+      consumes:
+      - application/json
+      description: |-
+        CspRole(mcmp_role_csp_roles) 레코드를 수정합니다. Name/Description/ExtendedConfig를 반영합니다.
+        AWS의 경우 클라우드 측 리소스는 건드리지 않고 DB만 갱신합니다(SAML saml_client_id 등 설정용).
+      operationId: updateCspRole
+      parameters:
+      - description: CSP Role ID
+        in: path
+        name: roleId
+        required: true
+        type: string
+      - description: CSP Role Info
+        in: body
+        name: role
+        required: true
+        schema:
+          $ref: '#/definitions/model.CreateCspRoleRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.CspRole'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Update CSP role
       tags:
       - roles
   /api/roles/csp/list:
@@ -7195,6 +7307,36 @@ paths:
       summary: List role master mappings
       tags:
       - roles
+  /api/roles/mappings/platform-roles/id/{roleId}/groups:
+    get:
+      description: 특정 플랫폼 역할이 할당된 그룹 목록을 조회합니다 (역할→그룹 역방향 조회).
+      operationId: listGroupsByPlatformRole
+      parameters:
+      - description: 역할 ID
+        in: path
+        name: roleId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.GroupPlatformRoleResponse'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 특정 Platform Role이 부여된 그룹 목록 조회
+      tags:
+      - roles
   /api/roles/mappings/platform-roles/users/list:
     post:
       consumes:
@@ -7269,6 +7411,36 @@ paths:
       security:
       - BearerAuth: []
       summary: Get role master mappings
+      tags:
+      - roles
+  /api/roles/mappings/workspace-roles/id/{roleId}/groups:
+    get:
+      description: 특정 워크스페이스 역할이 할당된 그룹 목록을 조회합니다 (역할→그룹 역방향 조회).
+      operationId: listGroupsByWorkspaceRole
+      parameters:
+      - description: 역할 ID
+        in: path
+        name: roleId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.GroupWorkspaceRoleResponse'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: 특정 Workspace Role이 부여된 그룹 목록 조회
       tags:
       - roles
   /api/roles/mappings/workspace-roles/users/list:
@@ -7478,6 +7650,48 @@ paths:
       security:
       - BearerAuth: []
       summary: Get platform role by ID
+      tags:
+      - roles
+    put:
+      consumes:
+      - application/json
+      description: 'Update the details of an existing platform role (RoleMaster: name/description/parentId,
+        RoleSub type list)'
+      operationId: updatePlatformRole
+      parameters:
+      - description: Platform Role ID
+        in: path
+        name: roleId
+        required: true
+        type: string
+      - description: Platform Role Info
+        in: body
+        name: role
+        required: true
+        schema:
+          $ref: '#/definitions/model.CreateRoleRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.RoleMaster'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Update platform role
       tags:
       - roles
   /api/roles/platform-roles/name/{roleName}:
@@ -7735,6 +7949,48 @@ paths:
       security:
       - BearerAuth: []
       summary: Get workspace role by ID
+      tags:
+      - roles
+    put:
+      consumes:
+      - application/json
+      description: 'Update the details of an existing workspace role (RoleMaster:
+        name/description/parentId, RoleSub type list)'
+      operationId: updateWorkspaceRole
+      parameters:
+      - description: Workspace Role ID
+        in: path
+        name: roleId
+        required: true
+        type: string
+      - description: Workspace Role Info
+        in: body
+        name: role
+        required: true
+        schema:
+          $ref: '#/definitions/model.CreateRoleRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.RoleMaster'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Update workspace role
       tags:
       - roles
   /api/roles/workspace-roles/list:

--- a/src/handler/role_handler.go
+++ b/src/handler/role_handler.go
@@ -914,8 +914,8 @@ func (h *RoleHandler) CreateCspRole(c echo.Context) error {
 // @Failure 500 {object} map[string]string
 // @Security BearerAuth
 // @Router /api/roles/csp/id/{roleId} [put]
-// @Id updateCspRoleRecord
-func (h *RoleHandler) UpdateCspRoleRecord(c echo.Context) error {
+// @Id updateCspRole
+func (h *RoleHandler) UpdateCspRole(c echo.Context) error {
 	roleIDInt, err := util.StringToUint(c.Param("roleId"))
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "잘못된 csp 역할 ID 형식입니다"})
@@ -1155,37 +1155,157 @@ func (h *RoleHandler) GetCspRoleByName(c echo.Context) error {
 	return c.JSON(http.StatusOK, role)
 }
 
-// @Summary Update csp role
-// @Description Update role information
+// @Summary Update platform role
+// @Description Update the details of an existing platform role (RoleMaster: name/description/parentId, RoleSub type list)
 // @Tags roles
 // @Accept json
 // @Produce json
-// @Param roleId path string true "Role ID"
-// @Param role body model.CreateRoleRequest true "Role Info"
+// @Param roleId path string true "Platform Role ID"
+// @Param role body model.CreateRoleRequest true "Platform Role Info"
 // @Success 200 {object} model.RoleMaster
 // @Failure 400 {object} map[string]string
-// @Failure 404 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Security BearerAuth
-// @Router /api/roles/csp-roles/id/{roleId} [put]
-// @Id updateCspRole
-func (h *RoleHandler) UpdateCspRole(c echo.Context) error {
-	roleType := constants.RoleTypeCSP
+// @Router /api/roles/platform-roles/id/{roleId} [put]
+// @Id updatePlatformRole
+func (h *RoleHandler) UpdatePlatformRole(c echo.Context) error {
+	roleIDInt, err := util.StringToUint(c.Param("roleId"))
+	if err != nil {
+		log.Printf("잘못된 platform 역할 ID 형식: %s", c.Param("roleId"))
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "잘못된 역할 ID 형식입니다"})
+	}
+
+	// RoleSub는 RoleMaster와 별도 테이블이라 요청 바디가 아닌 DB의 기존 RoleSub를 기준으로
+	// 이 roleId가 실제로 platform 타입인지 검증한다 (요청 바디의 RoleTypes만 보면 다른 타입을
+	// 함께 지정해 다른 엔드포인트의 역할까지 건드릴 수 있음).
+	existing, err := h.roleService.GetRoleByID(roleIDInt, constants.RoleTypePlatform)
+	if err != nil {
+		log.Printf("platform 역할 조회 실패 - ID: %d, 에러: %v", roleIDInt, err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("역할 조회 실패: %v", err)})
+	}
+	if existing == nil {
+		return c.JSON(http.StatusNotFound, map[string]string{"error": "platform 타입의 해당 역할을 찾을 수 없습니다"})
+	}
+
+	var req model.CreateRoleRequest
+	if err := c.Bind(&req); err != nil {
+		log.Printf("platform 역할 수정 요청 바인딩 실패 - 에러: %v", err)
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "잘못된 요청 형식입니다"})
+	}
+
+	if err := c.Validate(&req); err != nil {
+		log.Printf("platform 역할 수정 입력값 검증 실패 - 에러: %v", err)
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("입력값 검증 실패: %v", err)})
+	}
+
+	role := model.RoleMaster{
+		ID:          roleIDInt,
+		Name:        req.Name,
+		Description: req.Description,
+		ParentID:    req.ParentID,
+	}
+
+	updatedRole, err := h.roleService.UpdateRoleWithSubs(role, req.RoleTypes)
+	if err != nil {
+		log.Printf("platform 역할 수정 실패 - ID: %d, 에러: %v", roleIDInt, err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("역할 수정 실패: %v", err)})
+	}
+
+	log.Printf("platform 역할 수정 성공 - ID: %d", roleIDInt)
+	return c.JSON(http.StatusOK, updatedRole)
+}
+
+// @Summary Update workspace role
+// @Description Update the details of an existing workspace role (RoleMaster: name/description/parentId, RoleSub type list)
+// @Tags roles
+// @Accept json
+// @Produce json
+// @Param roleId path string true "Workspace Role ID"
+// @Param role body model.CreateRoleRequest true "Workspace Role Info"
+// @Success 200 {object} model.RoleMaster
+// @Failure 400 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Security BearerAuth
+// @Router /api/roles/workspace-roles/id/{roleId} [put]
+// @Id updateWorkspaceRole
+func (h *RoleHandler) UpdateWorkspaceRole(c echo.Context) error {
+	roleIDInt, err := util.StringToUint(c.Param("roleId"))
+	if err != nil {
+		log.Printf("잘못된 workspace 역할 ID 형식: %s", c.Param("roleId"))
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "잘못된 역할 ID 형식입니다"})
+	}
+
+	existing, err := h.roleService.GetRoleByID(roleIDInt, constants.RoleTypeWorkspace)
+	if err != nil {
+		log.Printf("workspace 역할 조회 실패 - ID: %d, 에러: %v", roleIDInt, err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("역할 조회 실패: %v", err)})
+	}
+	if existing == nil {
+		return c.JSON(http.StatusNotFound, map[string]string{"error": "workspace 타입의 해당 역할을 찾을 수 없습니다"})
+	}
+
+	var req model.CreateRoleRequest
+	if err := c.Bind(&req); err != nil {
+		log.Printf("workspace 역할 수정 요청 바인딩 실패 - 에러: %v", err)
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "잘못된 요청 형식입니다"})
+	}
+
+	if err := c.Validate(&req); err != nil {
+		log.Printf("workspace 역할 수정 입력값 검증 실패 - 에러: %v", err)
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("입력값 검증 실패: %v", err)})
+	}
+
+	role := model.RoleMaster{
+		ID:          roleIDInt,
+		Name:        req.Name,
+		Description: req.Description,
+		ParentID:    req.ParentID,
+	}
+
+	updatedRole, err := h.roleService.UpdateRoleWithSubs(role, req.RoleTypes)
+	if err != nil {
+		log.Printf("workspace 역할 수정 실패 - ID: %d, 에러: %v", roleIDInt, err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("역할 수정 실패: %v", err)})
+	}
+
+	log.Printf("workspace 역할 수정 성공 - ID: %d", roleIDInt)
+	return c.JSON(http.StatusOK, updatedRole)
+}
+
+// @Summary Update CSP-type platform role (RoleMaster)
+// @Description RoleSub.RoleType이 csp인 RoleMaster(플랫폼 역할 정의: name/description/parentId)를 수정합니다.
+// @Description CSP 클라우드 측 역할 레코드(mcmp_role_csp_roles)를 수정하는 UpdateCspRole(/api/roles/csp/id/{roleId})과는 다른 리소스입니다 — 혼동 방지를 위해 operationId를 updateCspRoleMaster로 분리했습니다.
+// @Tags roles
+// @Accept json
+// @Produce json
+// @Param roleId path string true "CSP-type Platform Role ID"
+// @Param role body model.CreateRoleRequest true "CSP-type Role Info"
+// @Success 200 {object} model.RoleMaster
+// @Failure 400 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Security BearerAuth
+// @Router /api/roles/csp-roles/master/id/{roleId} [put]
+// @Id updateCspRoleMaster
+func (h *RoleHandler) UpdateCspRoleMaster(c echo.Context) error {
+	roleIDInt, err := util.StringToUint(c.Param("roleId"))
+	if err != nil {
+		log.Printf("잘못된 csp 역할 ID 형식: %s", c.Param("roleId"))
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "잘못된 역할 ID 형식입니다"})
+	}
+
+	existing, err := h.roleService.GetRoleByID(roleIDInt, constants.RoleTypeCSP)
+	if err != nil {
+		log.Printf("csp 역할 조회 실패 - ID: %d, 에러: %v", roleIDInt, err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("역할 조회 실패: %v", err)})
+	}
+	if existing == nil {
+		return c.JSON(http.StatusNotFound, map[string]string{"error": "csp 타입의 해당 역할을 찾을 수 없습니다"})
+	}
 
 	var req model.CreateRoleRequest
 	if err := c.Bind(&req); err != nil {
 		log.Printf("csp 역할 수정 요청 바인딩 실패 - 에러: %v", err)
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "잘못된 요청 형식입니다"})
-	}
-
-	roleIDInt, err := util.StringToUint(c.Param("roleId"))
-	if err != nil {
-		log.Printf("잘못된 csp 역할 ID 형식: %s", c.Param("roleId"))
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "csp 역할 ID 형식입니다"})
-	}
-
-	if !util.CheckValueInArrayIAMRoleType(req.RoleTypes, roleType) { //roleType이 csp인지 확인
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "역할 타입이 일치하지 않습니다"})
 	}
 
 	if err := c.Validate(&req); err != nil {

--- a/src/main.go
+++ b/src/main.go
@@ -324,6 +324,7 @@ func main() {
 		roles.DELETE("/platform-roles/id/:roleId", roleHandler.DeletePlatformRole) //단건삭제
 		roles.GET("/platform-roles/id/:roleId", roleHandler.GetPlatformRoleByID)
 		roles.GET("/platform-roles/name/:roleName", roleHandler.GetPlatformRoleByName)
+		roles.PUT("/platform-roles/id/:roleId", roleHandler.UpdatePlatformRole)
 
 		roles.POST("/workspace-roles/list", roleHandler.ListWorkspaceRoles)
 		roles.POST("/workspace-roles", roleHandler.CreateWorkspaceRole)
@@ -331,15 +332,17 @@ func main() {
 		roles.DELETE("/workspace-roles/id/:roleId", roleHandler.DeleteWorkspaceRole) //단건삭제
 		roles.GET("/workspace-roles/id/:roleId", roleHandler.GetWorkspaceRoleByID)
 		roles.GET("/workspace-roles/name/:roleName", roleHandler.GetWorkspaceRoleByName)
+		roles.PUT("/workspace-roles/id/:roleId", roleHandler.UpdateWorkspaceRole)
 
 		roles.POST("/csp-roles/list", roleHandler.ListCspRoleMappings)
 		roles.GET("/csp-roles/id/:roleId", roleHandler.GetCspRoleMappings)
+		roles.PUT("/csp-roles/master/id/:roleId", roleHandler.UpdateCspRoleMaster)
 		roles.POST("/csp/list", roleHandler.ListCSPRoles)
 		roles.POST("/csp", roleHandler.CreateCspRole)
 		roles.POST("/csp/batch", roleHandler.CreateCspRoles)
 		//roles.DELETE("/csp", roleHandler.DeleteCspRole)
 		roles.DELETE("/csp/id/:roleId", roleHandler.DeleteCspRole) //단건삭제
-		roles.PUT("/csp/id/:roleId", roleHandler.UpdateCspRoleRecord)
+		roles.PUT("/csp/id/:roleId", roleHandler.UpdateCspRole)
 		roles.GET("/csp/id/:roleId", roleHandler.GetCspRoleByID)
 		roles.GET("/csp/name/:roleName", roleHandler.GetCspRoleByName)
 

--- a/src/service/mcmpapi_service_test.go
+++ b/src/service/mcmpapi_service_test.go
@@ -1,0 +1,79 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/m-cmp/mc-iam-manager/model/mcmpapi"
+	"github.com/m-cmp/mc-iam-manager/repository"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestMcmpApiService(t *testing.T) *mcmpApiService {
+	db := setupTestDB(t)
+	require.NoError(t, db.AutoMigrate(&mcmpapi.McmpApiServiceMeta{}))
+	return &mcmpApiService{db: db, repo: repository.NewMcmpApiRepository(db)}
+}
+
+// TestShouldUpdateService_UnchangedMeta_Skips: IAM-TECH-021 회귀 방지.
+// 레지스트리 YAML을 고쳐도 서비스의 _meta(version/generatedAt)를 갱신하지 않으면
+// syncServicesAndActions가 해당 서비스의 액션 전체를 조용히 스킵한다(IAM-TECH-020이
+// 배포+수동 동기화 후에도 반영되지 않았던 원인). generatedAt이 그대로면 false를
+// 반환해야 한다.
+func TestShouldUpdateService_UnchangedMeta_Skips(t *testing.T) {
+	s := newTestMcmpApiService(t)
+
+	generatedAt := time.Date(2026, 6, 1, 2, 11, 43, 0, time.UTC)
+	meta := &mcmpapi.McmpApiServiceMeta{
+		ServiceName: "mc-iam-manager",
+		Version:     "0.5.2",
+		GeneratedAt: generatedAt,
+	}
+	require.NoError(t, s.repo.UpsertServiceMeta(s.db, meta))
+
+	shouldUpdate, err := s.shouldUpdateService("mc-iam-manager", &mcmpapi.McmpApiServiceMeta{
+		ServiceName: "mc-iam-manager",
+		Version:     "0.5.2",
+		GeneratedAt: generatedAt,
+	})
+	require.NoError(t, err)
+	assert.False(t, shouldUpdate, "version/generatedAt 동일 시 스킵되어야 함")
+}
+
+// TestShouldUpdateService_GeneratedAtBumped_Updates: generatedAt만 바뀌어도
+// (version 동일) 갱신 대상으로 인식해야 한다 — IAM-TECH-021의 수정 사항.
+func TestShouldUpdateService_GeneratedAtBumped_Updates(t *testing.T) {
+	s := newTestMcmpApiService(t)
+
+	oldGeneratedAt := time.Date(2026, 6, 1, 2, 11, 43, 0, time.UTC)
+	meta := &mcmpapi.McmpApiServiceMeta{
+		ServiceName: "mc-iam-manager",
+		Version:     "0.5.2",
+		GeneratedAt: oldGeneratedAt,
+	}
+	require.NoError(t, s.repo.UpsertServiceMeta(s.db, meta))
+
+	newGeneratedAt := oldGeneratedAt.Add(24 * time.Hour)
+	shouldUpdate, err := s.shouldUpdateService("mc-iam-manager", &mcmpapi.McmpApiServiceMeta{
+		ServiceName: "mc-iam-manager",
+		Version:     "0.5.2",
+		GeneratedAt: newGeneratedAt,
+	})
+	require.NoError(t, err)
+	assert.True(t, shouldUpdate, "generatedAt이 바뀌면 갱신 대상으로 인식해야 함")
+}
+
+// TestShouldUpdateService_NewService_AlwaysUpdates: DB에 메타가 아예 없으면
+// (신규 서비스) 항상 갱신 대상.
+func TestShouldUpdateService_NewService_AlwaysUpdates(t *testing.T) {
+	s := newTestMcmpApiService(t)
+
+	shouldUpdate, err := s.shouldUpdateService("brand-new-service", &mcmpapi.McmpApiServiceMeta{
+		ServiceName: "brand-new-service",
+		Version:     "0.1.0",
+		GeneratedAt: time.Now(),
+	})
+	require.NoError(t, err)
+	assert.True(t, shouldUpdate, "DB에 없는 신규 서비스는 항상 갱신 대상이어야 함")
+}

--- a/src/service/role_service_test.go
+++ b/src/service/role_service_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"testing"
 
+	"github.com/m-cmp/mc-iam-manager/constants"
 	"github.com/m-cmp/mc-iam-manager/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -360,4 +361,76 @@ func TestGetEffectiveWorkspaceRoles_MultipleGroupsSameWorkspace(t *testing.T) {
 		assert.Equal(t, ws.ID, r.WorkspaceID)
 		assert.Equal(t, ws.Name, r.WorkspaceName)
 	}
+}
+
+// ── GetRoleByID 타입 가드 단위 테스트 (IAM-TECH-021 확장) ──────────────────────
+// UpdatePlatformRole/UpdateWorkspaceRole/UpdateCspRoleMaster 핸들러가 요청 바디의
+// RoleTypes 대신 DB의 기존 RoleSub를 기준으로 타입을 검증하도록 바꾼 근거.
+// RoleMaster에는 타입이 없고 RoleSub가 타입을 가지며 다중일 수 있으므로,
+// roleId가 실제로 그 타입의 RoleSub를 가지고 있는지 DB로 확인해야 한다.
+
+func setupRoleServiceTestDBWithSubs(t *testing.T) *gorm.DB {
+	t.Helper()
+	db := setupRoleServiceTestDB(t)
+	require.NoError(t, db.AutoMigrate(&model.RoleSub{}))
+	return db
+}
+
+func seedRoleSub(t *testing.T, db *gorm.DB, roleID uint, roleType constants.IAMRoleType) {
+	t.Helper()
+	require.NoError(t, db.Create(&model.RoleSub{RoleID: roleID, RoleType: roleType}).Error)
+}
+
+// TC-ROLE-GBID-01: roleId가 요청한 타입의 RoleSub를 가지고 있으면 조회 성공
+func TestGetRoleByID_MatchingType_ReturnsRole(t *testing.T) {
+	db := setupRoleServiceTestDBWithSubs(t)
+	svc := NewRoleService(db)
+
+	role := seedRoleMaster(t, db, "csp-admin")
+	seedRoleSub(t, db, role.ID, constants.RoleTypeCSP)
+
+	found, err := svc.GetRoleByID(role.ID, constants.RoleTypeCSP)
+
+	require.NoError(t, err)
+	require.NotNil(t, found)
+	assert.Equal(t, role.ID, found.ID)
+}
+
+// TC-ROLE-GBID-02: roleId는 존재하지만 다른 타입으로만 등록된 경우 nil 반환
+// — 예: platform 타입 역할의 ID를 UpdateCspRoleMaster에 넣으면 다른 역할을
+// 건드리지 못하도록 nil(404)이어야 한다.
+func TestGetRoleByID_MismatchedType_ReturnsNil(t *testing.T) {
+	db := setupRoleServiceTestDBWithSubs(t)
+	svc := NewRoleService(db)
+
+	role := seedRoleMaster(t, db, "platform-admin")
+	seedRoleSub(t, db, role.ID, constants.RoleTypePlatform)
+
+	found, err := svc.GetRoleByID(role.ID, constants.RoleTypeCSP)
+
+	require.NoError(t, err)
+	assert.Nil(t, found, "다른 타입으로만 등록된 역할은 조회되지 않아야 함")
+}
+
+// TC-ROLE-GBID-03: 하나의 RoleMaster가 여러 RoleSub(다중 타입)를 가질 수 있고,
+// 그 중 하나만 일치해도 해당 타입 기준으로는 조회 성공해야 한다.
+func TestGetRoleByID_MultiTypeRole_MatchesEitherType(t *testing.T) {
+	db := setupRoleServiceTestDBWithSubs(t)
+	svc := NewRoleService(db)
+
+	role := seedRoleMaster(t, db, "platform-and-workspace-admin")
+	seedRoleSub(t, db, role.ID, constants.RoleTypePlatform)
+	seedRoleSub(t, db, role.ID, constants.RoleTypeWorkspace)
+
+	foundAsPlatform, err := svc.GetRoleByID(role.ID, constants.RoleTypePlatform)
+	require.NoError(t, err)
+	assert.NotNil(t, foundAsPlatform)
+
+	foundAsWorkspace, err := svc.GetRoleByID(role.ID, constants.RoleTypeWorkspace)
+	require.NoError(t, err)
+	assert.NotNil(t, foundAsWorkspace)
+
+	foundAsCsp, err := svc.GetRoleByID(role.ID, constants.RoleTypeCSP)
+	require.NoError(t, err)
+	assert.Nil(t, foundAsCsp, "csp 타입 RoleSub는 없으므로 nil이어야 함")
 }


### PR DESCRIPTION
## 변경 사항

**1. 레지스트리 동기화 수정**
- `asset/mcmpapi/service-actions.yaml`, `conf/mc-iam-manager/service-actions.yaml`의 mc-iam-manager 서비스 `_meta.generatedAt` 갱신 — 다음 동기화가 실제로 재적재되도록 함

**2. 핸들러 보완 + CSP Role API 이름 정리**

| 기존 | 변경 후 | 내용 |
|---|---|---|
| `UpdateCspRole` (RoleMaster, `main.go` 미등록, `CreateWorkspaceRole`류와 로직 100% 중복) | 삭제 | 죽은 코드 제거, swagger에서 잘못된 경로 소거 |
| `UpdateCspRoleRecord` (`PUT /roles/csp/id/{roleId}`) | `UpdateCspRole` | 형제 액션(`createCspRole`/`deleteCspRole`/`getCspRoleById`)과 이름 통일, 경로 변경 없음 |
| — (없었음) | `UpdatePlatformRole` (`PUT /roles/platform-roles/id/{roleId}`) | `platform-roles`에 Create/Delete/Get만 있고 Update가 없던 비대칭 해소 |
| — (없었음) | `UpdateWorkspaceRole` (`PUT /roles/workspace-roles/id/{roleId}`) | 상동, workspace-roles |
| — (없었음) | `UpdateCspRoleMaster` (`PUT /roles/csp-roles/master/id/{roleId}`) | CSP 타입 RoleMaster 수정 — `csp`(레코드)/`csp-roles`(매핑)와 겹치지 않는 별도 이름으로, 위 `UpdateCspRole`(레코드)과 재충돌하지 않도록 분리 |

신설한 3개 핸들러는 RoleMaster 자체에는 타입이 없고 RoleSub가 타입을 가지며(다중 가능) 하다는 점을 감안해, 요청 바디의 `RoleTypes`가 아니라 **DB의 기존 RoleSub를 기준으로**(`roleService.GetRoleByID(roleId, requiredType)`) roleId가 실제로 해당 타입인지 검증한다(IAM-BUG-017과 동일 패턴).
