### PR TITLE
fix(role): DeleteCspRoleRecord api 보완

### DIFF
--- a/src/handler/role_handler_cspmaster_test.go
+++ b/src/handler/role_handler_cspmaster_test.go
@@ -17,10 +17,6 @@ import (
 	"gorm.io/gorm"
 )
 
-type testValidator struct{ v *validator.Validate }
-
-func (tv *testValidator) Validate(i interface{}) error { return tv.v.Struct(i) }
-
 func setupCspRoleMasterTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
 	// NewRoleHandler가 구성하는 MenuRepository 등 다른 리포지토리가 자체적으로
@@ -28,6 +24,9 @@ func setupCspRoleMasterTestDB(t *testing.T) *gorm.DB {
 	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
 	require.NoError(t, err)
 
+	// CspRolePermission(mcmp_csp_role_permissions)은 의도적으로 마이그레이트하지 않는다 —
+	// 실 환경(main.go AutoMigrate)에도 이 테이블이 없다(IAM-BUG-021). 여기서 만들어버리면
+	// 관련 회귀를 테스트가 잡아내지 못한다.
 	require.NoError(t, db.AutoMigrate(
 		&model.RoleMaster{},
 		&model.RoleSub{},
@@ -35,7 +34,6 @@ func setupCspRoleMasterTestDB(t *testing.T) *gorm.DB {
 		&model.RoleMasterCspRoleMapping{},
 		&model.CspPolicy{},
 		&model.CspRolePolicyMapping{},
-		&model.CspRolePermission{},
 	))
 	return db
 }

--- a/src/repository/csp_role_repository.go
+++ b/src/repository/csp_role_repository.go
@@ -205,9 +205,9 @@ func (r *CspRoleRepository) DeleteCspRoleRecord(id uint) error {
 		if err := tx.Where("csp_role_id = ?", id).Delete(&model.CspRolePolicyMapping{}).Error; err != nil {
 			return fmt.Errorf("CSP 역할 정책 매핑 삭제 실패: %w", err)
 		}
-		if err := tx.Where("csp_role_id = ?", fmt.Sprintf("%d", id)).Delete(&model.CspRolePermission{}).Error; err != nil {
-			return fmt.Errorf("CSP 역할 권한 삭제 실패: %w", err)
-		}
+		// CspRolePermission(mcmp_csp_role_permissions)은 main.go의 AutoMigrate 목록에
+		// 포함된 적이 없어 어떤 환경에도 테이블이 존재하지 않는다(관련 레포지토리 메서드도
+		// 호출부 없는 죽은 코드). 여기서 삭제를 시도하면 항상 500 에러가 난다 — IAM-BUG-021.
 		if err := tx.Where("id = ?", id).Delete(&model.CspRole{}).Error; err != nil {
 			return fmt.Errorf("CSP 역할 삭제 실패: %w", err)
 		}

--- a/src/repository/csp_role_repository_delete_test.go
+++ b/src/repository/csp_role_repository_delete_test.go
@@ -12,21 +12,25 @@ import (
 
 func setupCspRoleDeleteTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
+	// CspRolePermission(mcmp_csp_role_permissions)은 의도적으로 마이그레이트하지 않는다 —
+	// 실 환경(main.go AutoMigrate)에도 이 테이블이 없으므로, 여기서 만들어버리면
+	// IAM-BUG-021이 재발해도 테스트가 잡아내지 못한다.
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(
 		&model.CspRole{},
 		&model.CspPolicy{},
 		&model.CspRolePolicyMapping{},
-		&model.CspRolePermission{},
 	))
 	return db
 }
 
-// TC-IAM-TECH-022-01: DeleteCspRoleRecord는 CspRole 레코드뿐 아니라 그 레코드를
-// 참조하는 CspRolePolicyMapping/CspRolePermission도 함께 정리해야 한다(cascade).
-// 수정 전 DeleteCSPRole은 cascade 정리 없이 레코드만(그것도 AWS 호출 실패 시 도달 못함) 지웠다.
-func TestDeleteCspRoleRecord_CascadesPolicyMappingAndPermission(t *testing.T) {
+// TC-IAM-TECH-022-01: DeleteCspRoleRecord는 CspRole 레코드와 그 레코드를 참조하는
+// CspRolePolicyMapping을 함께 정리해야 한다(cascade).
+// IAM-BUG-021: CspRolePermission(mcmp_csp_role_permissions)은 어떤 환경에도 마이그레이트된
+// 적이 없는 테이블이라, 이를 cascade 대상에 포함하면 실제 삭제 호출이 항상 실패한다 —
+// 그 컬럼을 건드리지 않고도 정상 동작해야 함을 이 테스트로 고정한다.
+func TestDeleteCspRoleRecord_CascadesPolicyMapping(t *testing.T) {
 	db := setupCspRoleDeleteTestDB(t)
 	r := NewCspRoleRepository(db)
 
@@ -36,16 +40,13 @@ func TestDeleteCspRoleRecord_CascadesPolicyMappingAndPermission(t *testing.T) {
 	policy := &model.CspPolicy{Name: "test-policy", CspAccountID: 1, PolicyType: model.PolicyTypeCustom}
 	require.NoError(t, db.Create(policy).Error)
 	require.NoError(t, db.Create(&model.CspRolePolicyMapping{CspRoleID: role.ID, CspPolicyID: policy.ID}).Error)
-	require.NoError(t, db.Create(&model.CspRolePermission{ID: "perm-1", CspRoleID: "1", Permission: "read"}).Error)
 
-	require.NoError(t, r.DeleteCspRoleRecord(role.ID))
+	require.NoError(t, r.DeleteCspRoleRecord(role.ID), "존재하지 않는 mcmp_csp_role_permissions 테이블을 건드리지 않아야 에러 없이 삭제된다")
 
-	var roleCount, mappingCount, permCount int64
+	var roleCount, mappingCount int64
 	require.NoError(t, db.Model(&model.CspRole{}).Where("id = ?", role.ID).Count(&roleCount).Error)
 	require.NoError(t, db.Model(&model.CspRolePolicyMapping{}).Where("csp_role_id = ?", role.ID).Count(&mappingCount).Error)
-	require.NoError(t, db.Model(&model.CspRolePermission{}).Where("csp_role_id = ?", "1").Count(&permCount).Error)
 
 	assert.Zero(t, roleCount, "CspRole 레코드가 삭제되어야 한다")
 	assert.Zero(t, mappingCount, "CspRolePolicyMapping이 함께 정리되어야 한다")
-	assert.Zero(t, permCount, "CspRolePermission이 함께 정리되어야 한다")
 }


### PR DESCRIPTION
## Summary
- `model.CspRolePermission`(테이블 `mcmp_csp_role_permissions`)을 삭제 시도하는데, 이 모델은 `main.go`의 `AutoMigrate` 목록에 처음부터 포함된 적이 없어 어떤 환경에도 해당 테이블이 존재하지 않음을 확인
