### PR TITLE
fix(role): DeleteCspRole 재배선(레코드 삭제) + CSP 타입 Create/Delete API 대칭 완성

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -7222,59 +7222,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/roles/csp-roles/id/{roleId}": {
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Delete a role",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "roles"
-                ],
-                "summary": "Delete csp role",
-                "operationId": "deleteCspRole",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Role ID",
-                        "name": "roleId",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/api/roles/csp-roles/list": {
             "post": {
                 "security": [
@@ -7310,6 +7257,64 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/model.RoleMasterCspRoleMappingRequest"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/roles/csp-roles/master": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "RoleMaster + RoleSub(csp)를 생성합니다. CreatePlatformRole/CreateWorkspaceRole과 대칭되는\ncsp 타입 전용 생성 API입니다. 대상 CSP의 실제 역할(CspRole 레코드)은 CreateCspRole로 별도 생성/매핑해야 합니다.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "Create csp role master",
+                "operationId": "createCspRoleMaster",
+                "parameters": [
+                    {
+                        "description": "Role Info",
+                        "name": "role",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CreateRoleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/model.RoleMaster"
                         }
                     },
                     "400": {
@@ -7379,6 +7384,75 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "RoleMaster의 csp 타입 RoleSub 태그를 삭제합니다(DeletePlatformRole/DeleteWorkspaceRole과 대칭).\nRoleMaster 자체나 CspRole 레코드는 삭제하지 않습니다 — CspRole 레코드 삭제는 DeleteCspRole을 사용하세요.\n이 역할에 CSP 역할 매핑이 남아있으면 삭제할 수 없습니다(먼저 매핑을 해제해야 합니다).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "Delete csp role master",
+                "operationId": "deleteCspRoleMaster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Role ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -7498,6 +7572,66 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "CspRole(mcmp_role_csp_roles) 레코드를 삭제합니다. 이 레코드를 참조하는 RoleMaster-CspRole\n매핑을 먼저 정리한 뒤 레코드를 삭제하며, AWS인 경우 실제 클라우드 Role도 함께 삭제합니다.\nRoleMaster/RoleSub(csp)는 건드리지 않습니다 — 그 삭제는 DeleteCspRoleMaster를 사용하세요.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "Delete csp role",
+                "operationId": "deleteCspRole",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CSP Role ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -7216,59 +7216,6 @@
                 }
             }
         },
-        "/api/roles/csp-roles/id/{roleId}": {
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Delete a role",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "roles"
-                ],
-                "summary": "Delete csp role",
-                "operationId": "deleteCspRole",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Role ID",
-                        "name": "roleId",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/api/roles/csp-roles/list": {
             "post": {
                 "security": [
@@ -7304,6 +7251,64 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/model.RoleMasterCspRoleMappingRequest"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/roles/csp-roles/master": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "RoleMaster + RoleSub(csp)를 생성합니다. CreatePlatformRole/CreateWorkspaceRole과 대칭되는\ncsp 타입 전용 생성 API입니다. 대상 CSP의 실제 역할(CspRole 레코드)은 CreateCspRole로 별도 생성/매핑해야 합니다.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "Create csp role master",
+                "operationId": "createCspRoleMaster",
+                "parameters": [
+                    {
+                        "description": "Role Info",
+                        "name": "role",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CreateRoleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/model.RoleMaster"
                         }
                     },
                     "400": {
@@ -7373,6 +7378,75 @@
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "RoleMaster의 csp 타입 RoleSub 태그를 삭제합니다(DeletePlatformRole/DeleteWorkspaceRole과 대칭).\nRoleMaster 자체나 CspRole 레코드는 삭제하지 않습니다 — CspRole 레코드 삭제는 DeleteCspRole을 사용하세요.\n이 역할에 CSP 역할 매핑이 남아있으면 삭제할 수 없습니다(먼저 매핑을 해제해야 합니다).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "Delete csp role master",
+                "operationId": "deleteCspRoleMaster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Role ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -7492,6 +7566,66 @@
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "CspRole(mcmp_role_csp_roles) 레코드를 삭제합니다. 이 레코드를 참조하는 RoleMaster-CspRole\n매핑을 먼저 정리한 뒤 레코드를 삭제하며, AWS인 경우 실제 클라우드 Role도 함께 삭제합니다.\nRoleMaster/RoleSub(csp)는 건드리지 않습니다 — 그 삭제는 DeleteCspRoleMaster를 사용하세요.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "Delete csp role",
+                "operationId": "deleteCspRole",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CSP Role ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -6753,40 +6753,6 @@ paths:
       summary: Get role-CSP role mapping
       tags:
       - roles
-  /api/roles/csp-roles/id/{roleId}:
-    delete:
-      consumes:
-      - application/json
-      description: Delete a role
-      operationId: deleteCspRole
-      parameters:
-      - description: Role ID
-        in: path
-        name: roleId
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "204":
-          description: No Content
-        "404":
-          description: Not Found
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "500":
-          description: Internal Server Error
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-      security:
-      - BearerAuth: []
-      summary: Delete csp role
-      tags:
-      - roles
   /api/roles/csp-roles/list:
     post:
       consumes:
@@ -6824,7 +6790,94 @@ paths:
       summary: Get role-CSP role mapping
       tags:
       - roles
+  /api/roles/csp-roles/master:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        RoleMaster + RoleSub(csp)를 생성합니다. CreatePlatformRole/CreateWorkspaceRole과 대칭되는
+        csp 타입 전용 생성 API입니다. 대상 CSP의 실제 역할(CspRole 레코드)은 CreateCspRole로 별도 생성/매핑해야 합니다.
+      operationId: createCspRoleMaster
+      parameters:
+      - description: Role Info
+        in: body
+        name: role
+        required: true
+        schema:
+          $ref: '#/definitions/model.CreateRoleRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/model.RoleMaster'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Create csp role master
+      tags:
+      - roles
   /api/roles/csp-roles/master/id/{roleId}:
+    delete:
+      consumes:
+      - application/json
+      description: |-
+        RoleMaster의 csp 타입 RoleSub 태그를 삭제합니다(DeletePlatformRole/DeleteWorkspaceRole과 대칭).
+        RoleMaster 자체나 CspRole 레코드는 삭제하지 않습니다 — CspRole 레코드 삭제는 DeleteCspRole을 사용하세요.
+        이 역할에 CSP 역할 매핑이 남아있으면 삭제할 수 없습니다(먼저 매핑을 해제해야 합니다).
+      operationId: deleteCspRoleMaster
+      parameters:
+      - description: Role ID
+        in: path
+        name: roleId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Forbidden
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Delete csp role master
+      tags:
+      - roles
     put:
       consumes:
       - application/json
@@ -6869,6 +6922,48 @@ paths:
       tags:
       - roles
   /api/roles/csp/id/{roleId}:
+    delete:
+      consumes:
+      - application/json
+      description: |-
+        CspRole(mcmp_role_csp_roles) 레코드를 삭제합니다. 이 레코드를 참조하는 RoleMaster-CspRole
+        매핑을 먼저 정리한 뒤 레코드를 삭제하며, AWS인 경우 실제 클라우드 Role도 함께 삭제합니다.
+        RoleMaster/RoleSub(csp)는 건드리지 않습니다 — 그 삭제는 DeleteCspRoleMaster를 사용하세요.
+      operationId: deleteCspRole
+      parameters:
+      - description: CSP Role ID
+        in: path
+        name: roleId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Delete csp role
+      tags:
+      - roles
     get:
       consumes:
       - application/json

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -7222,59 +7222,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/roles/csp-roles/id/{roleId}": {
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Delete a role",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "roles"
-                ],
-                "summary": "Delete csp role",
-                "operationId": "deleteCspRole",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Role ID",
-                        "name": "roleId",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/api/roles/csp-roles/list": {
             "post": {
                 "security": [
@@ -7310,6 +7257,64 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/model.RoleMasterCspRoleMappingRequest"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/roles/csp-roles/master": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "RoleMaster + RoleSub(csp)를 생성합니다. CreatePlatformRole/CreateWorkspaceRole과 대칭되는\ncsp 타입 전용 생성 API입니다. 대상 CSP의 실제 역할(CspRole 레코드)은 CreateCspRole로 별도 생성/매핑해야 합니다.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "Create csp role master",
+                "operationId": "createCspRoleMaster",
+                "parameters": [
+                    {
+                        "description": "Role Info",
+                        "name": "role",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CreateRoleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/model.RoleMaster"
                         }
                     },
                     "400": {
@@ -7379,6 +7384,75 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "RoleMaster의 csp 타입 RoleSub 태그를 삭제합니다(DeletePlatformRole/DeleteWorkspaceRole과 대칭).\nRoleMaster 자체나 CspRole 레코드는 삭제하지 않습니다 — CspRole 레코드 삭제는 DeleteCspRole을 사용하세요.\n이 역할에 CSP 역할 매핑이 남아있으면 삭제할 수 없습니다(먼저 매핑을 해제해야 합니다).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "Delete csp role master",
+                "operationId": "deleteCspRoleMaster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Role ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -7498,6 +7572,66 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "CspRole(mcmp_role_csp_roles) 레코드를 삭제합니다. 이 레코드를 참조하는 RoleMaster-CspRole\n매핑을 먼저 정리한 뒤 레코드를 삭제하며, AWS인 경우 실제 클라우드 Role도 함께 삭제합니다.\nRoleMaster/RoleSub(csp)는 건드리지 않습니다 — 그 삭제는 DeleteCspRoleMaster를 사용하세요.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "Delete csp role",
+                "operationId": "deleteCspRole",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CSP Role ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -7216,59 +7216,6 @@
                 }
             }
         },
-        "/api/roles/csp-roles/id/{roleId}": {
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Delete a role",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "roles"
-                ],
-                "summary": "Delete csp role",
-                "operationId": "deleteCspRole",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Role ID",
-                        "name": "roleId",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/api/roles/csp-roles/list": {
             "post": {
                 "security": [
@@ -7304,6 +7251,64 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/model.RoleMasterCspRoleMappingRequest"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/roles/csp-roles/master": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "RoleMaster + RoleSub(csp)를 생성합니다. CreatePlatformRole/CreateWorkspaceRole과 대칭되는\ncsp 타입 전용 생성 API입니다. 대상 CSP의 실제 역할(CspRole 레코드)은 CreateCspRole로 별도 생성/매핑해야 합니다.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "Create csp role master",
+                "operationId": "createCspRoleMaster",
+                "parameters": [
+                    {
+                        "description": "Role Info",
+                        "name": "role",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CreateRoleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/model.RoleMaster"
                         }
                     },
                     "400": {
@@ -7373,6 +7378,75 @@
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "RoleMaster의 csp 타입 RoleSub 태그를 삭제합니다(DeletePlatformRole/DeleteWorkspaceRole과 대칭).\nRoleMaster 자체나 CspRole 레코드는 삭제하지 않습니다 — CspRole 레코드 삭제는 DeleteCspRole을 사용하세요.\n이 역할에 CSP 역할 매핑이 남아있으면 삭제할 수 없습니다(먼저 매핑을 해제해야 합니다).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "Delete csp role master",
+                "operationId": "deleteCspRoleMaster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Role ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -7492,6 +7566,66 @@
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "CspRole(mcmp_role_csp_roles) 레코드를 삭제합니다. 이 레코드를 참조하는 RoleMaster-CspRole\n매핑을 먼저 정리한 뒤 레코드를 삭제하며, AWS인 경우 실제 클라우드 Role도 함께 삭제합니다.\nRoleMaster/RoleSub(csp)는 건드리지 않습니다 — 그 삭제는 DeleteCspRoleMaster를 사용하세요.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "roles"
+                ],
+                "summary": "Delete csp role",
+                "operationId": "deleteCspRole",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CSP Role ID",
+                        "name": "roleId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -6753,40 +6753,6 @@ paths:
       summary: Get role-CSP role mapping
       tags:
       - roles
-  /api/roles/csp-roles/id/{roleId}:
-    delete:
-      consumes:
-      - application/json
-      description: Delete a role
-      operationId: deleteCspRole
-      parameters:
-      - description: Role ID
-        in: path
-        name: roleId
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "204":
-          description: No Content
-        "404":
-          description: Not Found
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "500":
-          description: Internal Server Error
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-      security:
-      - BearerAuth: []
-      summary: Delete csp role
-      tags:
-      - roles
   /api/roles/csp-roles/list:
     post:
       consumes:
@@ -6824,7 +6790,94 @@ paths:
       summary: Get role-CSP role mapping
       tags:
       - roles
+  /api/roles/csp-roles/master:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        RoleMaster + RoleSub(csp)를 생성합니다. CreatePlatformRole/CreateWorkspaceRole과 대칭되는
+        csp 타입 전용 생성 API입니다. 대상 CSP의 실제 역할(CspRole 레코드)은 CreateCspRole로 별도 생성/매핑해야 합니다.
+      operationId: createCspRoleMaster
+      parameters:
+      - description: Role Info
+        in: body
+        name: role
+        required: true
+        schema:
+          $ref: '#/definitions/model.CreateRoleRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/model.RoleMaster'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Create csp role master
+      tags:
+      - roles
   /api/roles/csp-roles/master/id/{roleId}:
+    delete:
+      consumes:
+      - application/json
+      description: |-
+        RoleMaster의 csp 타입 RoleSub 태그를 삭제합니다(DeletePlatformRole/DeleteWorkspaceRole과 대칭).
+        RoleMaster 자체나 CspRole 레코드는 삭제하지 않습니다 — CspRole 레코드 삭제는 DeleteCspRole을 사용하세요.
+        이 역할에 CSP 역할 매핑이 남아있으면 삭제할 수 없습니다(먼저 매핑을 해제해야 합니다).
+      operationId: deleteCspRoleMaster
+      parameters:
+      - description: Role ID
+        in: path
+        name: roleId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Forbidden
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Delete csp role master
+      tags:
+      - roles
     put:
       consumes:
       - application/json
@@ -6869,6 +6922,48 @@ paths:
       tags:
       - roles
   /api/roles/csp/id/{roleId}:
+    delete:
+      consumes:
+      - application/json
+      description: |-
+        CspRole(mcmp_role_csp_roles) 레코드를 삭제합니다. 이 레코드를 참조하는 RoleMaster-CspRole
+        매핑을 먼저 정리한 뒤 레코드를 삭제하며, AWS인 경우 실제 클라우드 Role도 함께 삭제합니다.
+        RoleMaster/RoleSub(csp)는 건드리지 않습니다 — 그 삭제는 DeleteCspRoleMaster를 사용하세요.
+      operationId: deleteCspRole
+      parameters:
+      - description: CSP Role ID
+        in: path
+        name: roleId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Delete csp role
+      tags:
+      - roles
     get:
       consumes:
       - application/json

--- a/src/handler/role_handler.go
+++ b/src/handler/role_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -1443,33 +1444,134 @@ func (h *RoleHandler) DeleteWorkspaceRole(c echo.Context) error {
 }
 
 // @Summary Delete csp role
-// @Description Delete a role
+// @Description CspRole(mcmp_role_csp_roles) 레코드를 삭제합니다. 이 레코드를 참조하는 RoleMaster-CspRole
+// @Description 매핑을 먼저 정리한 뒤 레코드를 삭제하며, AWS인 경우 실제 클라우드 Role도 함께 삭제합니다.
+// @Description RoleMaster/RoleSub(csp)는 건드리지 않습니다 — 그 삭제는 DeleteCspRoleMaster를 사용하세요.
 // @Tags roles
 // @Accept json
 // @Produce json
-// @Param roleId path string true "Role ID"
+// @Param roleId path string true "CSP Role ID"
 // @Success 204 "No Content"
+// @Failure 400 {object} map[string]string
 // @Failure 404 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Security BearerAuth
-// @Router /api/roles/csp-roles/id/{roleId} [delete]
+// @Router /api/roles/csp/id/{roleId} [delete]
 // @Id deleteCspRole
 func (h *RoleHandler) DeleteCspRole(c echo.Context) error {
-	roleType := constants.RoleTypeCSP
-
-	var req model.CreateRoleRequest
-	if err := c.Bind(&req); err != nil {
-		log.Printf("csp 역할 수정 요청 바인딩 실패 - 에러: %v", err)
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "잘못된 요청 형식입니다"})
-	}
-
-	roleIDInt, err := util.StringToUint(c.Param("roleId"))
+	cspRoleIDInt, err := util.StringToUint(c.Param("roleId"))
 	if err != nil {
 		log.Printf("잘못된 csp 역할 ID 형식: %s", c.Param("roleId"))
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "잘못된 CSP Role ID 형식입니다"})
 	}
 
-	log.Printf("csp 역할 삭제 요청 - ID: %d", roleIDInt)
+	log.Printf("csp 역할 레코드 삭제 요청 - ID: %d", cspRoleIDInt)
+
+	existing, err := h.cspRoleService.GetCspRoleByID(cspRoleIDInt)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			log.Printf("csp 역할을 찾을 수 없음 - ID: %d", cspRoleIDInt)
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "해당 ID의 CSP 역할을 찾을 수 없습니다"})
+		}
+		log.Printf("csp 역할 조회 실패 - ID: %d, 에러: %v", cspRoleIDInt, err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("역할 조회 실패: %v", err)})
+	}
+	if existing == nil {
+		log.Printf("csp 역할을 찾을 수 없음 - ID: %d", cspRoleIDInt)
+		return c.JSON(http.StatusNotFound, map[string]string{"error": "해당 ID의 CSP 역할을 찾을 수 없습니다"})
+	}
+
+	if err := h.roleService.DeleteRoleCspRoleMappingsByCspRoleID(cspRoleIDInt); err != nil {
+		log.Printf("csp 역할 매핑 삭제 실패 - ID: %d, 에러: %v", cspRoleIDInt, err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("역할 매핑 삭제 실패: %v", err)})
+	}
+
+	if err := h.cspRoleService.DeleteCspRole(cspRoleIDInt); err != nil {
+		log.Printf("csp 역할 삭제 실패 - ID: %d, 에러: %v", cspRoleIDInt, err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("역할 삭제 실패: %v", err)})
+	}
+
+	log.Printf("csp 역할 레코드 삭제 성공 - ID: %d", cspRoleIDInt)
+	return c.NoContent(http.StatusNoContent)
+}
+
+// @Summary Create csp role master
+// @Description RoleMaster + RoleSub(csp)를 생성합니다. CreatePlatformRole/CreateWorkspaceRole과 대칭되는
+// @Description csp 타입 전용 생성 API입니다. 대상 CSP의 실제 역할(CspRole 레코드)은 CreateCspRole로 별도 생성/매핑해야 합니다.
+// @Tags roles
+// @Accept json
+// @Produce json
+// @Param role body model.CreateRoleRequest true "Role Info"
+// @Success 201 {object} model.RoleMaster
+// @Failure 400 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Security BearerAuth
+// @Router /api/roles/csp-roles/master [post]
+// @Id createCspRoleMaster
+func (h *RoleHandler) CreateCspRoleMaster(c echo.Context) error {
+	var req model.CreateRoleRequest
+	if err := c.Bind(&req); err != nil {
+		log.Printf("Failed to bind role creation request: %v", err)
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request format"})
+	}
+
+	log.Printf("Role creation request - name: %s, description: %s, parentID: %d, roleTypes: %v",
+		req.Name, req.Description, req.ParentID, req.RoleTypes)
+
+	if err := c.Validate(&req); err != nil {
+		log.Printf("Role creation input validation failed: %v", err)
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("Input validation failed: %v", err)})
+	}
+
+	role := &model.RoleMaster{
+		Name:        req.Name,
+		Description: req.Description,
+		Predefined:  false,
+	}
+
+	roleSubs := make([]model.RoleSub, len(req.RoleTypes))
+	for i := range req.RoleTypes {
+		roleSubs[i] = model.RoleSub{
+			RoleID:   role.ID,
+			RoleType: constants.RoleTypeCSP,
+		}
+	}
+
+	createdRole, err := h.roleService.CreateRoleWithSubs(role, roleSubs)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	log.Printf("Role creation successful - ID: %d", createdRole.ID)
+	return c.JSON(http.StatusCreated, createdRole)
+}
+
+// @Summary Delete csp role master
+// @Description RoleMaster의 csp 타입 RoleSub 태그를 삭제합니다(DeletePlatformRole/DeleteWorkspaceRole과 대칭).
+// @Description RoleMaster 자체나 CspRole 레코드는 삭제하지 않습니다 — CspRole 레코드 삭제는 DeleteCspRole을 사용하세요.
+// @Description 이 역할에 CSP 역할 매핑이 남아있으면 삭제할 수 없습니다(먼저 매핑을 해제해야 합니다).
+// @Tags roles
+// @Accept json
+// @Produce json
+// @Param roleId path string true "Role ID"
+// @Success 204 "No Content"
+// @Failure 400 {object} map[string]string
+// @Failure 403 {object} map[string]string
+// @Failure 404 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Security BearerAuth
+// @Router /api/roles/csp-roles/master/id/{roleId} [delete]
+// @Id deleteCspRoleMaster
+func (h *RoleHandler) DeleteCspRoleMaster(c echo.Context) error {
+	roleType := constants.RoleTypeCSP
+
+	roleIDInt, err := util.StringToUint(c.Param("roleId"))
+	if err != nil {
+		log.Printf("잘못된 csp 역할 ID 형식: %s", c.Param("roleId"))
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "잘못된 Role ID 형식입니다"})
+	}
+
+	log.Printf("csp 역할(master) 삭제 요청 - ID: %d", roleIDInt)
 
 	// 역할 조회
 	role, err := h.roleService.GetRoleByID(roleIDInt, roleType)
@@ -1490,7 +1592,6 @@ func (h *RoleHandler) DeleteCspRole(c echo.Context) error {
 	}
 
 	// 역할에 매핑된 csp역할이 있으면 삭제 불가(먼저 삭제해야함.)
-	// 역할 타입이 없으면 사용자와 연관되는 역할 타입을 조회
 	mappingReq := model.FilterRoleMasterMappingRequest{}
 	mappingReq.RoleID = c.Param("roleId")
 	if mappingReq.RoleTypes == nil {
@@ -1507,11 +1608,11 @@ func (h *RoleHandler) DeleteCspRole(c echo.Context) error {
 	}
 
 	if err := h.roleService.DeleteRoleSubs(roleIDInt, []constants.IAMRoleType{constants.RoleTypeCSP}); err != nil {
-		log.Printf("csp 역할 삭제 실패 - ID: %d, 에러: %v", roleIDInt, err)
+		log.Printf("csp 역할(master) 삭제 실패 - ID: %d, 에러: %v", roleIDInt, err)
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("역할 삭제 실패: %v", err)})
 	}
 
-	log.Printf("csp 역할 삭제 성공 - ID: %d", roleIDInt)
+	log.Printf("csp 역할(master) 삭제 성공 - ID: %d", roleIDInt)
 	return c.NoContent(http.StatusNoContent)
 }
 

--- a/src/handler/role_handler_cspmaster_test.go
+++ b/src/handler/role_handler_cspmaster_test.go
@@ -1,0 +1,173 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/labstack/echo/v4"
+	"github.com/m-cmp/mc-iam-manager/constants"
+	"github.com/m-cmp/mc-iam-manager/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type testValidator struct{ v *validator.Validate }
+
+func (tv *testValidator) Validate(i interface{}) error { return tv.v.Struct(i) }
+
+func setupCspRoleMasterTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	// NewRoleHandler가 구성하는 MenuRepository 등 다른 리포지토리가 자체적으로
+	// AutoMigrate를 호출하며 새 커넥션을 열 수 있어 shared cache로 같은 DB를 공유한다.
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+
+	require.NoError(t, db.AutoMigrate(
+		&model.RoleMaster{},
+		&model.RoleSub{},
+		&model.CspRole{},
+		&model.RoleMasterCspRoleMapping{},
+		&model.CspPolicy{},
+		&model.CspRolePolicyMapping{},
+		&model.CspRolePermission{},
+	))
+	return db
+}
+
+func newTestValidatorEcho() *echo.Echo {
+	e := echo.New()
+	e.Validator = &testValidator{v: validator.New()}
+	return e
+}
+
+func uintToStr(v uint) string {
+	return strconv.FormatUint(uint64(v), 10)
+}
+
+// TC-IAM-TECH-022-02: DeleteCspRole(레코드 삭제)는 CspRole 레코드와 그 레코드를 참조하는
+// RoleMasterCspRoleMapping을 정리하고, RoleMaster/RoleSub(csp)는 건드리지 않아야 한다.
+func TestDeleteCspRole_DeletesRecordAndMapping_KeepsRoleMaster(t *testing.T) {
+	db := setupCspRoleMasterTestDB(t)
+	h := NewRoleHandler(db)
+
+	role := &model.RoleMaster{Name: "tc-iam-tech-022-role"}
+	require.NoError(t, db.Create(role).Error)
+	require.NoError(t, db.Create(&model.RoleSub{RoleID: role.ID, RoleType: constants.RoleTypeCSP}).Error)
+
+	cspRole := &model.CspRole{Name: "mciam-test-role", CspType: "gcp"}
+	require.NoError(t, db.Create(cspRole).Error)
+	require.NoError(t, db.Create(&model.RoleMasterCspRoleMapping{
+		RoleID: role.ID, AuthMethod: constants.AuthMethodOIDC, CspRoleID: cspRole.ID,
+	}).Error)
+
+	e := newTestValidatorEcho()
+	req := httptest.NewRequest(http.MethodDelete, "/api/roles/csp/id/"+uintToStr(cspRole.ID), nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("roleId")
+	c.SetParamValues(uintToStr(cspRole.ID))
+
+	require.NoError(t, h.DeleteCspRole(c))
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	var cspRoleCount, mappingCount int64
+	require.NoError(t, db.Model(&model.CspRole{}).Where("id = ?", cspRole.ID).Count(&cspRoleCount).Error)
+	require.NoError(t, db.Model(&model.RoleMasterCspRoleMapping{}).Where("csp_role_id = ?", cspRole.ID).Count(&mappingCount).Error)
+	assert.Zero(t, cspRoleCount, "CspRole 레코드가 삭제되어야 한다")
+	assert.Zero(t, mappingCount, "참조 매핑이 정리되어야 한다")
+
+	var stillThereRole model.RoleMaster
+	require.NoError(t, db.Where("id = ?", role.ID).First(&stillThereRole).Error, "RoleMaster는 그대로 유지되어야 한다")
+
+	var subCount int64
+	require.NoError(t, db.Model(&model.RoleSub{}).Where("role_id = ? AND role_type = ?", role.ID, constants.RoleTypeCSP).Count(&subCount).Error)
+	assert.Equal(t, int64(1), subCount, "RoleSub(csp)도 그대로 유지되어야 한다")
+}
+
+// TC-IAM-TECH-022-03: 존재하지 않는 CSP Role ID는 404를 반환해야 한다.
+func TestDeleteCspRole_NotFound_Returns404(t *testing.T) {
+	db := setupCspRoleMasterTestDB(t)
+	h := NewRoleHandler(db)
+
+	e := newTestValidatorEcho()
+	req := httptest.NewRequest(http.MethodDelete, "/api/roles/csp/id/9999", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("roleId")
+	c.SetParamValues("9999")
+
+	require.NoError(t, h.DeleteCspRole(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// TC-IAM-TECH-022-04: DeleteCspRoleMaster는 Predefined 역할을 삭제할 수 없어야 한다
+// (DeletePlatformRole/DeleteWorkspaceRole과 동일한 가드).
+func TestDeleteCspRoleMaster_PredefinedRole_Forbidden(t *testing.T) {
+	db := setupCspRoleMasterTestDB(t)
+	h := NewRoleHandler(db)
+
+	role := &model.RoleMaster{Name: "tc-iam-tech-022-predefined", Predefined: true}
+	require.NoError(t, db.Create(role).Error)
+	require.NoError(t, db.Create(&model.RoleSub{RoleID: role.ID, RoleType: constants.RoleTypeCSP}).Error)
+
+	e := newTestValidatorEcho()
+	req := httptest.NewRequest(http.MethodDelete, "/api/roles/csp-roles/master/id/"+uintToStr(role.ID), nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("roleId")
+	c.SetParamValues(uintToStr(role.ID))
+
+	require.NoError(t, h.DeleteCspRoleMaster(c))
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+
+	var subCount int64
+	require.NoError(t, db.Model(&model.RoleSub{}).Where("role_id = ?", role.ID).Count(&subCount).Error)
+	assert.Equal(t, int64(1), subCount, "Predefined 역할은 RoleSub도 그대로 유지되어야 한다")
+}
+
+// TC-IAM-TECH-022-05: DeleteCspRoleMaster는 존재하지 않는 역할에 404를 반환해야 한다.
+func TestDeleteCspRoleMaster_NotFound_Returns404(t *testing.T) {
+	db := setupCspRoleMasterTestDB(t)
+	h := NewRoleHandler(db)
+
+	e := newTestValidatorEcho()
+	req := httptest.NewRequest(http.MethodDelete, "/api/roles/csp-roles/master/id/9999", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("roleId")
+	c.SetParamValues("9999")
+
+	require.NoError(t, h.DeleteCspRoleMaster(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// TC-IAM-TECH-022-06: CreateCspRoleMaster는 CreatePlatformRole/CreateWorkspaceRole과
+// 대칭적으로 RoleSub(csp)를 요청 개수만큼 정확히 생성해야 한다(IAM-BUG-019 회귀 패턴 재확인).
+func TestCreateCspRoleMaster_CreatesRoleSubsWithCspType(t *testing.T) {
+	db := setupCspRoleMasterTestDB(t)
+	h := NewRoleHandler(db)
+
+	e := newTestValidatorEcho()
+	body := `{"name":"tc-iam-tech-022-create","roleTypes":["csp"]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/roles/csp-roles/master", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, h.CreateCspRoleMaster(c))
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var role model.RoleMaster
+	require.NoError(t, db.Where("name = ?", "tc-iam-tech-022-create").First(&role).Error)
+
+	var subs []model.RoleSub
+	require.NoError(t, db.Where("role_id = ?", role.ID).Find(&subs).Error)
+	require.Len(t, subs, 1)
+	assert.Equal(t, constants.RoleTypeCSP, subs[0].RoleType)
+}

--- a/src/main.go
+++ b/src/main.go
@@ -336,7 +336,9 @@ func main() {
 
 		roles.POST("/csp-roles/list", roleHandler.ListCspRoleMappings)
 		roles.GET("/csp-roles/id/:roleId", roleHandler.GetCspRoleMappings)
+		roles.POST("/csp-roles/master", roleHandler.CreateCspRoleMaster)
 		roles.PUT("/csp-roles/master/id/:roleId", roleHandler.UpdateCspRoleMaster)
+		roles.DELETE("/csp-roles/master/id/:roleId", roleHandler.DeleteCspRoleMaster)
 		roles.POST("/csp/list", roleHandler.ListCSPRoles)
 		roles.POST("/csp", roleHandler.CreateCspRole)
 		roles.POST("/csp/batch", roleHandler.CreateCspRoles)

--- a/src/repository/csp_role_repository.go
+++ b/src/repository/csp_role_repository.go
@@ -196,40 +196,23 @@ func (r *CspRoleRepository) UpdateCSPRole(role *model.CspRole) error {
 }
 
 // Delete AWS IAM Role을 삭제합니다.
-func (r *CspRoleRepository) DeleteCSPRole(id string) error {
-	// 1. DB에서 역할 조회 (role_master 테이블 조인)
-	var role model.CspRole
-	if err := r.db.Joins("JOIN mcmp_role_csp_role_mappings ON mcmp_role_csp_role_mappings.csp_role_id = mcmp_role_csps.id").
-		Where("mcmp_role_csp_role_mappings.csp_role_id = ?", id).
-		First(&role).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
-			return fmt.Errorf("CSP 역할을 찾을 수 없습니다: %v", err)
+// DeleteCspRoleRecord CspRole(mcmp_role_csp_roles) 레코드를 cascade 삭제한다.
+// 이 레코드를 참조하는 RoleMasterCspRoleMapping은 호출 전에 별도로 정리되어야 한다
+// (RoleRepository.DeleteRoleCspRoleMappingsByCspRoleID). 실제 클라우드 리소스 삭제는
+// CspType별로 분기가 필요해 서비스 레이어(CspRoleService.DeleteCspRole)에서 처리한다.
+func (r *CspRoleRepository) DeleteCspRoleRecord(id uint) error {
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("csp_role_id = ?", id).Delete(&model.CspRolePolicyMapping{}).Error; err != nil {
+			return fmt.Errorf("CSP 역할 정책 매핑 삭제 실패: %w", err)
 		}
-		return fmt.Errorf("DB 조회 실패: %v", err)
-	}
-
-	// 2. AWS IAM Role 삭제
-	input := &iam.DeleteRoleInput{
-		RoleName: aws.String(role.Name),
-	}
-
-	awsIamClient, err := r.getAwsIamClient("system")
-	if err != nil {
-		return fmt.Errorf("failed to get AWS IAM client: %v", err)
-	}
-
-	_, err = awsIamClient.DeleteRole(context.TODO(), input)
-	if err != nil {
-		return fmt.Errorf("failed to delete IAM role: %v", err)
-	}
-
-	// 3. DB에서도 삭제
-	if err := r.db.Delete(&role).Error; err != nil {
-		return fmt.Errorf("failed to delete role from database: %v", err)
-	}
-
-	log.Printf("DeleteRole API Response: [RoleName: %s] - Successfully deleted", role.Name)
-	return nil
+		if err := tx.Where("csp_role_id = ?", fmt.Sprintf("%d", id)).Delete(&model.CspRolePermission{}).Error; err != nil {
+			return fmt.Errorf("CSP 역할 권한 삭제 실패: %w", err)
+		}
+		if err := tx.Where("id = ?", id).Delete(&model.CspRole{}).Error; err != nil {
+			return fmt.Errorf("CSP 역할 삭제 실패: %w", err)
+		}
+		return nil
+	})
 }
 
 func getRoleDescription(role types.Role) string {

--- a/src/repository/csp_role_repository_delete_test.go
+++ b/src/repository/csp_role_repository_delete_test.go
@@ -1,0 +1,51 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/m-cmp/mc-iam-manager/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupCspRoleDeleteTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&model.CspRole{},
+		&model.CspPolicy{},
+		&model.CspRolePolicyMapping{},
+		&model.CspRolePermission{},
+	))
+	return db
+}
+
+// TC-IAM-TECH-022-01: DeleteCspRoleRecord는 CspRole 레코드뿐 아니라 그 레코드를
+// 참조하는 CspRolePolicyMapping/CspRolePermission도 함께 정리해야 한다(cascade).
+// 수정 전 DeleteCSPRole은 cascade 정리 없이 레코드만(그것도 AWS 호출 실패 시 도달 못함) 지웠다.
+func TestDeleteCspRoleRecord_CascadesPolicyMappingAndPermission(t *testing.T) {
+	db := setupCspRoleDeleteTestDB(t)
+	r := NewCspRoleRepository(db)
+
+	role := &model.CspRole{Name: "mciam-test-role", CspType: "gcp"}
+	require.NoError(t, db.Create(role).Error)
+
+	policy := &model.CspPolicy{Name: "test-policy", CspAccountID: 1, PolicyType: model.PolicyTypeCustom}
+	require.NoError(t, db.Create(policy).Error)
+	require.NoError(t, db.Create(&model.CspRolePolicyMapping{CspRoleID: role.ID, CspPolicyID: policy.ID}).Error)
+	require.NoError(t, db.Create(&model.CspRolePermission{ID: "perm-1", CspRoleID: "1", Permission: "read"}).Error)
+
+	require.NoError(t, r.DeleteCspRoleRecord(role.ID))
+
+	var roleCount, mappingCount, permCount int64
+	require.NoError(t, db.Model(&model.CspRole{}).Where("id = ?", role.ID).Count(&roleCount).Error)
+	require.NoError(t, db.Model(&model.CspRolePolicyMapping{}).Where("csp_role_id = ?", role.ID).Count(&mappingCount).Error)
+	require.NoError(t, db.Model(&model.CspRolePermission{}).Where("csp_role_id = ?", "1").Count(&permCount).Error)
+
+	assert.Zero(t, roleCount, "CspRole 레코드가 삭제되어야 한다")
+	assert.Zero(t, mappingCount, "CspRolePolicyMapping이 함께 정리되어야 한다")
+	assert.Zero(t, permCount, "CspRolePermission이 함께 정리되어야 한다")
+}

--- a/src/repository/role_repository.go
+++ b/src/repository/role_repository.go
@@ -416,6 +416,13 @@ func (r *RoleRepository) DeleteRoleCspRoleMappings(roleID uint) error {
 		Delete(&model.RoleMasterCspRoleMapping{}).Error
 }
 
+// DeleteRoleCspRoleMappingsByCspRoleID 해당 csp_role_id를 참조하는 모든 매핑을 role_id 무관하게 삭제
+// (CspRole 레코드 자체를 삭제하기 전, 그 레코드를 참조하는 매핑을 먼저 끊어내는 용도)
+func (r *RoleRepository) DeleteRoleCspRoleMappingsByCspRoleID(cspRoleID uint) error {
+	return r.db.Where("csp_role_id = ?", cspRoleID).
+		Delete(&model.RoleMasterCspRoleMapping{}).Error
+}
+
 // CreateWorkspaceRoleCspRoleMapping 워크스페이스 역할-CSP 역할 매핑 생성
 // RoleSub = 'workspace' 가 없으면 생성하고 RoleSub = 'csp' 가 없으면 생성
 func (r *RoleRepository) CreateWorkspaceRoleCspRoleMapping(req *model.CreateCspRolesMappingRequest) error {

--- a/src/service/csp_role_service.go
+++ b/src/service/csp_role_service.go
@@ -610,8 +610,45 @@ func (s *CspRoleService) UpdateCspRole(id uint, req *model.CreateCspRoleRequest)
 }
 
 // DeleteCspRole CSP 역할을 삭제합니다.
+// DeleteCspRole CspRole(mcmp_role_csp_roles) 레코드를 삭제합니다.
+// CreateCspRole과 대칭되는 CspType 분기: AWS는 실제 클라우드 Role도 함께 삭제하고,
+// 그 외에는 DB 레코드만 정리합니다. 이 레코드를 참조하는 RoleMasterCspRoleMapping은
+// 호출 전에 별도로 정리되어 있어야 한다(핸들러에서 DeleteRoleCspRoleMappingsByCspRoleID 선행 호출).
 func (s *CspRoleService) DeleteCspRole(id uint) error {
-	return s.cspRoleRepo.DeleteCSPRole(fmt.Sprintf("%d", id))
+	role, err := s.cspRoleRepo.GetRoleByID(id)
+	if err != nil {
+		return fmt.Errorf("failed to find CSP role: %w", err)
+	}
+
+	if role.CspType == "aws" {
+		if err := s.deleteAwsIamRole(role.Name); err != nil {
+			return err
+		}
+	}
+
+	return s.cspRoleRepo.DeleteCspRoleRecord(id)
+}
+
+// deleteAwsIamRole AWS IAM Role을 삭제합니다. (private, AWS 전용)
+func (s *CspRoleService) deleteAwsIamRole(roleName string) error {
+	issuedBy := "system"
+	credential, err := s.tempCredentialRepo.GetOrCreateValidCredential("aws", "oidc", "ap-northeast-2", nil, issuedBy, func() (*model.TempCredential, error) {
+		return s.createNewAwsCredential(issuedBy)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get or create valid credential: %v", err)
+	}
+
+	awsCfg, err := s.createAwsConfigWithTempCredential(credential)
+	if err != nil {
+		return fmt.Errorf("failed to create AWS config with temp credential: %v", err)
+	}
+
+	awsIamClient := iam.NewFromConfig(awsCfg)
+	if _, err := awsIamClient.DeleteRole(context.TODO(), &iam.DeleteRoleInput{RoleName: aws.String(roleName)}); err != nil {
+		return fmt.Errorf("failed to delete IAM role: %v", err)
+	}
+	return nil
 }
 
 // CleanupExpiredCredentials 만료된 임시 자격 증명을 정리합니다.
@@ -624,16 +661,6 @@ func (s *CspRoleService) UpdateCSPRole(role *model.CspRole) error {
 	err := s.cspRoleRepo.UpdateCSPRole(role)
 	if err != nil {
 		log.Printf("Failed to update CSP role: %v", err)
-		return err
-	}
-	return nil
-}
-
-// DeleteCSPRole CSP 역할을 삭제합니다.
-func (s *CspRoleService) DeleteCSPRole(id string) error {
-	err := s.cspRoleRepo.DeleteCSPRole(id)
-	if err != nil {
-		log.Printf("Failed to delete CSP role: %v", err)
 		return err
 	}
 	return nil

--- a/src/service/role_service.go
+++ b/src/service/role_service.go
@@ -361,6 +361,11 @@ func (s *RoleService) DeleteRoleCspRoleMappingsByRoleId(roleID uint) error {
 	return s.roleRepository.DeleteRoleCspRoleMappings(roleID)
 }
 
+// DeleteRoleCspRoleMappingsByCspRoleID 해당 csp_role_id를 참조하는 모든 매핑 삭제 (CspRole 레코드 삭제 전 선행 작업)
+func (s *RoleService) DeleteRoleCspRoleMappingsByCspRoleID(cspRoleID uint) error {
+	return s.roleRepository.DeleteRoleCspRoleMappingsByCspRoleID(cspRoleID)
+}
+
 // ListWorkspaceRoleCspRoleMappings 워크스페이스 역할-CSP 역할 매핑 목록 조회
 func (s *RoleService) ListWorkspaceRoleCspRoleMappings(req *model.RoleMasterCspRoleMappingRequest) ([]*model.RoleMasterCspRoleMapping, error) {
 	return s.roleRepository.FindWorkspaceRoleCspRoleMappings(req)


### PR DESCRIPTION
## Summary
- `DELETE /api/roles/csp/id/:roleId`(`DeleteCspRole`)가 이름표(CspRole **레코드** CRUD 네임스페이스)와 실제 동작(RoleMaster의 RoleSub 태그만 삭제, 레코드는 안 건드림)이 어긋나 있던 문제를 확인. `DeletePlatformRole`/`DeleteWorkspaceRole`과 대조 결과 RoleSub 삭제 로직 자체는 대칭적으로 의도된 설계였으나, CSP 타입만 레코드 CRUD 경로를 잘못 공유해 발생한 문제로 확정
- `DeleteCspRole`을 실제로 CspRole 레코드를 삭제하도록 재배선: 참조하는 `RoleMasterCspRoleMapping`을 먼저 정리(`RoleRepository.DeleteRoleCspRoleMappingsByCspRoleID` 신규)한 뒤, 레코드를 cascade 삭제(`CspRolePolicyMapping`/`CspRolePermission` 포함, `CspRoleRepository.DeleteCspRoleRecord` 신규)하고 CspType=aws인 경우 실제 클라우드 Role도 함께 삭제(`CreateCspRole`과 대칭되는 CspType 분기)
- 기존 RoleMaster/RoleSub 삭제 로직(Predefined 체크, 매핑 존재 시 차단 가드)은 신설된 `DeleteCspRoleMaster`(`DELETE /api/roles/csp-roles/master/id/:roleId`)로 이전 — `DeletePlatformRole`/`DeleteWorkspaceRole`과 동일 패턴
- `CreateCspRoleMaster`(`POST /api/roles/csp-roles/master`) 신설 — `CreatePlatformRole`/`CreateWorkspaceRole`과 대칭되는 csp 타입 전용 생성 API. `UpdateCspRoleMaster`(PR #150 머지 완료)에 이어 Create/Delete까지 platform/workspace/csp 3타입 API 대칭 완성
- 기존 `CspRoleService.DeleteCspRole`/`DeleteCSPRole`/`CspRoleRepository.DeleteCSPRole` 새 로직으로 완전히 대체

