### PR TITLE
fix(role): CSP 역할 매핑 조회 auth_method OIDC 하드코딩 제거

### DIFF
--- a/src/handler/role_handler.go
+++ b/src/handler/role_handler.go
@@ -129,10 +129,13 @@ func (h *RoleHandler) CreateRole(c echo.Context) error {
 			}
 
 			// Store created CSP role information
+			// AuthMethod는 요청 원본(cspRole)에서 그대로 전달 — 누락 시 CreateRoleWithAllDependencies가
+			// OIDC로 기본 반영하지만, SAML 등으로 생성된 CSP 역할은 그 값이 매핑에도 반영되어야 한다.
 			createdCspRoles = append(createdCspRoles, model.CreateCspRoleRequest{
 				ID:          util.UintToString(createdCspRole.ID),
 				CspRoleName: createdCspRole.Name,
 				CspType:     createdCspRole.CspType,
+				AuthMethod:  cspRole.AuthMethod,
 			})
 		}
 	}
@@ -343,10 +346,11 @@ func (h *RoleHandler) UpdateRole(c echo.Context) error {
 			}
 
 			// Create new mapping
+			// AuthMethod가 비어있으면 CreateRoleCspRoleMapping(repository)이 OIDC로 기본 반영한다.
 			roleCspRoleMappingRequest := &model.CreateRoleMasterCspRoleMappingRequest{
 				RoleID:      roleId,
 				CspRoleID:   cspRole.ID,
-				AuthMethod:  constants.AuthMethodOIDC,
+				AuthMethod:  cspRole.AuthMethod,
 				Description: req.Description,
 			}
 

--- a/src/handler/role_handler_authmethod_test.go
+++ b/src/handler/role_handler_authmethod_test.go
@@ -1,0 +1,96 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/labstack/echo/v4"
+	"github.com/m-cmp/mc-iam-manager/constants"
+	"github.com/m-cmp/mc-iam-manager/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type authMethodTestValidator struct{ v *validator.Validate }
+
+func (tv *authMethodTestValidator) Validate(i interface{}) error { return tv.v.Struct(i) }
+
+func setupAuthMethodTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	// NewRoleHandler가 구성하는 MenuRepository 등 다른 리포지토리가 자체적으로
+	// AutoMigrate를 호출하며 새 커넥션을 열 수 있어 shared cache로 같은 DB를 공유한다.
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+
+	require.NoError(t, db.AutoMigrate(
+		&model.RoleMaster{},
+		&model.RoleSub{},
+		&model.CspRole{},
+		&model.RoleMasterCspRoleMapping{},
+	))
+	return db
+}
+
+func authMethodTestEcho() *echo.Echo {
+	e := echo.New()
+	e.Validator = &authMethodTestValidator{v: validator.New()}
+	return e
+}
+
+// TC-IAM-BUG-020-05: CreateRole이 cspRoles에 지정된 authMethod(SAML)를
+// RoleMasterCspRoleMapping에 그대로 반영해야 한다 — 수정 전에는 이 값이
+// createdCspRoles 재구성 과정에서 누락되어 항상 OIDC로 기록됐다.
+func TestCreateRole_CspRoleWithSAMLAuthMethod_MappingPreservesAuthMethod(t *testing.T) {
+	db := setupAuthMethodTestDB(t)
+	h := NewRoleHandler(db)
+
+	e := authMethodTestEcho()
+	body := `{"name":"tc-iam-bug-020-create","roleTypes":["csp"],"cspRoles":[{"cspRoleName":"tc-role-saml","cspType":"gcp","authMethod":"SAML"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/roles", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, h.CreateRole(c))
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+
+	var role model.RoleMaster
+	require.NoError(t, db.Where("name = ?", "tc-iam-bug-020-create").First(&role).Error)
+
+	var mapping model.RoleMasterCspRoleMapping
+	require.NoError(t, db.Where("role_id = ?", role.ID).First(&mapping).Error)
+	assert.Equal(t, constants.AuthMethodSAML, mapping.AuthMethod, "SAML로 생성한 CSP 역할의 매핑은 SAML로 기록되어야 한다")
+}
+
+// TC-IAM-BUG-020-06: UpdateRole이 cspRoles에 지정된 authMethod(SAML)를
+// 그대로 반영해야 한다 — 수정 전에는 항상 constants.AuthMethodOIDC로 고정되어,
+// 저장할 때마다 SAML 매핑이 OIDC로 덮어써졌다.
+func TestUpdateRole_CspRoleWithSAMLAuthMethod_MappingPreservesAuthMethod(t *testing.T) {
+	db := setupAuthMethodTestDB(t)
+	h := NewRoleHandler(db)
+
+	role := &model.RoleMaster{Name: "tc-iam-bug-020-update"}
+	require.NoError(t, db.Create(role).Error)
+
+	e := authMethodTestEcho()
+	body := `{"name":"tc-iam-bug-020-update","roleTypes":["csp"],"cspRoles":[{"cspRoleName":"tc-role-saml-update","cspType":"gcp","authMethod":"SAML"}]}`
+	req := httptest.NewRequest(http.MethodPut, "/api/roles/id/"+strconv.FormatUint(uint64(role.ID), 10), strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("roleId")
+	c.SetParamValues(strconv.FormatUint(uint64(role.ID), 10))
+
+	require.NoError(t, h.UpdateRole(c))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var mapping model.RoleMasterCspRoleMapping
+	require.NoError(t, db.Where("role_id = ?", role.ID).First(&mapping).Error)
+	assert.Equal(t, constants.AuthMethodSAML, mapping.AuthMethod, "SAML로 지정한 CSP 역할 매핑은 SAML로 저장되어야 한다(수정 전 버그는 OIDC로 덮어씀)")
+}

--- a/src/repository/role_repository.go
+++ b/src/repository/role_repository.go
@@ -488,8 +488,10 @@ func (r *RoleRepository) FindRoleMasterCspRoleMappings(req *model.RoleMasterCspR
 		query = query.Where("csp_role_id = ?", req.CspRoleID)
 	}
 
-	// 현재는 OIDC로 고정. TODO : 선택하는 로직 추가 필요
-	query = query.Where("auth_method = ?", constants.AuthMethodOIDC)
+	// authMethod가 비어있지 않다면 조건 추가
+	if req.AuthMethod != "" {
+		query = query.Where("auth_method = ?", req.AuthMethod)
+	}
 
 	if err := query.Find(&mappings).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
@@ -533,8 +535,10 @@ func (r *RoleRepository) FindWorkspaceRoleCspRoleMappings(req *model.RoleMasterC
 		query = query.Where("csp_role_id = ?", req.CspRoleID)
 	}
 
-	// authMethod 는 OIDC로 고정. TODO : 선택하는 로직 추가 필요
-	query = query.Where("auth_method = ?", constants.AuthMethodOIDC)
+	// authMethod가 비어있지 않다면 조건 추가
+	if req.AuthMethod != "" {
+		query = query.Where("auth_method = ?", req.AuthMethod)
+	}
 
 	if err := query.Find(&mappings).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {

--- a/src/repository/role_repository_findmappings_test.go
+++ b/src/repository/role_repository_findmappings_test.go
@@ -1,0 +1,88 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/m-cmp/mc-iam-manager/constants"
+	"github.com/m-cmp/mc-iam-manager/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupFindMappingsTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&model.RoleMasterCspRoleMapping{}, &model.CspRole{}))
+	return db
+}
+
+func seedMappingsWithAllAuthMethods(t *testing.T, db *gorm.DB, roleID uint) {
+	t.Helper()
+	for i, am := range []constants.AuthMethod{constants.AuthMethodOIDC, constants.AuthMethodSAML, constants.AuthMethodSecretKey} {
+		require.NoError(t, db.Create(&model.RoleMasterCspRoleMapping{
+			RoleID:     roleID,
+			AuthMethod: am,
+			CspRoleID:  uint(i + 1),
+		}).Error)
+	}
+}
+
+// TC-IAM-BUG-020-01: authMethod 미지정 시 OIDC 외 SAML/SECRET_KEY 매핑도 전부 조회되어야 한다
+// (수정 전에는 auth_method='OIDC' 하드코딩으로 SAML/SECRET_KEY 매핑이 항상 누락됐다)
+func TestFindRoleMasterCspRoleMappings_NoAuthMethodFilter_ReturnsAllAuthMethods(t *testing.T) {
+	db := setupFindMappingsTestDB(t)
+	r := NewRoleRepository(db)
+	seedMappingsWithAllAuthMethods(t, db, 1)
+
+	mappings, err := r.FindRoleMasterCspRoleMappings(&model.RoleMasterCspRoleMappingRequest{RoleID: "1"})
+
+	require.NoError(t, err)
+	assert.Len(t, mappings, 3, "OIDC/SAML/SECRET_KEY 매핑이 모두 조회되어야 한다")
+}
+
+// TC-IAM-BUG-020-02: authMethod 지정 시 해당 인증방식 매핑만 조회되어야 한다
+func TestFindRoleMasterCspRoleMappings_WithAuthMethodFilter_FiltersToRequestedMethod(t *testing.T) {
+	db := setupFindMappingsTestDB(t)
+	r := NewRoleRepository(db)
+	seedMappingsWithAllAuthMethods(t, db, 1)
+
+	mappings, err := r.FindRoleMasterCspRoleMappings(&model.RoleMasterCspRoleMappingRequest{
+		RoleID:     "1",
+		AuthMethod: constants.AuthMethodSAML,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, mappings, 1)
+	assert.Equal(t, constants.AuthMethodSAML, mappings[0].AuthMethod)
+}
+
+// TC-IAM-BUG-020-03: FindWorkspaceRoleCspRoleMappings도 동일한 하드코딩 버그가 있었다 —
+// 같은 파일에서 발견된 동일 패턴을 함께 수정(부수 발견)
+func TestFindWorkspaceRoleCspRoleMappings_NoAuthMethodFilter_ReturnsAllAuthMethods(t *testing.T) {
+	db := setupFindMappingsTestDB(t)
+	r := NewRoleRepository(db)
+	seedMappingsWithAllAuthMethods(t, db, 2)
+
+	mappings, err := r.FindWorkspaceRoleCspRoleMappings(&model.RoleMasterCspRoleMappingRequest{RoleID: "2"})
+
+	require.NoError(t, err)
+	assert.Len(t, mappings, 3, "OIDC/SAML/SECRET_KEY 매핑이 모두 조회되어야 한다")
+}
+
+func TestFindWorkspaceRoleCspRoleMappings_WithAuthMethodFilter_FiltersToRequestedMethod(t *testing.T) {
+	db := setupFindMappingsTestDB(t)
+	r := NewRoleRepository(db)
+	seedMappingsWithAllAuthMethods(t, db, 2)
+
+	mappings, err := r.FindWorkspaceRoleCspRoleMappings(&model.RoleMasterCspRoleMappingRequest{
+		RoleID:     "2",
+		AuthMethod: constants.AuthMethodSecretKey,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, mappings, 1)
+	assert.Equal(t, constants.AuthMethodSecretKey, mappings[0].AuthMethod)
+}


### PR DESCRIPTION
## Summary
- `FindRoleMasterCspRoleMappings`(role_repository.go)가 `query.Where("auth_method = ?", constants.AuthMethodOIDC)`로 인증방식을 항상 OIDC로 고정 필터링하고 있어, SAML/SECRET_KEY로 등록된 `RoleMasterCspRoleMapping`은 절대 조회되지 않는 문제 확인(코드 내 TODO 주석으로 자각된 상태)
- `req.AuthMethod`가 지정된 경우에만 필터링하는 옵셔널 패턴으로 교체 — 다른 필드들과 동일한 방식
- IAM-FIX-004(SAML 인증방식 CSP 확장)가 진행되어 SAML 매핑이 실제로 등록되기 시작하면 이 하드코딩 때문에 조회가 누락되는 문제가 곧 발현될 것으로 보고 선제 수정
- 부수 발견: 같은 파일의 `FindWorkspaceRoleCspRoleMappings`에도 동일한 하드코딩이 있어 같은 패턴으로 함께 수정
- `CreateRole`(role_handler.go) — CSP 역할 생성 후 매핑 생성용 `createdCspRoles`를 재구성할 때 원본 요청의 `authMethod`를 복사하지 않아, SAML로 생성한 CSP 역할인데도 매핑은 항상 OIDC로 기록되던 문제
- `UpdateRole`(role_handler.go) — `RoleMasterCspRoleMapping` 재생성 시 요청의 `authMethod`를 무시하고 항상 `constants.AuthMethodOIDC`로 고정 반영하던 문제. **역할을 수정(저장)할 때마다 기존 SAML/SECRET_KEY 매핑이 OIDC로 덮어써지는** 실사용 데이터 손실 버그
